### PR TITLE
fix(client): hydrate init() underneath in-memory state, not over it

### DIFF
--- a/packages/client/src/local/local-adapter.ts
+++ b/packages/client/src/local/local-adapter.ts
@@ -150,11 +150,32 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
         this.idbDb = await openSharedIDB([this.tableName], composeName('gsquery', this.namespace))
       }
 
+      const seqBefore = this.queue.currentSeq()
       const rows = await this.readAllFromIDB()
-      if (rows.length > 0) {
+      if (rows.length === 0) return
+
+      const wroteDuringRead = this.queue.currentSeq() > seqBefore
+      if (!wroteDuringRead && this.data.length === 0) {
         this.data = rows
         this.rebuildIndex()
+        return
       }
+
+      // Anything already in memory — initialData, or a write that landed while
+      // the read was in flight — is newer than this snapshot, so hydrate
+      // underneath it rather than over it (#106). Note replaceAll() bypasses
+      // the queue, so a pull landing mid-init() would not trip wroteDuringRead;
+      // unreachable today since registerTable runs after init().
+      const merged = new Map<string | number, T>(rows.map(r => [r.id, r]))
+      for (const row of this.data) merged.set(row.id, row)
+      if (wroteDuringRead) {
+        for (const m of this.queue.getMerged()) {
+          if (m.type === 'delete') merged.delete(m.id)
+        }
+      }
+      this.data = [...merged.values()]
+      this.rebuildIndex()
+      this.schedulePersist()
     } catch {
       // IndexedDB unavailable - continue in-memory only
       this.idbEnabled = false

--- a/packages/client/tests/unit/local/init-hydration.test.ts
+++ b/packages/client/tests/unit/local/init-hydration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * LocalAdapter.init() hydration tests (#106).
+ *
+ * init() reads IndexedDB asynchronously, so anything already in memory —
+ * constructor initialData, or a write that lands while the read is in flight —
+ * is newer than the snapshot coming back. The fake below mirrors the one real
+ * IDB semantic that matters here: a readonly transaction captures its rows at
+ * open time, and its getAll() resolves only when the test releases it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { LocalAdapter } from '../../../src/local/local-adapter.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+
+interface Row {
+  id: string
+  value: number
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+function createFakeIDB(initialRows: Row[] = []) {
+  const rows = new Map<string, Row>(initialRows.map(r => [r.id, r]))
+  const pendingReads: Array<() => void> = []
+
+  const db = {
+    objectStoreNames: { contains: () => true },
+    transaction(_store: string, mode: 'readonly' | 'readwrite' = 'readonly') {
+      const tx: any = { error: null }
+
+      if (mode === 'readonly') {
+        const snapshot = [...rows.values()] // captured at open time, as IDB does
+        tx.objectStore = () => ({
+          getAll() {
+            const request: any = { result: snapshot, error: null }
+            pendingReads.push(() => request.onsuccess?.())
+            return request
+          },
+        })
+        return tx
+      }
+
+      tx.objectStore = () => ({
+        clear: () => rows.clear(),
+        put: (row: Row) => rows.set(row.id, row),
+      })
+      queueMicrotask(() => tx.oncomplete?.())
+      return tx
+    },
+    close: () => {},
+  }
+
+  return {
+    db: db as unknown as IDBDatabase,
+    rows,
+    releaseRead: () => {
+      for (const fire of pendingReads.splice(0)) fire()
+    },
+  }
+}
+
+function createAdapter(db: IDBDatabase, initialData?: Row[]) {
+  return new LocalAdapter<Row>({
+    tableName: 'Counter',
+    idMode: 'client',
+    mutationStorage: createMemoryStorage(),
+    idbDb: db,
+    initialData,
+  })
+}
+
+describe('LocalAdapter.init() hydration [#106]', () => {
+  beforeEach(() => {
+    // Only presence is checked (`typeof indexedDB !== 'undefined'`); the
+    // adapter uses the handle passed via idbDb.
+    ;(globalThis as any).indexedDB = {}
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).indexedDB
+  })
+
+  it('keeps a write that lands while the IDB read is in flight', async () => {
+    const { db, releaseRead } = createFakeIDB([{ id: 'c1', value: 1 }])
+    const adapter = createAdapter(db)
+
+    const initPromise = adapter.init()
+    adapter.insert({ id: 'c2', value: 2 })
+    releaseRead()
+    await initPromise
+
+    expect(adapter.findById('c2')).toBeDefined()
+    expect(adapter.findById('c1')).toBeDefined()
+  })
+
+  it('does not resurrect a row deleted while the IDB read is in flight', async () => {
+    const { db, releaseRead } = createFakeIDB([{ id: 'c1', value: 1 }])
+    const adapter = createAdapter(db, [{ id: 'c1', value: 1 }])
+
+    const initPromise = adapter.init()
+    adapter.delete('c1')
+    releaseRead()
+    await initPromise
+
+    expect(adapter.findById('c1')).toBeUndefined()
+  })
+
+  it('does not silently drop constructor initialData', async () => {
+    const { db, releaseRead } = createFakeIDB([{ id: 'c1', value: 1 }])
+    const adapter = createAdapter(db, [{ id: 'c2', value: 2 }])
+
+    const initPromise = adapter.init()
+    releaseRead()
+    await initPromise
+
+    expect(adapter.findById('c2')).toBeDefined()
+    expect(adapter.findById('c1')).toBeDefined()
+  })
+
+  it('still hydrates straight from IDB on a cold start', async () => {
+    const { db, releaseRead } = createFakeIDB([
+      { id: 'c1', value: 1 },
+      { id: 'c2', value: 2 },
+    ])
+    const adapter = createAdapter(db)
+
+    const initPromise = adapter.init()
+    releaseRead()
+    await initPromise
+
+    expect(adapter.findAll()).toHaveLength(2)
+    // Hydration must not look like local mutations.
+    expect(adapter.queue.hasPending).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #106

## The bug

`LocalAdapter.init()` read IndexedDB and then assigned the result straight over `this.data`, with no guard — no loaded flag, no merge, no write queue:

```ts
const rows = await this.readAllFromIDB()
if (rows.length > 0) {
  this.data = rows        // destroys whatever was already in memory
  this.rebuildIndex()
}
```

Three ways that loses data, all reproduced:

| Case | What happens |
|---|---|
| Write during the in-flight read | Row is live in memory and in the queue, then wiped by the older snapshot |
| **Delete** during the in-flight read | The deleted row **comes back to life** |
| Constructor `initialData` | Silently dropped whenever IDB already holds rows — **no race required** |

The third is the one the issue understates: `createClientDB({ initialData })` fills `this.data` in the constructor, then `init()` throws it away deterministically. Unlike a mutation it was never enqueued, so nothing can recover it.

Step 5 makes the first case worse than it looks: `init()` schedules no persist, so memory and IDB disagree — and the *next* mutation's `persistToIDB()` starts with `store.clear()`, wiping the row from IDB too.

## The fix

Memory is the newer state in all three cases, so hydrate the snapshot **underneath** it:

```ts
const seqBefore = this.queue.currentSeq()
const rows = await this.readAllFromIDB()
if (rows.length === 0) return

const wroteDuringRead = this.queue.currentSeq() > seqBefore
if (!wroteDuringRead && this.data.length === 0) { /* unchanged cold-start path */ }

const merged = new Map<string | number, T>(rows.map(r => [r.id, r]))
for (const row of this.data) merged.set(row.id, row)
if (wroteDuringRead) {
  for (const m of this.queue.getMerged()) if (m.type === 'delete') merged.delete(m.id)
}
```

Reuses `MutationQueue.currentSeq()` (already there for #109) as the "something wrote during the read" signal instead of adding another flag. The delete pass is load-bearing — without it the merge resurrects deleted rows.

## Verification

**Three of the four new tests fail without the fix:**

| Test | Failure without the fix |
|---|---|
| keeps a write that lands while the IDB read is in flight | `expected undefined to be defined` |
| does not resurrect a row deleted while the IDB read is in flight | `expected { id: 'c1', value: 1 } to be undefined` |
| does not silently drop constructor initialData | `expected undefined to be defined` |
| still hydrates straight from IDB on a cold start | **passes both ways** — the control |

The fake IDB models the one semantic that matters: a readonly transaction captures its rows at open time, and `getAll()` resolves only when the test releases it.

Full suite green on top of current `dev` (including #118): client 116 / core 508 / cli 228 / skills 14. `typecheck` clean.

**Consumer check:** built this together with the #118 fix, packed `@gsquery/client`, and ran the real consumer app (`gas-task-manager`) against it in a worktree — typecheck 0, 609 unit tests, 3 gws-emul integration tests, and a full production build, all identical to the npm-`rc3` baseline. Note the app passes no `initialData`, so only the write-during-read variant is on its path.

## Intentional behaviour changes

1. `initialData` now survives a non-empty IDB. That is the fix, but it is a semantic change for anyone who relied on "persisted state wins".
2. The merge path fires one extra `schedulePersist()` so IDB is reconciled with merged state instead of being left ahead of memory.

Cold start is untouched: empty memory, no concurrent write, `rows.length > 0` takes a branch equivalent to the old assignment — and the control test asserts hydration still enqueues no mutations.

## Known ceiling (noted in the code)

`replaceAll()` bypasses the queue, so a pull landing mid-`init()` would not trip `wroteDuringRead`. Unreachable today because `registerTable` runs after `init()` — but it is the first thing to break if that ordering ever changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)