### PR TITLE
fix(core): treat empty cells as unset in schema migrations

### DIFF
--- a/packages/core/src/core/migration.ts
+++ b/packages/core/src/core/migration.ts
@@ -138,6 +138,19 @@ export class NoMigrationsToRollbackError extends SheetsQueryError {
 // ============================================================================
 
 /**
+ * Whether a column value counts as "not set" for schema operations.
+ *
+ * `undefined` is not storable in a Sheets cell — SheetsAdapter writes it as
+ * `''` and reads it back as `''` — so guards that test only for `undefined`
+ * hold in memory but silently no-op against a real sheet (#112). Treating
+ * empty-string as empty is the only definition implementable identically
+ * across MockAdapter, LocalAdapter and SheetsAdapter.
+ */
+function isEmptyCell(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
+/**
  * SchemaBuilder that records operations
  */
 class RecordingSchemaBuilder implements SchemaBuilder {
@@ -302,9 +315,9 @@ export class MigrationRunner {
       case 'addColumn': {
         const defaultValue = operation.options?.default
         for (const row of rows) {
-          // Treat missing-or-undefined as "needs default" so a default is
-          // re-applied after a prior removeColumn left the key undefined (#99).
-          if ((row as Record<string, unknown>)[operation.column!] === undefined) {
+          // Treat an empty cell as "needs default" so a default is re-applied
+          // after a prior removeColumn cleared the value (#99, #112).
+          if (isEmptyCell((row as Record<string, unknown>)[operation.column!])) {
             store.update(row.id as string | number, {
               [operation.column!]: defaultValue
             })
@@ -316,10 +329,10 @@ export class MigrationRunner {
       case 'removeColumn': {
         // Clears the column's value (in-memory: key left undefined; Sheets: cell
         // cleared). This is a value operation — it does not drop the column from
-        // the sheet header. addColumn's `=== undefined` guard (#99) lets a later
+        // the sheet header. addColumn's empty-cell guard (#99) lets a later
         // re-add re-apply its default over the cleared value.
         for (const row of rows) {
-          if ((row as Record<string, unknown>)[operation.column!] !== undefined) {
+          if (!isEmptyCell((row as Record<string, unknown>)[operation.column!])) {
             store.update(row.id as string | number, {
               [operation.column!]: undefined
             })
@@ -332,11 +345,11 @@ export class MigrationRunner {
         for (const row of rows) {
           const r = row as Record<string, unknown>
           // Rename when the source has a value and the target is empty
-          // (missing OR left undefined by a prior op) — `=== undefined` rather
-          // than `in`, consistent with the addColumn guard (#99). Using `in`
-          // here would wrongly skip the rename when the target key lingers as
-          // undefined from an earlier removeColumn/rename.
-          if (r[operation.oldColumn!] !== undefined && r[operation.newColumn!] === undefined) {
+          // (missing, or cleared by a prior op) — an emptiness test rather than
+          // `in`, consistent with the addColumn guard (#99). Using `in` here
+          // would wrongly skip the rename when the target key lingers from an
+          // earlier removeColumn/rename.
+          if (!isEmptyCell(r[operation.oldColumn!]) && isEmptyCell(r[operation.newColumn!])) {
             store.update(row.id as string | number, {
               [operation.oldColumn!]: undefined,
               [operation.newColumn!]: r[operation.oldColumn!]

--- a/packages/core/tests/unit/migration-adapter-parity.test.ts
+++ b/packages/core/tests/unit/migration-adapter-parity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The same migration must produce the same result on MockAdapter and on
+ * SheetsAdapter (#112).
+ *
+ * The schema operations live in the shared MigrationRunner, not in the
+ * adapters, and their guards used to test for `undefined`. A Sheets cell
+ * cannot hold `undefined` — SheetsAdapter writes it as `''` and reads it back
+ * as `''` — so those guards held in memory and silently no-op'd against a real
+ * sheet. These tests run one sequence through both stores and assert they agree.
+ */
+import { describe, it, expect } from 'vitest'
+import { createMigrationRunner } from '../../src/core/migration'
+import type { Migration, MigrationRecord, StoreResolver } from '../../src/core/migration'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+import type { DataStore, Row } from '../../src/core/types'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+
+/** addColumn(status, default) → removeColumn(status) → addColumn(status, default) */
+const RE_ADD_DEFAULT: Migration[] = [
+  {
+    version: 1,
+    name: 'add-status',
+    up: schema => schema.addColumn('users', 'status', { default: 'unknown' }),
+    down: schema => schema.removeColumn('users', 'status'),
+  },
+]
+
+const RENAME: Migration[] = [
+  {
+    version: 1,
+    name: 'rename-name',
+    up: schema => schema.renameColumn('users', 'name', 'label'),
+    down: schema => schema.renameColumn('users', 'label', 'name'),
+  },
+]
+
+function mockSetup() {
+  const users = new MockAdapter<any>({ initialData: [{ id: 1, name: 'John' }] })
+  const resolver: StoreResolver = <T extends Row>() => users as unknown as DataStore<T>
+  return { users, resolver, read: () => users.findById(1) as Record<string, unknown> }
+}
+
+function sheetsSetup(columns: string[], header: unknown[][]) {
+  const ss = fromArrays({ Users: header })
+  installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: ss }, activeId: SPREADSHEET_ID })
+  const users = new SheetsAdapter<any>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Users',
+    columns,
+  })
+  const resolver: StoreResolver = <T extends Row>() => users as unknown as DataStore<T>
+  return {
+    users,
+    resolver,
+    read: () => {
+      users.clearCache()
+      return users.findById(1) as Record<string, unknown>
+    },
+  }
+}
+
+function runner(resolver: StoreResolver, migrations: Migration[]) {
+  return createMigrationRunner({
+    migrationsStore: new MockAdapter<MigrationRecord>(),
+    storeResolver: resolver,
+    migrations,
+  })
+}
+
+describe('migration parity between MockAdapter and SheetsAdapter [#112]', () => {
+  it('re-applies an addColumn default after removeColumn cleared it', async () => {
+    const mock = mockSetup()
+    const mockRunner = runner(mock.resolver, RE_ADD_DEFAULT)
+    await mockRunner.migrate()
+    await mockRunner.rollback()
+    await mockRunner.migrate()
+
+    const sheets = sheetsSetup(
+      ['id', 'name', 'status'],
+      [
+        ['id', 'name', 'status'],
+        [1, 'John', ''],
+      ]
+    )
+    const sheetsRunner = runner(sheets.resolver, RE_ADD_DEFAULT)
+    await sheetsRunner.migrate()
+    await sheetsRunner.rollback()
+    await sheetsRunner.migrate()
+
+    expect(mock.read().status).toBe('unknown')
+    expect(sheets.read().status).toBe('unknown')
+  })
+
+  it('applies renameColumn on both stores', async () => {
+    const mock = mockSetup()
+    await runner(mock.resolver, RENAME).migrate()
+
+    const sheets = sheetsSetup(
+      ['id', 'name', 'label'],
+      [
+        ['id', 'name', 'label'],
+        [1, 'John', ''],
+      ]
+    )
+    await runner(sheets.resolver, RENAME).migrate()
+
+    expect(mock.read().label).toBe('John')
+    expect(sheets.read().label).toBe('John')
+    expect(sheets.users.getRawData()).toEqual([
+      ['id', 'name', 'label'],
+      [1, '', 'John'],
+    ])
+  })
+})


### PR DESCRIPTION
Closes #112

## Root cause — not in either adapter

`addColumn` / `removeColumn` / `renameColumn` are not adapter methods. They live in the shared `MigrationRunner` (`migration.ts:297-349`), so both adapters run the *same* code. The guards tested for `undefined`:

```ts
if (row[col] === undefined) { ... }          // addColumn
if (row[col] !== undefined) { ... }          // removeColumn
if (r[old] !== undefined && r[new] === undefined) { ... }   // renameColumn
```

A Sheets cell cannot hold `undefined`. `removeColumn` writes `{ [col]: undefined }`, `sheets-adapter.ts:229` turns that into `''`, and `rowToObject` reads it back as `''`. Every guard is then false and the operation is silently skipped.

MockAdapter is unaffected because `{ ...oldRow, ...data }` leaves the key present with value `undefined`.

## What actually broke

Same migration sequence, both stores:

```
MOCK   after up  : { name: 'John', id: 1 }                    status: undefined
SHEETS after up  : { id: 1, name: 'John', status: '' }        status: ''
MOCK   after down: { name: 'John', status: 'unknown', id: 1 }  ← default re-applied
SHEETS after down: { id: 1, name: 'John', status: '' }         ← silently skipped

RENAME mock  : { status: 'John', id: 1 }        ← applied
RENAME sheets: { id: 1, name: 'John', ... }     ← skipped entirely
```

**`renameColumn` is broken too** — the issue only mentions `addColumn`.

## Fix

One helper, three call sites:

```ts
function isEmptyCell(value: unknown): boolean {
  return value === undefined || value === null || value === ''
}
```

MockAdapter's behaviour is the correct contract — a cleared column re-takes a later default. SheetsAdapter cannot be "fixed" to store `undefined`, and any sentinel would be visible garbage in the user's spreadsheet. So the guards are the defect: they assume an in-memory-only representation.

Empty-string is the only "unset" definition implementable identically across MockAdapter, LocalAdapter and SheetsAdapter, because on Sheets an empty cell and an empty string are indistinguishable on read.

**Rejected alternative:** normalising on read (`rowToObject` returning `undefined` for empty cells) would change the shape of every `findAll()` / `findById()` result for all users, not just migrations.

## Verification

Both new parity tests fail without the fix — the Mock assertions pass either way, so the failures land exactly on the divergence:

| Test | Failure without the fix |
|---|---|
| re-applies an addColumn default after removeColumn cleared it | `expected '' to be 'unknown'` |
| applies renameColumn on both stores | `expected '' to be 'John'` |

Each runs one migration sequence through `MockAdapter` and through `SheetsAdapter` on the `@gsquery/core/testing` fake and asserts they agree; the rename test also asserts the raw grid, so a skipped write can't hide behind a cached read.

Full suite: core 510 / client 116 / cli 228 / skills 14. `typecheck` clean.

## Behaviour change

A genuine empty-string value now counts as missing, so `addColumn('c', { default: 'x' })` overwrites a row holding `c: ''`.

- On Sheets: not observable — `''` and empty already read identically.
- On MockAdapter / LocalAdapter: observable, and the unavoidable price of parity.

Worth a CHANGELOG line.

`packages/client/src/local/local-adapter.ts:271` uses the same `{ ...oldRow, ...data }` spread as MockAdapter, so LocalAdapter follows Mock's semantics; this keeps all three consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)