### PR TITLE
fix: resolve 13 code review issues for v1.0 readiness

### DIFF
--- a/.github/workflows/tests-and-coverage.yml
+++ b/.github/workflows/tests-and-coverage.yml
@@ -42,5 +42,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@v2
         with:
-          json-summary-path: './packages/*/coverage/coverage-summary.json'
-          json-final-path: './packages/*/coverage/coverage-final.json'
+          json-summary-path: './packages/core/coverage/coverage-summary.json'
+          json-final-path: './packages/core/coverage/coverage-final.json'
+          name: '@gsquery/core'

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -64,12 +64,22 @@ export const schema = {
 
 /**
  * Placeholder createClient - replaced by generated version after `gsquery generate --client`
- * 
+ *
+ * This function returns a proxy that provides a clear error message when
+ * any table operation is attempted, guiding users to run code generation.
+ *
  * Run `gsquery generate --client` to generate proper types and client.
  */
-export function createClient(_options?: { spreadsheetId?: string; mock?: boolean }): never {
-  throw new Error(
-    '@gsquery/client: No schema generated yet.\n' +
+export function createClient(_options?: { spreadsheetId?: string; mock?: boolean }): {
+  from(tableName: string): never
+} {
+  const message =
+    '@gsquery/client: No schema generated yet. ' +
     'Run `gsquery generate --client` to generate types and client from your schema.'
-  )
+
+  return {
+    from(_tableName: string): never {
+      throw new Error(message)
+    }
+  }
 }

--- a/packages/core/src/core/migration.ts
+++ b/packages/core/src/core/migration.ts
@@ -309,14 +309,14 @@ export class MigrationRunner {
       }
       
       case 'removeColumn': {
-        // In-memory: we can't truly remove a column, but we can set it to undefined
-        // In real Sheets: would need to delete the column
+        // Set column value to undefined via update
+        // In-memory adapters: the column key will have undefined value
+        // In Sheets adapter: the cell will be cleared
         for (const row of rows) {
           if (operation.column! in row) {
-            const updates = { ...row }
-            delete updates[operation.column!]
-            delete updates.id
-            store.update(row.id as string | number, updates)
+            store.update(row.id as string | number, {
+              [operation.column!]: undefined
+            })
           }
         }
         break

--- a/packages/core/src/core/query-utils.ts
+++ b/packages/core/src/core/query-utils.ts
@@ -5,6 +5,13 @@
 import type { Row, WhereCondition, OrderByCondition } from './types'
 
 /**
+ * Escape regex special characters in a string
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
  * Evaluate a single where condition against a row
  */
 export function evaluateCondition<T extends Row>(row: T, condition: WhereCondition<T>): boolean {
@@ -26,7 +33,8 @@ export function evaluateCondition<T extends Row>(row: T, condition: WhereConditi
       return (fieldValue as number) <= (value as number)
     case 'like':
       if (typeof fieldValue !== 'string' || typeof value !== 'string') return false
-      const pattern = value.replace(/%/g, '.*').replace(/_/g, '.')
+      const escaped = escapeRegex(value)
+      const pattern = escaped.replace(/%/g, '.*').replace(/_/g, '.')
       return new RegExp(`^${pattern}$`, 'i').test(fieldValue)
     case 'in':
       return Array.isArray(value) && value.includes(fieldValue)

--- a/packages/core/tests/unit/aggregation.test.ts
+++ b/packages/core/tests/unit/aggregation.test.ts
@@ -67,8 +67,8 @@ describe('Aggregation Functions', () => {
         expect(query.where('status', '=', 'completed').avg('amount')).toBe(92)
       })
 
-      it('should return 0 for empty results', () => {
-        expect(query.where('status', '=', 'nonexistent').avg('amount')).toBe(0)
+      it('should return null for empty results', () => {
+        expect(query.where('status', '=', 'nonexistent').avg('amount')).toBeNull()
       })
     })
 
@@ -81,8 +81,8 @@ describe('Aggregation Functions', () => {
         expect(query.where('category', '=', 'electronics').min('amount')).toBe(100)
       })
 
-      it('should return 0 for empty results', () => {
-        expect(query.where('status', '=', 'nonexistent').min('amount')).toBe(0)
+      it('should return null for empty results', () => {
+        expect(query.where('status', '=', 'nonexistent').min('amount')).toBeNull()
       })
     })
 
@@ -95,8 +95,8 @@ describe('Aggregation Functions', () => {
         expect(query.where('category', '=', 'books').max('amount')).toBe(50)
       })
 
-      it('should return 0 for empty results', () => {
-        expect(query.where('status', '=', 'nonexistent').max('amount')).toBe(0)
+      it('should return null for empty results', () => {
+        expect(query.where('status', '=', 'nonexistent').max('amount')).toBeNull()
       })
     })
   })
@@ -260,9 +260,9 @@ describe('Aggregation Functions', () => {
       
       expect(emptyQuery.count()).toBe(0)
       expect(emptyQuery.sum('amount')).toBe(0)
-      expect(emptyQuery.avg('amount')).toBe(0)
-      expect(emptyQuery.min('amount')).toBe(0)
-      expect(emptyQuery.max('amount')).toBe(0)
+      expect(emptyQuery.avg('amount')).toBeNull()
+      expect(emptyQuery.min('amount')).toBeNull()
+      expect(emptyQuery.max('amount')).toBeNull()
     })
 
     it('should handle single row', () => {

--- a/packages/core/tests/unit/type-safety.test.ts
+++ b/packages/core/tests/unit/type-safety.test.ts
@@ -2,13 +2,10 @@
  * Type safety validation tests
  *
  * These tests verify that the type system correctly enforces compile-time
- * safety for schema-based database operations. While runtime tests can't
- * fully validate TypeScript's compile-time checks, they demonstrate the
- * expected behavior and document the type guarantees.
+ * safety for schema-based database operations.
  */
 import { describe, it, expect } from 'vitest'
 import { defineSheetsDB, MockAdapter } from '../../src'
-import type { InferRowFromSchema, InferTablesFromConfig } from '../../src/core/types'
 
 describe('Type Safety Validation', () => {
   describe('Schema type inference', () => {
@@ -40,18 +37,11 @@ describe('Type Safety Validation', () => {
         active: true
       })
 
-      // Verify inferred types at runtime
       expect(typeof user.id).toBe('number')
       expect(typeof user.name).toBe('string')
       expect(typeof user.email).toBe('string')
       expect(typeof user.age).toBe('number')
       expect(typeof user.active).toBe('boolean')
-
-      // Note: TypeScript compile-time checks would prevent:
-      // - Assigning to readonly id field
-      // - Wrong types in create() (e.g., name: 123)
-      // - Missing required fields
-      // These errors are enforced at compile time in real usage
     })
 
     it('should enforce type safety in update operations', () => {
@@ -75,7 +65,6 @@ describe('Type Safety Validation', () => {
         inStock: true
       })
 
-      // Valid update
       const updated = db.from('products').update(product.id, {
         price: 24.99,
         inStock: false
@@ -83,11 +72,6 @@ describe('Type Safety Validation', () => {
 
       expect(updated.price).toBe(24.99)
       expect(updated.inStock).toBe(false)
-
-      // Note: TypeScript compile-time checks would prevent:
-      // - Updating readonly id field
-      // - Wrong types (e.g., price: '24.99')
-      // - Invalid field names (e.g., quantity: 10)
     })
 
     it('should enforce type safety in query where clauses', () => {
@@ -98,17 +82,13 @@ describe('Type Safety Validation', () => {
             types: { id: 0, customerId: 0, total: 0, status: '' }
           }
         },
-        stores: {
-          orders: new MockAdapter()
-        }
+        mock: true
       })
 
-      // Create test data
       db.from('orders').create({ customerId: 1, total: 100, status: 'pending' })
       db.from('orders').create({ customerId: 1, total: 200, status: 'completed' })
       db.from('orders').create({ customerId: 2, total: 150, status: 'pending' })
 
-      // Valid queries
       const query1 = db.from('orders')
         .query()
         .where('customerId', '=', 1)
@@ -123,16 +103,6 @@ describe('Type Safety Validation', () => {
         .exec()
 
       expect(query2.length).toBe(2)
-
-      // TypeScript should catch these at compile time:
-      // @ts-expect-error - invalid field name
-      // db.from('orders').query().where('invalid', '=', 1)
-
-      // @ts-expect-error - wrong type for customerId
-      // db.from('orders').query().where('customerId', '=', '1')
-
-      // @ts-expect-error - wrong type for total
-      // db.from('orders').query().where('total', '>', '100')
     })
 
     it('should enforce type safety in orderBy', () => {
@@ -143,28 +113,18 @@ describe('Type Safety Validation', () => {
             types: { id: 0, name: '', value: 0 }
           }
         },
-        stores: {
-          items: new MockAdapter()
-        }
+        mock: true
       })
 
       db.from('items').create({ name: 'Item A', value: 100 })
       db.from('items').create({ name: 'Item B', value: 50 })
 
-      // Valid orderBy
       const sorted = db.from('items')
         .query()
         .orderBy('value', 'desc')
         .exec()
 
       expect(sorted[0].value).toBeGreaterThan(sorted[1].value)
-
-      // TypeScript should catch these at compile time:
-      // @ts-expect-error - invalid field name
-      // db.from('items').query().orderBy('invalid', 'asc')
-
-      // @ts-expect-error - invalid sort direction
-      // db.from('items').query().orderBy('value', 'invalid')
     })
   })
 
@@ -181,10 +141,7 @@ describe('Type Safety Validation', () => {
             types: { id: 0, title: '', userId: 0, published: false }
           }
         },
-        stores: {
-          users: new MockAdapter(),
-          posts: new MockAdapter()
-        }
+        mock: true
       })
 
       const user = db.from('users').create({
@@ -198,37 +155,15 @@ describe('Type Safety Validation', () => {
         published: true
       })
 
-      // Verify types are distinct
       expect(user).toHaveProperty('username')
       expect(user).not.toHaveProperty('title')
       expect(post).toHaveProperty('title')
       expect(post).not.toHaveProperty('username')
-
-      // TypeScript should catch these at compile time:
-      // @ts-expect-error - users table doesn't have 'title' field
-      // db.from('users').create({ username: '', email: '', title: '' })
-
-      // @ts-expect-error - posts table doesn't have 'email' field
-      // db.from('posts').create({ title: '', userId: 0, published: false, email: '' })
-
-      // @ts-expect-error - wrong field for users table
-      // db.from('users').query().where('title', '=', 'test')
-
-      // @ts-expect-error - wrong field for posts table
-      // db.from('posts').query().where('username', '=', 'test')
     })
   })
 
   describe('InferRowFromSchema type utility', () => {
     it('should correctly infer types from schema definition', () => {
-      type UserSchema = {
-        columns: ['id', 'name', 'age', 'active']
-        types: { id: 0; name: ''; age: 0; active: true }
-      }
-
-      type UserRow = InferRowFromSchema<UserSchema>
-
-      // This is validated at compile time, but we can test runtime behavior
       const db = defineSheetsDB({
         tables: {
           users: {
@@ -236,9 +171,7 @@ describe('Type Safety Validation', () => {
             types: { id: 0, name: '', age: 0, active: true }
           }
         },
-        stores: {
-          users: new MockAdapter<any>()
-        }
+        mock: true
       })
 
       const user = db.from('users').create({
@@ -247,7 +180,6 @@ describe('Type Safety Validation', () => {
         active: true
       })
 
-      // Runtime verification
       expect(typeof user.id).toBe('number')
       expect(typeof user.name).toBe('string')
       expect(typeof user.age).toBe('number')
@@ -255,26 +187,17 @@ describe('Type Safety Validation', () => {
     })
 
     it('should handle schemas without type hints', () => {
-      type BasicSchema = {
-        columns: ['id', 'data']
-      }
-
-      type BasicRow = InferRowFromSchema<BasicSchema>
-
       const db = defineSheetsDB({
         tables: {
           items: {
             columns: ['id', 'data'] as const
           }
         },
-        stores: {
-          items: new MockAdapter()
-        }
+        mock: true
       })
 
       const item = db.from('items').create({ data: 'anything' })
 
-      // Without type hints, fields are unknown except id
       expect(item.id).toBeDefined()
       expect(item.data).toBe('anything')
     })
@@ -282,20 +205,6 @@ describe('Type Safety Validation', () => {
 
   describe('InferTablesFromConfig type utility', () => {
     it('should correctly infer all table types from config', () => {
-      type Config = {
-        users: {
-          columns: ['id', 'name']
-          types: { id: 0; name: '' }
-        }
-        posts: {
-          columns: ['id', 'title', 'userId']
-          types: { id: 0; title: ''; userId: 0 }
-        }
-      }
-
-      type Tables = InferTablesFromConfig<Config>
-
-      // This is validated at compile time
       const db = defineSheetsDB({
         tables: {
           users: {
@@ -307,10 +216,7 @@ describe('Type Safety Validation', () => {
             types: { id: 0, title: '', userId: 0 }
           }
         },
-        stores: {
-          users: new MockAdapter(),
-          posts: new MockAdapter()
-        }
+        mock: true
       })
 
       const user = db.from('users').create({ name: 'John' })
@@ -331,28 +237,18 @@ describe('Type Safety Validation', () => {
             types: { id: 0, product: '', amount: 0, quantity: 0 }
           }
         },
-        stores: {
-          sales: new MockAdapter()
-        }
+        mock: true
       })
 
       db.from('sales').create({ product: 'Widget', amount: 100, quantity: 5 })
       db.from('sales').create({ product: 'Widget', amount: 200, quantity: 10 })
       db.from('sales').create({ product: 'Gadget', amount: 150, quantity: 7 })
 
-      // Valid aggregations
       const total = db.from('sales').query().sum('amount')
       expect(total).toBeGreaterThan(0)
 
       const avgQuantity = db.from('sales').query().avg('quantity')
       expect(avgQuantity).toBeGreaterThan(0)
-
-      // TypeScript should catch these at compile time:
-      // @ts-expect-error - can't sum a string field
-      // db.from('sales').query().sum('product')
-
-      // @ts-expect-error - invalid field name
-      // db.from('sales').query().avg('invalid')
     })
 
     it('should enforce type safety in IN operator', () => {
@@ -363,34 +259,24 @@ describe('Type Safety Validation', () => {
             types: { id: 0, name: '', priority: 0 }
           }
         },
-        stores: {
-          categories: new MockAdapter()
-        }
+        mock: true
       })
 
       db.from('categories').create({ name: 'Electronics', priority: 1 })
       db.from('categories').create({ name: 'Books', priority: 2 })
       db.from('categories').create({ name: 'Clothing', priority: 3 })
 
-      // Valid IN query
       const results = db.from('categories')
         .query()
         .where('name', 'in', ['Electronics', 'Books'])
         .exec()
 
       expect(results.length).toBe(2)
-
-      // TypeScript should catch these at compile time:
-      // @ts-expect-error - IN requires array
-      // db.from('categories').query().where('name', 'in', 'Electronics')
-
-      // @ts-expect-error - array elements must match field type
-      // db.from('categories').query().where('priority', 'in', ['1', '2'])
     })
   })
 
-  describe('Compile-time error prevention', () => {
-    it('should document TypeScript compile-time protections', () => {
+  describe('mock: true option', () => {
+    it('should auto-create MockAdapter stores when mock: true', () => {
       const db = defineSheetsDB({
         tables: {
           test: {
@@ -398,39 +284,30 @@ describe('Type Safety Validation', () => {
             types: { id: 0, str: '', num: 0, bool: false }
           }
         },
-        stores: {
-          test: new MockAdapter()
-        }
+        mock: true
       })
 
-      // These should all be caught by TypeScript at compile time:
+      const row = db.from('test').create({ str: 'hello', num: 42, bool: true })
+      expect(row.id).toBe(1)
+      expect(row.str).toBe('hello')
+      expect(row.num).toBe(42)
+      expect(row.bool).toBe(true)
 
-      // @ts-expect-error - table name must exist
-      // db.from('nonexistent')
+      const found = db.from('test').findById(1)
+      expect(found.str).toBe('hello')
+    })
 
-      // @ts-expect-error - must provide all required fields
-      // db.from('test').create({ str: 'hello' })
-
-      // @ts-expect-error - field types must match
-      // db.from('test').create({ str: 123, num: 0, bool: false })
-
-      // @ts-expect-error - can't modify readonly id
-      // db.from('test').update(1, { id: 999 })
-
-      // @ts-expect-error - field must exist in schema
-      // db.from('test').query().where('nonexistent', '=', 'value')
-
-      // @ts-expect-error - value type must match field type
-      // db.from('test').query().where('num', '=', '123')
-
-      // @ts-expect-error - orderBy field must exist
-      // db.from('test').query().orderBy('nonexistent', 'asc')
-
-      // @ts-expect-error - direction must be 'asc' | 'desc'
-      // db.from('test').query().orderBy('str', 'up')
-
-      // All these errors are caught at compile time!
-      expect(true).toBe(true) // Test passes if it compiles
+    it('should throw when neither stores nor mock is provided', () => {
+      expect(() => {
+        defineSheetsDB({
+          tables: {
+            test: {
+              columns: ['id', 'data'] as const,
+              types: { id: 0, data: '' }
+            }
+          }
+        })
+      }).toThrow('defineSheetsDB requires either "stores" or "mock: true"')
     })
   })
 })

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'json-summary', 'html'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.d.ts']
     }


### PR DESCRIPTION
## Summary

Resolves all 13 issues identified during the v1.0.0 readiness code review. Covers critical bugs, performance improvements, and DX fixes across core, client, and test packages.

### Critical (4)
- **#49** - `like` operator crashes on regex special chars (`[`, `]`, etc.) → added `escapeRegex()`
- **#50** - `SheetsAdapter.batchUpdate` fails with string IDs → removed `as number` casts
- **#51** - `new MockAdapter()` type mismatch with `defineSheetsDB` → added `mock: true` option
- **#52** - `limit(0)` returns all rows in SheetsAdapter vs empty in MockAdapter → unified to `>= 0`

### High (4)
- **#53** - SheetsAdapter reads entire sheet every query → added data cache with write invalidation
- **#54** - `getNextId()` race condition in concurrent GAS → added `LockService` locking
- **#55** - `@gsquery/client` `createClient()` throws on call → deferred error to `.from()` usage
- **#56** - `count()`/`sum()`/`avg()` mutate QueryBuilder state without try-finally → build separate options

### Medium (5)
- **#57** - Migration `removeColumn` didn't actually clear data → explicit `undefined` set
- **#58** - JoinQueryBuilder silently strips foreign table prefix → throws descriptive error
- **#59** - `min()`/`max()`/`avg()` return `0` for empty data → return `null` (breaking)
- **#60** - Local GAS type declarations removed → uses `@types/google-apps-script`
- **#61** - `type-safety.test.ts` had 10+ TS errors → rewritten with `mock: true` pattern

## Breaking Changes
- `min()`, `max()`, `avg()` now return `number | null` instead of `number`
- `defineSheetsDB()` now requires either `stores` or `mock: true`

## Test plan
- [x] All 470 tests passing (333 core + 9 client + 128 cli)
- [x] TypeScript strict check passes on all 3 packages
- [x] Build succeeds for all packages (ESM, CJS, IIFE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)