### PR TITLE
feat(client): namespace-isolated local state + close() teardown

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsquery/cli",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "CLI for gas-sheets-query schema generation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsquery/client",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "Typed client for gas-sheets-query",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/local/create-client-db.ts
+++ b/packages/client/src/local/create-client-db.ts
@@ -12,6 +12,7 @@ import type { SyncEngineOptions } from './sync-engine.js'
 import type { SyncTransport, ConflictStrategy } from './sync-transport.js'
 import type { MutationStorage } from './mutation-queue.js'
 import type { IndexDefinition } from '@gsquery/core'
+import { composeName } from './naming.js'
 
 /** Schema definition for createClientDB */
 export interface ClientDBSchema {
@@ -33,6 +34,12 @@ export interface CreateClientDBOptions<Tables extends Record<string, RowWithId>>
   disableIDB?: boolean
   /** Pre-populated data per table (for testing) */
   initialData?: { [K in keyof Tables]?: Tables[K][] }
+  /**
+   * Caller-supplied partition key isolating this instance's IndexedDB
+   * database and mutation-queue storage from other instances on the same
+   * origin (e.g. one per team). Omitted = identical naming to rc2.
+   */
+  namespace?: string
 }
 
 export interface ClientDBResult<Tables extends Record<string, RowWithId>> {
@@ -40,13 +47,20 @@ export interface ClientDBResult<Tables extends Record<string, RowWithId>> {
   sync: SyncEngine
   /** Access adapters directly (for testing/advanced use) */
   adapters: { [K in keyof Tables & string]: LocalAdapter<Tables[K]> }
+  /**
+   * Tear down this instance: cancels SyncEngine auto-sync/debounce timers and
+   * closes the shared IndexedDB connection. Idempotent — safe to call more
+   * than once. Pending mutations are left persisted in storage rather than
+   * flushed, so no transport call fires after this resolves.
+   */
+  close: () => Promise<void>
 }
 
 /** Create a local-first client DB (async init for IndexedDB hydration) */
 export async function createClientDB<Tables extends Record<string, RowWithId>>(
   options: CreateClientDBOptions<Tables>
 ): Promise<ClientDBResult<Tables>> {
-  const { schema, transport, conflictStrategy, pushDebounceMs, mutationStorage, disableIDB } = options
+  const { schema, transport, conflictStrategy, pushDebounceMs, mutationStorage, disableIDB, namespace } = options
 
   const syncEngine = new SyncEngine({
     transport,
@@ -63,7 +77,7 @@ export async function createClientDB<Tables extends Record<string, RowWithId>>(
   if (idbEnabled) {
     try {
       const allTableNames = Object.keys(schema.tables)
-      sharedDb = await openSharedIDB(allTableNames)
+      sharedDb = await openSharedIDB(allTableNames, composeName('gsquery', namespace))
     } catch {
       // IndexedDB unavailable - adapters will run in-memory only
     }
@@ -79,6 +93,7 @@ export async function createClientDB<Tables extends Record<string, RowWithId>>(
       disableIDB: disableIDB ?? false,
       initialData: options.initialData?.[tableName as keyof Tables] as any[],
       idbDb: sharedDb,
+      namespace,
     }
 
     const adapter = new LocalAdapter(adapterOpts)
@@ -106,9 +121,18 @@ export async function createClientDB<Tables extends Record<string, RowWithId>>(
     stores: stores as { [K in keyof Tables]: DataStore<Tables[K]> },
   })
 
+  let closed = false
+  const close = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    syncEngine.dispose()
+    sharedDb?.close()
+  }
+
   return {
     db,
     sync: syncEngine,
     adapters: adapters as { [K in keyof Tables & string]: LocalAdapter<Tables[K]> },
+    close,
   }
 }

--- a/packages/client/src/local/local-adapter.ts
+++ b/packages/client/src/local/local-adapter.ts
@@ -22,16 +22,20 @@ import { IndexStore, evaluateCondition, compareRows } from '@gsquery/core'
 import type { IndexDefinition } from '@gsquery/core'
 import { MutationQueue } from './mutation-queue.js'
 import type { MutationStorage } from './mutation-queue.js'
+import { composeName } from './naming.js'
 
 /**
  * Open the gsquery IndexedDB with all required object stores in a single
  * upgrade transaction. This avoids the race condition where multiple
  * adapters independently try to open/upgrade the same database.
+ *
+ * `dbName` defaults to `'gsquery'` (the rc2 name) so omitting it is
+ * byte-identical to the pre-namespace behavior.
  */
-export function openSharedIDB(tableNames: string[]): Promise<IDBDatabase> {
+export function openSharedIDB(tableNames: string[], dbName = 'gsquery'): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     // First, open without a version to discover the current version
-    const probe = indexedDB.open('gsquery')
+    const probe = indexedDB.open(dbName)
     probe.onsuccess = () => {
       const existing = probe.result
       const currentVersion = existing.version
@@ -51,7 +55,7 @@ export function openSharedIDB(tableNames: string[]): Promise<IDBDatabase> {
       // Need an upgrade — close this connection and reopen with bumped version
       existing.close()
       const nextVersion = currentVersion + 1
-      const upgrade = indexedDB.open('gsquery', nextVersion)
+      const upgrade = indexedDB.open(dbName, nextVersion)
       upgrade.onupgradeneeded = () => {
         const db = upgrade.result
         for (const name of tableNames) {
@@ -68,7 +72,7 @@ export function openSharedIDB(tableNames: string[]): Promise<IDBDatabase> {
     }
     probe.onerror = () => {
       // DB doesn't exist yet — create fresh with version 1
-      const fresh = indexedDB.open('gsquery', 1)
+      const fresh = indexedDB.open(dbName, 1)
       fresh.onupgradeneeded = () => {
         const db = fresh.result
         for (const name of tableNames) {
@@ -93,6 +97,8 @@ export interface LocalAdapterOptions<T extends RowWithId = RowWithId> {
   disableIDB?: boolean
   /** Pre-opened shared IDBDatabase handle (from openSharedIDB) */
   idbDb?: IDBDatabase
+  /** Caller-supplied partition key, threaded into the MutationQueue storage key */
+  namespace?: string
 }
 
 export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
@@ -108,12 +114,14 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
   private idbEnabled: boolean
   private idbDb: IDBDatabase | null = null
   private persistScheduled = false
+  private readonly namespace: string | undefined
 
   constructor(options: LocalAdapterOptions<T>) {
     this.tableName = options.tableName
     this.idMode = options.idMode ?? 'client'
     this.idbEnabled = !options.disableIDB && typeof indexedDB !== 'undefined'
     this.indexStore = new IndexStore<T>(options.indexes ?? [])
+    this.namespace = options.namespace
 
     // Accept pre-opened shared IDB handle
     if (options.idbDb) {
@@ -123,6 +131,7 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
     this.queue = new MutationQueue<T>({
       tableName: options.tableName,
       storage: options.mutationStorage,
+      namespace: options.namespace,
     })
 
     if (options.initialData) {
@@ -138,7 +147,7 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
     try {
       // If a shared DB handle was provided, just hydrate from it
       if (!this.idbDb) {
-        this.idbDb = await openSharedIDB([this.tableName])
+        this.idbDb = await openSharedIDB([this.tableName], composeName('gsquery', this.namespace))
       }
 
       const rows = await this.readAllFromIDB()

--- a/packages/client/src/local/mutation-queue.ts
+++ b/packages/client/src/local/mutation-queue.ts
@@ -12,6 +12,7 @@
  */
 import type { RowWithId } from '@gsquery/core'
 import type { Mutation, MutationType, MergedMutation } from './sync-transport.js'
+import { composeName } from './naming.js'
 
 /** Storage interface for testability (defaults to localStorage) */
 export interface MutationStorage {
@@ -25,6 +26,8 @@ export interface MutationQueueOptions {
   tableName: string
   /** Custom storage (defaults to localStorage if available) */
   storage?: MutationStorage
+  /** Caller-supplied partition key; omitted = rc2-identical storage key */
+  namespace?: string
 }
 
 export class MutationQueue<T extends RowWithId = RowWithId> {
@@ -35,7 +38,7 @@ export class MutationQueue<T extends RowWithId = RowWithId> {
   private seqCounter = 0
 
   constructor(options: MutationQueueOptions) {
-    this.storageKey = `gsquery:${options.tableName}:mutations`
+    this.storageKey = `${composeName('gsquery', options.namespace)}:${options.tableName}:mutations`
     this.storage = options.storage ?? this.detectStorage()
     this.loadFromStorage()
   }

--- a/packages/client/src/local/naming.ts
+++ b/packages/client/src/local/naming.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for namespaced storage names (IDB database name,
+ * mutation-queue storage keys). Omitting `namespace` reproduces the
+ * pre-namespace (rc2) name exactly.
+ */
+export function composeName(base: string, namespace?: string): string {
+  return namespace ? `${base}:${namespace}` : base
+}

--- a/packages/client/tests/unit/local/namespace.test.ts
+++ b/packages/client/tests/unit/local/namespace.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Namespace isolation + close() teardown tests (#gsquery-client-namespace).
+ *
+ * IndexedDB isn't available in the Node test environment (see other test
+ * files, which all pass `disableIDB: true`). To verify `openSharedIDB` and
+ * `createClientDB` request the correctly-composed database name, these tests
+ * install a minimal fake `indexedDB` that always takes the "database not
+ * found yet" branch (probe errors, fresh open succeeds) — enough to observe
+ * which name/version each call site requests without emulating the full
+ * IndexedDB upgrade state machine.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { openSharedIDB } from '../../../src/local/local-adapter.js'
+import { createClientDB } from '../../../src/local/create-client-db.js'
+import { MockTransport } from '../../../src/transports/mock-transport.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+
+interface FakeIDBDatabase {
+  version: number
+  objectStoreNames: { contains: (name: string) => boolean }
+  createObjectStore: (name: string) => void
+  close: () => void
+}
+
+function installFakeIndexedDB() {
+  const opens: Array<{ name: string; version?: number }> = []
+  const closeSpies = new Map<string, ReturnType<typeof vi.fn>>()
+
+  ;(globalThis as any).indexedDB = {
+    open(name: string, version?: number) {
+      opens.push({ name, version })
+      const req: any = {}
+      queueMicrotask(() => {
+        if (version === undefined) {
+          // Probe: pretend the database doesn't exist yet.
+          req.onerror?.()
+          return
+        }
+        const stores = new Set<string>()
+        const closeSpy = closeSpies.get(name) ?? vi.fn()
+        closeSpies.set(name, closeSpy)
+        const db: FakeIDBDatabase = {
+          version,
+          objectStoreNames: { contains: (n: string) => stores.has(n) },
+          createObjectStore: (n: string) => stores.add(n),
+          close: closeSpy,
+        }
+        req.result = db
+        req.onupgradeneeded?.()
+        req.onsuccess?.()
+      })
+      return req
+    },
+  }
+
+  return { opens, closeSpies }
+}
+
+function uninstallFakeIndexedDB() {
+  delete (globalThis as any).indexedDB
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+describe('openSharedIDB dbName', () => {
+  afterEach(() => uninstallFakeIndexedDB())
+
+  it('defaults to the rc2 database name "gsquery"', async () => {
+    const { opens } = installFakeIndexedDB()
+    await openSharedIDB(['Counter'])
+    expect(opens.map(o => o.name)).toEqual(['gsquery', 'gsquery'])
+  })
+
+  it('uses the composed namespaced name when dbName is given', async () => {
+    const { opens } = installFakeIndexedDB()
+    await openSharedIDB(['Counter'], 'gsquery:team:t1')
+    expect(opens.map(o => o.name)).toEqual(['gsquery:team:t1', 'gsquery:team:t1'])
+  })
+
+  it('creates the requested table stores plus _meta', async () => {
+    installFakeIndexedDB()
+    const db = (await openSharedIDB(['Counter', 'Issue'])) as unknown as FakeIDBDatabase
+    expect(db.objectStoreNames.contains('Counter')).toBe(true)
+    expect(db.objectStoreNames.contains('Issue')).toBe(true)
+    expect(db.objectStoreNames.contains('_meta')).toBe(true)
+  })
+})
+
+interface Counter {
+  id: string
+  value: number
+  updatedAt: string
+}
+
+type Tables = { Counter: Counter }
+
+const schema = {
+  tables: {
+    Counter: { columns: ['id', 'value', 'updatedAt'] as const },
+  },
+}
+
+describe('createClientDB namespace isolation', () => {
+  let transport: MockTransport
+
+  beforeEach(() => {
+    transport = new MockTransport()
+  })
+  afterEach(() => uninstallFakeIndexedDB())
+
+  it('opens the namespaced IDB database when namespace is set', async () => {
+    const { opens } = installFakeIndexedDB()
+    await createClientDB<Tables>({ schema, transport, namespace: 'team:t1' })
+    expect(opens[0].name).toBe('gsquery:team:t1')
+  })
+
+  it('two namespaces have fully disjoint mutation queues on shared storage', async () => {
+    const sharedStorage = createMemoryStorage()
+
+    const a = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: sharedStorage,
+      namespace: 'team:a',
+    })
+    const b = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: sharedStorage,
+      namespace: 'team:b',
+    })
+
+    a.db.from('Counter').create({ id: 'c1', value: 1, updatedAt: '' })
+    b.db.from('Counter').create({ id: 'c2', value: 2, updatedAt: '' })
+
+    expect(a.adapters.Counter.queue.length).toBe(1)
+    expect(b.adapters.Counter.queue.length).toBe(1)
+
+    // B's clear() must never touch A's persisted queue.
+    b.adapters.Counter.queue.clear()
+    expect(b.adapters.Counter.queue.length).toBe(0)
+    expect(a.adapters.Counter.queue.length).toBe(1)
+  })
+
+  it('omitting namespace produces the same mutation-queue key as rc2', async () => {
+    const storage = createMemoryStorage()
+    const { db } = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: storage,
+    })
+
+    db.from('Counter').create({ id: 'c1', value: 1, updatedAt: '' })
+
+    // Pre-namespace consumers relied on this exact key; a rename would silently
+    // orphan every existing user's persisted offline queue.
+    const anyStorage = storage as unknown as { getItem(key: string): string | null }
+    expect(anyStorage.getItem('gsquery:Counter:mutations')).not.toBeNull()
+  })
+})
+
+describe('ClientDBResult.close()', () => {
+  let transport: MockTransport
+
+  beforeEach(() => {
+    transport = new MockTransport()
+  })
+  afterEach(() => uninstallFakeIndexedDB())
+
+  it('cancels a pending debounced push so no transport call fires after resolution', async () => {
+    const { close, db, sync } = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+      pushDebounceMs: 20,
+    })
+
+    db.from('Counter').create({ id: 'c1', value: 1, updatedAt: '' })
+    sync.schedulePush()
+
+    await close()
+
+    await new Promise(r => setTimeout(r, 50))
+    expect(transport.pushHistory).toHaveLength(0)
+  })
+
+  it('is idempotent', async () => {
+    const { close } = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+    })
+
+    await expect(close()).resolves.toBeUndefined()
+    await expect(close()).resolves.toBeUndefined()
+  })
+
+  it('closes the shared IDB connection', async () => {
+    const { closeSpies } = installFakeIndexedDB()
+    const { close } = await createClientDB<Tables>({
+      schema,
+      transport,
+      namespace: 'team:t1',
+    })
+
+    await close()
+
+    expect(closeSpies.get('gsquery:team:t1')).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/client/tests/unit/local/naming.test.ts
+++ b/packages/client/tests/unit/local/naming.test.ts
@@ -1,0 +1,20 @@
+/**
+ * naming tests - single source of truth for namespaced storage names
+ */
+import { describe, it, expect } from 'vitest'
+import { composeName } from '../../../src/local/naming.js'
+
+describe('composeName', () => {
+  it('returns the base name unchanged when namespace is omitted', () => {
+    expect(composeName('gsquery')).toBe('gsquery')
+    expect(composeName('gsquery', undefined)).toBe('gsquery')
+  })
+
+  it('returns the base name unchanged when namespace is empty string', () => {
+    expect(composeName('gsquery', '')).toBe('gsquery')
+  })
+
+  it('appends the namespace with a colon separator', () => {
+    expect(composeName('gsquery', 'team:t1')).toBe('gsquery:team:t1')
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsquery/core",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "TypeScript library for using Google Sheets as a database in GAS projects",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsquery/skills",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "AI coding assistant context files for gas-sheets-query",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add optional `namespace` to `createClientDB` so multiple isolated client instances (one per Kanbee team) can coexist on one browser origin — IndexedDB database name and mutation-queue storage keys are partitioned via a single `composeName()` helper. Omitting `namespace` reproduces rc2 naming byte-for-byte.
- Add `ClientDBResult.close()`: cancels SyncEngine timers (`dispose()`) and closes the shared IDB connection, idempotently, with no final mutation flush (so no transport call fires after it resolves).
- Bump all packages to `1.0.0-rc3` (client-namespace + close patch only).

## Test plan
- [x] `pnpm test` — 110/110 client tests pass (98 pre-existing unmodified + 12 new), full workspace green
- [x] `pnpm typecheck` — green across all packages
- [x] `pnpm build` — green across all packages
- [x] Existing suite passes unmodified (backward-compat proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)