### PR TITLE
fix(core): enforce id immutability in batchUpdate, deprecate idColumn

### DIFF
--- a/docs/schema-syntax.md
+++ b/docs/schema-syntax.md
@@ -92,6 +92,8 @@ id: number @id
 ```
 
 > **Contract (1.0):** the `@id` field **must be named `id`**. Schema validation rejects any other name (e.g. `userId: number @id`) with a clear error. Custom primary-key column names are planned for a future release. This keeps the generated types, both adapters, and the runtime consistent.
+>
+> The `idColumn` option on `SheetsAdapterOptions` / `TableSchema` predates this contract and is **deprecated**. Only `SheetsAdapter` honors it; `MockAdapter` and `LocalAdapter` have no such option, `defineSheetsDB` stores it without reading it, and `InferRowFromSchema` always types rows as `& { id }` — so a custom name produces rows whose declared type does not match their runtime shape. Leave it unset.
 
 ### @default(value)
 

--- a/packages/core/src/adapters/mock-adapter.ts
+++ b/packages/core/src/adapters/mock-adapter.ts
@@ -328,12 +328,15 @@ export class MockAdapter<T extends RowWithId> implements DataStore<T> {
       if (index === undefined) continue
       
       const oldRow = this.data[index]
-      const newRow = { ...oldRow, ...data }
+      // Same immutability guard update() has (#98/#113) — without it the row
+      // keeps its old idIndex entry and becomes a ghost: findById(oldId)
+      // returns it, findById(newId) does not.
+      const newRow = { ...oldRow, ...data, id: oldRow.id }
       this.data[index] = newRow
-      
+
       // Update column indexes
       this.indexStore.updateIndex(index, oldRow, newRow)
-      
+
       results.push(newRow)
     }
     

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -26,7 +26,16 @@ export interface SheetsAdapterOptions {
   columns: string[]
   /** Whether to create sheet if it doesn't exist (default: true) */
   createIfNotExists?: boolean
-  /** ID column name (default: 'id') */
+  /**
+   * ID column name (default: 'id')
+   *
+   * @deprecated 1.0 fixes the primary key at `'id'` (#101). SheetsAdapter is
+   * the only layer that honors this — MockAdapter and LocalAdapter have no
+   * such option, the CLI rejects a non-`id` `@id` field, and
+   * `InferRowFromSchema` always types the row as `& { id }`. Setting it yields
+   * rows whose declared type does not match their runtime shape. Custom
+   * primary-key names are planned for a later release.
+   */
   idColumn?: string
   /** 
    * ID generation mode (default: 'auto')
@@ -518,6 +527,11 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       if (updateData) {
         const currentRow = this.rowToObject(allData[i])
         const updatedRow = { ...currentRow, ...updateData } as T
+        // id is immutable via batchUpdate too — mirrors the guard update()
+        // already has (#98/#113). Without this, `data` carrying an id rewrites
+        // the key cell and the row becomes reachable only at its new id.
+        ;(updatedRow as Record<string, unknown>)[this.idColumn] =
+          (currentRow as Record<string, unknown>)[this.idColumn]
         results.push(updatedRow)
         updatedRows.push({
           rowIndex: i + 2, // +2 for header and 1-indexing

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -141,7 +141,14 @@ export interface TableSchemaTyped<
   columns: C
   /** Type hints using sample values */
   types?: T
-  /** ID column name (default: 'id') */
+  /**
+   * ID column name (default: 'id')
+   *
+   * @deprecated 1.0 fixes the primary key at `'id'` (#101). This value is
+   * stored on the config but never read — `defineSheetsDB` ignores it, and
+   * `InferRowFromSchema` always types the row as `& { id }`. Custom primary-key
+   * names are planned for a later release.
+   */
   idColumn?: string
 }
 
@@ -174,7 +181,12 @@ export type InferTablesFromConfig<
 export interface TableSchema<T extends RowWithId = RowWithId> {
   /** Column names in order */
   columns: readonly (keyof T & string)[]
-  /** ID column name (default: 'id') */
+  /**
+   * ID column name (default: 'id')
+   *
+   * @deprecated 1.0 fixes the primary key at `'id'` (#101). Stored but never
+   * read. Custom primary-key names are planned for a later release.
+   */
   idColumn?: string
   /** Sheet name (defaults to table name if not specified) */
   sheetName?: string

--- a/packages/core/tests/unit/batch-update-id-immutability.test.ts
+++ b/packages/core/tests/unit/batch-update-id-immutability.test.ts
@@ -1,0 +1,85 @@
+/**
+ * batchUpdate must honour the same id-immutability guard update() got (#98),
+ * in both adapters (#113). Without it MockAdapter leaves a ghost row (reachable
+ * only at the old id) while SheetsAdapter genuinely rewrites the key cell — the
+ * exact mock-vs-sheets divergence #98 was filed to remove.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+
+interface Row {
+  id: number
+  name: string
+}
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+
+function createSheetsAdapter(): SheetsAdapter<Row> {
+  const ss = fromArrays({
+    Users: [
+      ['id', 'name'],
+      [1, 'a'],
+      [2, 'b'],
+    ],
+  })
+  installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: ss }, activeId: SPREADSHEET_ID })
+  return new SheetsAdapter<Row>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Users',
+    columns: ['id', 'name'],
+  })
+}
+
+describe('batchUpdate id immutability [#113]', () => {
+  let mock: MockAdapter<Row>
+
+  beforeEach(() => {
+    mock = new MockAdapter<Row>({
+      initialData: [
+        { id: 1, name: 'a' },
+        { id: 2, name: 'b' },
+      ],
+    })
+  })
+
+  it('MockAdapter ignores an id in the update payload', () => {
+    const [updated] = mock.batchUpdate([
+      { id: 1, data: { id: 99, name: 'z' } as Partial<Row> },
+    ])
+
+    expect(updated.id).toBe(1)
+    expect(updated.name).toBe('z')
+    expect(mock.findById(1)?.name).toBe('z')
+    expect(mock.findById(99)).toBeUndefined()
+  })
+
+  it('SheetsAdapter ignores an id in the update payload', () => {
+    const sheets = createSheetsAdapter()
+
+    const [updated] = sheets.batchUpdate([
+      { id: 1, data: { id: 99, name: 'z' } as Partial<Row> },
+    ])
+
+    expect(updated.id).toBe(1)
+    expect(updated.name).toBe('z')
+
+    sheets.clearCache()
+    expect(sheets.findById(1)?.name).toBe('z')
+    expect(sheets.findById(99)).toBeUndefined()
+    expect(sheets.getRawData()).toEqual([
+      ['id', 'name'],
+      [1, 'z'],
+      [2, 'b'],
+    ])
+  })
+
+  it('does not let two rows collide onto one id', () => {
+    mock.batchUpdate([{ id: 1, data: { id: 2 } as Partial<Row> }])
+
+    const ids = mock.findAll().map(r => r.id)
+    expect(ids).toEqual([1, 2])
+  })
+})

--- a/packages/skills/skills/generic/gsquery-config.md
+++ b/packages/skills/skills/generic/gsquery-config.md
@@ -65,7 +65,7 @@ const store = new SheetsAdapter<User>({
   sheetName: 'Users',              // required
   columns: ['id', 'name', 'email', 'age', 'active'],  // required
   createIfNotExists: true,         // default: true
-  idColumn: 'id',                  // default: 'id'
+  // idColumn is deprecated — 1.0 fixes the primary key at 'id' (#101)
   idMode: 'auto',                  // default: 'auto'
   columnTypes: {                   // optional type serialization
     age: 'number',
@@ -122,6 +122,6 @@ const db = defineSheetsDB({
 ## Common Mistakes
 
 - SheetsAdapter only works in GAS — use MockAdapter for Node.js/testing
-- First column should be `'id'` (or set `idColumn`)
+- First column must be `'id'` — 1.0 fixes the primary key name (#101); `idColumn` is deprecated
 - Index field names are case-sensitive
 - `columnTypes` keys must match actual column names

--- a/packages/skills/skills/gsquery/references/adapters-and-config.md
+++ b/packages/skills/skills/gsquery/references/adapters-and-config.md
@@ -96,7 +96,7 @@ const store = new SheetsAdapter<User>({
   sheetName: 'Users',               // required — name of the sheet tab
   columns: ['id', 'name', 'email', 'age', 'active'],  // required — column order
   createIfNotExists: true,          // default: true — creates sheet if missing
-  idColumn: 'id',                   // default: 'id'
+  // idColumn is deprecated — 1.0 fixes the primary key at 'id' (#101)
   idMode: 'auto',                   // default: 'auto'
   columnTypes: {                    // optional — type-aware serialization
     age: 'number',
@@ -115,7 +115,7 @@ interface SheetsAdapterOptions {
   sheetName: string
   columns: string[]
   createIfNotExists?: boolean
-  idColumn?: string
+  idColumn?: string                 // deprecated — 1.0 fixes it at 'id'
   idMode?: IdMode
   columnTypes?: Record<string, ColumnType>
 }
@@ -207,7 +207,7 @@ const store = new MockAdapter<User>()
 
 // WRONG: columns array doesn't include 'id'
 new SheetsAdapter({ sheetName: 'T', columns: ['name', 'email'] })
-// RIGHT: first column should be 'id' (or set idColumn)
+// RIGHT: first column must be 'id' — 1.0 fixes the primary key name
 new SheetsAdapter({ sheetName: 'T', columns: ['id', 'name', 'email'] })
 
 // WRONG: index fields not matching actual field names


### PR DESCRIPTION
Closes #101
Refs #113 (runtime half; the type-level narrowing stays open — see below)

## #101 — the decision was already made, the codebase just didn't say so

The 1.0 contract landed in `c8f5864`: `schema-parser.ts:408-416` rejects a non-`id` `@id` field, and `docs/schema-syntax.md:94` documents it. What remained was that the codebase still advertised the opposite.

`idColumn` is honored by **exactly one layer**:

| Layer | `idColumn` |
|---|---|
| `SheetsAdapter` | honored |
| `MockAdapter` | **no such option** — `.id` hardcoded |
| `LocalAdapter` | **structurally impossible** — IndexedDB `keyPath: 'id'` is baked into the object store |
| `defineSheetsDB` | **accepts and discards** — written to config, read by nothing |
| `InferRowFromSchema` | appends `& { id }` unconditionally |
| CLI generators | emit `X['id']`; never generate `idColumn` |
| `MigrationRunner` | `store.update(row.id, …)` → **silently no-ops** on a custom id column |

So `defineSheetsDB({ tables: { users: { columns: ['uid','name'], idColumn: 'uid' } } })` stores `'uid'`, stamps a phantom `id`, and `findById(7)` throws `RowNotFoundError`. The repo's own test acknowledges the type lie by casting: `sheets-adapter.test.ts` writes `SheetsAdapter<{ uid: number; name: string } & { id: number }>`.

**This PR ratifies the decision and labels it:**

- `@deprecated` on the three `idColumn` declarations (`types.ts` ×2, `sheets-adapter.ts`), each naming what actually ignores it
- Skill docs stop advertising it (`gsquery-config.md:68,125`, `adapters-and-config.md:99,118,210`) — they contradicted `docs/schema-syntax.md:94`
- One paragraph added to the schema-syntax contract block

**No type, signature, or export changes.** The frozen surface is untouched — deleting `idColumn` would be the breaking move, so it stays.

Making the other adapters honor `idColumn` would mean adding the option to MockAdapter, LocalAdapter (including an IndexedDB `keyPath` change baked in at `onupgradeneeded`, so a schema version bump), `ClientDBSchema`, the migration runner, `InferRowFromSchema`, and two codegen templates. That is a feature for a later release, not a release-gate fix.

## #113 — batchUpdate had no id guard, in *either* adapter

`update()` re-pins the id (#98). `batchUpdate()` did not — and the two adapters diverged in **opposite** directions:

- `MockAdapter`: the `idIndex` entry is left behind → a ghost row. `findById(oldId)` returns it; `findById(newId)` returns `undefined`.
- `SheetsAdapter`: the key cell is genuinely rewritten → the row is reachable only at its new id.

Two ids could also collide onto one row (`[2, 2]` below). Both now mirror `update()`'s guard; `SheetsAdapter` re-pins `this.idColumn`, not a literal `'id'`.

### Verification

All three new tests fail without the guards:

| Test | Failure without the fix |
|---|---|
| MockAdapter ignores an id in the update payload | `expected 99 to be 1` |
| SheetsAdapter ignores an id in the update payload | `expected 99 to be 1` |
| does not let two rows collide onto one id | `expected [ 2, 2 ] to deeply equal [ 1, 2 ]` |

The SheetsAdapter case runs against the `@gsquery/core/testing` fake and asserts the raw grid, so it catches a rewritten key cell rather than just the returned object.

Full suite: core 511 / client 116 / cli 228 / skills 14. `typecheck` clean.

### What #113 still covers

`Repository.batchUpdate` (`repository.ts:123`) types `data` as `Partial<T>`, which admits `id` — so the corruption is reachable through the ordinary public API with **no cast**, while `update()` correctly rejects it via `Partial<Omit<T,'id'>>`. Narrowing that signature (and `TableHandle.batchUpdate` at `sheets-db.ts:51`) is a compile-time change that breaks exactly the code currently triggering the bug. It is left out of this PR so it can be decided on its own — the runtime is safe either way now, since both adapters are exported and constructed directly in user tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)