### PR TITLE
ci: grant pull-requests write to Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

Grants `pull-requests: write` to the Claude Code Review workflow so it can post inline review comments.

## Why

`claude-code-action` enforces a security check: it only runs when the PR's workflow file is **byte-identical to the version on the default branch (`main`)**. Because the previous permission (`pull-requests: read`) also blocked the action from posting comments, the fix must land on `main` itself — otherwise any PR carrying the change fails workflow validation and the action skips entirely.

## Changes

- `claude-code-review.yml`: `pull-requests: read` → `write`

## Test Plan

- [ ] After merge, re-trigger review on an open PR (#107) and confirm inline comments post.