### PR TITLE
fix(client): serialize sync/push/pull to stop concurrent-op data loss

### DIFF
--- a/packages/client/src/local/sync-engine.ts
+++ b/packages/client/src/local/sync-engine.ts
@@ -35,6 +35,7 @@ export class SyncEngine {
   private pushDebounceTimer: ReturnType<typeof setTimeout> | null = null
   private readonly pushDebounceMs: number
   private syncing = false
+  private opChain: Promise<unknown> = Promise.resolve()
 
   constructor(options: SyncEngineOptions) {
     this.transport = options.transport
@@ -70,56 +71,83 @@ export class SyncEngine {
     }
   }
 
+  /**
+   * Run an operation after every previously started one has settled, so
+   * sync/push/pull never interleave.
+   *
+   * pullTable reads the mutation queue *after* awaiting the server snapshot.
+   * A push landing in that window clears the queue, and the now-stale snapshot
+   * overwrites the local edit with nothing left to re-apply it (#104).
+   * Serializing also stops two pushes from snapshotting the same mutations
+   * (#111).
+   */
+  private serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.opChain.then(fn, fn)
+    this.opChain = run.then(
+      () => {},
+      () => {}
+    )
+    return run
+  }
+
   /** Full sync: push first (preserve local changes), then pull */
   async sync(tableName?: string): Promise<void> {
+    // Flag is set synchronously so overlapping sync() calls still drop rather
+    // than queue up — auto-sync ticks must not pile up behind a slow transport.
     if (this.syncing) return
     this.syncing = true
 
-    try {
-      this.emit({ type: 'sync-start', table: tableName })
+    return this.serialize(async () => {
+      try {
+        this.emit({ type: 'sync-start', table: tableName })
 
+        const tableNames = tableName
+          ? [tableName]
+          : Array.from(this.tables.keys())
+
+        for (const name of tableNames) {
+          await this.pushTable(name)
+          await this.pullTable(name)
+        }
+
+        this.emit({ type: 'sync-complete', table: tableName })
+      } catch (err) {
+        this.emit({
+          type: 'error',
+          table: tableName,
+          error: err instanceof Error ? err : new Error(String(err)),
+        })
+        throw err
+      } finally {
+        this.syncing = false
+      }
+    })
+  }
+
+  /** Push local mutations to server */
+  async push(tableName?: string): Promise<void> {
+    return this.serialize(async () => {
       const tableNames = tableName
         ? [tableName]
         : Array.from(this.tables.keys())
 
       for (const name of tableNames) {
         await this.pushTable(name)
-        await this.pullTable(name)
       }
-
-      this.emit({ type: 'sync-complete', table: tableName })
-    } catch (err) {
-      this.emit({
-        type: 'error',
-        table: tableName,
-        error: err instanceof Error ? err : new Error(String(err)),
-      })
-      throw err
-    } finally {
-      this.syncing = false
-    }
-  }
-
-  /** Push local mutations to server */
-  async push(tableName?: string): Promise<void> {
-    const tableNames = tableName
-      ? [tableName]
-      : Array.from(this.tables.keys())
-
-    for (const name of tableNames) {
-      await this.pushTable(name)
-    }
+    })
   }
 
   /** Pull server data to local */
   async pull(tableName?: string): Promise<void> {
-    const tableNames = tableName
-      ? [tableName]
-      : Array.from(this.tables.keys())
+    return this.serialize(async () => {
+      const tableNames = tableName
+        ? [tableName]
+        : Array.from(this.tables.keys())
 
-    for (const name of tableNames) {
-      await this.pullTable(name)
-    }
+      for (const name of tableNames) {
+        await this.pullTable(name)
+      }
+    })
   }
 
   private async pushTable(tableName: string): Promise<void> {

--- a/packages/client/tests/unit/local/sync-engine.test.ts
+++ b/packages/client/tests/unit/local/sync-engine.test.ts
@@ -100,6 +100,9 @@ describe('SyncEngine', () => {
           return { rows: [] as Todo[] }
         },
         async push() {
+          // Enqueue while the push is genuinely in flight — the queue has
+          // already been snapshotted, so this is the window that can lose data.
+          a.update('t1', { title: 'v2' })
           await pushGate
           return { success: true }
         },
@@ -116,7 +119,6 @@ describe('SyncEngine', () => {
       a.insert({ id: 't1', title: 'v1', done: false })
 
       const pushPromise = s.push() // snapshots queue, blocks at the gate
-      a.update('t1', { title: 'v2' }) // enqueued during the await
       releasePush()
       await pushPromise
 
@@ -126,6 +128,95 @@ describe('SyncEngine', () => {
       expect(remaining).toHaveLength(1)
       expect(remaining[0].id).toBe('t1')
       expect(remaining[0].data).toMatchObject({ title: 'v2' })
+    })
+
+    it('does not double-send when two pushes overlap [#111]', async () => {
+      let releasePush!: () => void
+      const pushGate = new Promise<void>(r => {
+        releasePush = r
+      })
+      const slowTransport = {
+        pushHistory: [] as unknown[][],
+        async pull() {
+          return { rows: [] as Todo[] }
+        },
+        async push(_table: string, mutations: unknown[]) {
+          this.pushHistory.push(mutations)
+          await pushGate
+          return { success: true }
+        },
+      }
+      const a = new LocalAdapter<Todo>({
+        tableName: 'Todo',
+        idMode: 'client',
+        disableIDB: true,
+        mutationStorage: createMemoryStorage(),
+      })
+      const s = new SyncEngine({ transport: slowTransport as any })
+      s.registerTable('Todo', a, a.queue)
+
+      a.insert({ id: 't1', title: 'v1', done: false })
+
+      const p1 = s.push()
+      const p2 = s.push()
+      releasePush()
+      await Promise.all([p1, p2])
+
+      // The second push runs after the first cleared the queue, so it finds
+      // nothing to send instead of re-sending the same mutations.
+      expect(slowTransport.pushHistory).toHaveLength(1)
+    })
+
+    it('does not revert a local edit when a pull overlaps a push [#104]', async () => {
+      // pull() reads server state immediately but resolves at the gate, so a
+      // push can land (and clear the queue) inside the pull's await window.
+      let releasePull!: () => void
+      const pullGate = new Promise<void>(r => {
+        releasePull = r
+      })
+      const inner = new MockTransport()
+      const gated = {
+        async pull<T>(table: string): Promise<{ rows: T[] }> {
+          const snapshot = await inner.pull<any>(table)
+          await pullGate
+          return snapshot as { rows: T[] }
+        },
+        push(table: string, mutations: any) {
+          return inner.push<any>(table, mutations)
+        },
+      }
+      const a = new LocalAdapter<Todo>({
+        tableName: 'Todo',
+        idMode: 'client',
+        disableIDB: true,
+        mutationStorage: createMemoryStorage(),
+      })
+      const s = new SyncEngine({ transport: gated as any })
+      s.registerTable('Todo', a, a.queue)
+
+      inner.setServerData<Todo>('Todo', [{ id: 't1', title: 'server-v1', done: false }])
+      releasePull()
+      await s.pull()
+
+      // Re-arm the gate, then race a pull against a push of a local edit.
+      let releaseSecond!: () => void
+      const secondGate = new Promise<void>(r => {
+        releaseSecond = r
+      })
+      ;(gated as any).pull = async (table: string) => {
+        const snapshot = await inner.pull<any>(table)
+        await secondGate
+        return snapshot
+      }
+
+      a.update('t1', { title: 'local-v2' })
+      const pullPromise = s.pull()
+      const pushPromise = s.push()
+      releaseSecond()
+      await Promise.all([pullPromise, pushPromise])
+
+      expect((inner.serverData.get('Todo') as Todo[])[0].title).toBe('local-v2')
+      expect(a.findById('t1')?.title).toBe('local-v2')
     })
 
     it('surfaces a push failure with no conflicts instead of swallowing it [#110]', async () => {


### PR DESCRIPTION
Closes #104
Closes #111

## The bug

`pullTable` reads the mutation queue **after** awaiting the server snapshot. A push landing in that window clears the queue, and the now-stale snapshot overwrites the local edit — with nothing left to re-apply it:

```
A: getMerged() -> [insert done:false], boundary=1, await push   ── in flight
   adapter.update('t1', {done:true})                            ── seq 2
B: getMerged() -> [insert done:true],  boundary=2, await push   ── same row, sent again
B resolves first -> clearForRows({t1}, 2)                       ── queue now EMPTY
A resolves last  -> its STALE payload lands on the server
```

Server ends at `done:false`, local at `done:true`, queue empty. The next `pull()` overwrites local with the stale server row and the edit is gone. #109's boundary logic does not help — B's boundary legitimately clears everything, so the safety net is bypassed.

No user error required: `startAutoSync()` → `sync()` and `schedulePush()` → `push()` both fire pushes autonomously. `this.syncing` guarded only `sync()` vs `sync()`; `push()` and `pull()` had no guard at all.

> #111 carried a "✅ verified & fixed (`241aaef`)" comment. That commit never reached any remote — it exists only on the local branch `feat/v1.0-release-gate`. Confirmed by content on `origin/dev`, not just ancestry (PR #107 squash-merged that branch). See the correction comment on #111.

## The fix

One promise chain, 14 added lines; existing bodies are wrapped, not rewritten.

```ts
private serialize<T>(fn: () => Promise<T>): Promise<T> {
  const run = this.opChain.then(fn, fn)
  this.opChain = run.then(() => {}, () => {})
  return run
}
```

- `sync()` keeps its drop-if-already-syncing behaviour, with the flag set **synchronously** at call time so auto-sync ticks don't pile up behind a slow transport.
- `push()`/`pull()` **queue** instead of dropping, so no call is silently skipped.

**Placement matters:** the guard stays on the *public* methods. `sync()` calls `pushTable`/`pullTable` while already holding the flag, so guarding the privates would make every `sync()` a silent no-op.

`241aaef`'s flag approach also closes #111, but makes `push()` a no-op that resolves successfully, and does not cover #104. Not cherry-picked.

## Verification

**Both new regression tests fail without the fix** (engine reverted to `origin/dev`, tests unchanged):

| Test | Failure without the fix |
|---|---|
| `does not double-send when two pushes overlap [#111]` | `expected [...] to have a length of 1 but got 2` |
| `does not revert a local edit when a pull overlaps a push [#104]` | `expected 'server-v1' to be 'local-v2'` — the data loss, reproduced |

**The #109 regression test was re-timed, not weakened.** Its mutation moved from just after `s.push()` into the transport's `push()` handler — the actual in-flight window the test is named for. Confirmed still load-bearing by mutation testing: forcing `boundary = Number.MAX_SAFE_INTEGER` makes it fail.

Full suite green: client 112 / core 420 / cli 228 / skills 12. `typecheck` clean.

## Behaviour change worth knowing

`push()` now defers its body by one microtask, so a mutation enqueued in the *same tick* as the call rides along in that push instead of the next one. Not data loss — it reaches the server either way, one round-trip sooner. Only the undocumented assumption "everything enqueued before I called `push()` is in this push" no longer holds. Mutations arriving during the actual await are still protected by the existing boundary logic.

Preserving the old boundary exactly would mean snapshotting synchronously at call time and threading it into `pushTable`, splitting that signature from the `sync()` path — more code for a difference that loses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)