### PR TITLE
fix(cli): match @relation type to the target's id type, document it

### DIFF
--- a/docs/schema-syntax.md
+++ b/docs/schema-syntax.md
@@ -130,6 +130,48 @@ Automatically updates to current time when record is modified.
 updatedAt: datetime @updatedAt
 ```
 
+### @relation(Table)
+
+Marks a field as a foreign key referencing another table's `id`. The generator
+emits a type alias per referenced table and uses it as the field's type.
+
+```yaml
+tables:
+  User:
+    fields:
+      id: number @id @default(autoincrement)
+
+  Task:
+    fields:
+      id: number @id @default(autoincrement)
+      assigneeId: number? @relation(User)
+      watcherIds: number[]? @relation(User)
+```
+
+```typescript
+export type UserId = User['id']
+
+export interface Task {
+  id: number
+  assigneeId?: UserId
+  watcherIds?: UserId[]
+}
+```
+
+**The field's type must match the referenced table's `id` type.** `User.id` is
+`number` above, so the foreign keys are `number` / `number[]`; declaring
+`assigneeId: string @relation(User)` is rejected by schema validation, because
+the emitted `UserId` would resolve to `number` and contradict the declaration.
+
+> **Scope:** `@relation` is a **typing and documentation** aid. It does not add
+> runtime behaviour — no automatic JOIN, no foreign-key integrity check on
+> write, no cascade delete. Use `joinQuery()` to join explicitly.
+>
+> `UserId` is a plain type alias, not a branded type, so it is structurally
+> identical to `number` — nothing prevents assigning a raw `number` or a
+> `ProjectId` to a `UserId`. This is a deliberate 1.0 choice: branded types
+> would enforce the distinction but require a cast at every assignment site.
+
 ## Block Attributes
 
 Attributes applied at the table level.

--- a/packages/cli/src/generator/client-package-generator.ts
+++ b/packages/cli/src/generator/client-package-generator.ts
@@ -27,7 +27,7 @@ function getClientFieldType(field: FieldAST): string {
   const relationAttr = field.attributes.find(a => a.name === 'relation')
   if (relationAttr && typeof relationAttr.args[0] === 'string') {
     const alias = `${relationAttr.args[0]}Id`
-    if (field.type === 'string[]') return `${alias}[]`
+    if (field.type.endsWith('[]')) return `${alias}[]`
     return alias
   }
   return mapType(field.type)

--- a/packages/cli/src/generator/types-generator.ts
+++ b/packages/cli/src/generator/types-generator.ts
@@ -54,7 +54,7 @@ function getRelationType(field: FieldAST): string | null {
   if (!relationAttr || typeof relationAttr.args[0] !== 'string') return null
   const target = relationAttr.args[0]
   const alias = `${target}Id`
-  if (field.type === 'string[]') return `${alias}[]`
+  if (field.type.endsWith('[]')) return `${alias}[]`
   return alias
 }
 

--- a/packages/cli/src/parser/schema-parser.ts
+++ b/packages/cli/src/parser/schema-parser.ts
@@ -447,7 +447,7 @@ export function validateSchema(schema: SchemaAST): ParseError[] {
     }
 
     // Rule 7: @relation target must be a defined table
-    // Rule 8: @relation is only allowed on string-based fields
+    // Rule 8: the foreign key's type must match the target's id type
     for (const field of table.fields) {
       const relationAttr = field.attributes.find(a => a.name === 'relation')
       if (relationAttr) {
@@ -458,20 +458,30 @@ export function validateSchema(schema: SchemaAST): ParseError[] {
             table: tableName,
             field: field.name,
           })
-        } else {
-          if (!schema.tables[target]) {
-            errors.push({
-              message: `@relation target '${target}' in field '${tableName}.${field.name}' is not a defined table`,
-              table: tableName,
-              field: field.name,
-            })
-          }
+          continue
         }
 
-        const stringTypes = ['string', 'string[]']
-        if (!stringTypes.includes(field.type)) {
+        const targetTable = schema.tables[target]
+        if (!targetTable) {
           errors.push({
-            message: `@relation in field '${tableName}.${field.name}' is only allowed on string-based fields, got '${field.type}'`,
+            message: `@relation target '${target}' in field '${tableName}.${field.name}' is not a defined table`,
+            table: tableName,
+            field: field.name,
+          })
+          continue
+        }
+
+        // The generated alias resolves to the target's id type
+        // (`export type UserId = User['id']`), so a mismatch here would emit a
+        // field type that contradicts the one declared in the schema (#117).
+        // Rule 2b guarantees the @id field is named 'id'.
+        const targetId = targetTable.fields.find(f => f.name === 'id')
+        if (!targetId) continue
+
+        const fkBaseType = field.type.replace(/\[\]$/, '')
+        if (fkBaseType !== targetId.type) {
+          errors.push({
+            message: `@relation in field '${tableName}.${field.name}' has type '${field.type}' but '${target}.id' is '${targetId.type}' — a foreign key must match the type of the id it references`,
             table: tableName,
             field: field.name,
           })

--- a/packages/cli/tests/unit/schema-parser.test.ts
+++ b/packages/cli/tests/unit/schema-parser.test.ts
@@ -1028,7 +1028,58 @@ describe('validateSchema @relation rules', () => {
     )
   })
 
-  it('should error when @relation is used on non-string field', () => {
+  it('should allow a numeric @relation when the target id is numeric [#117]', () => {
+    const errors = validateSchema({
+      enums: {},
+      tables: {
+        User: {
+          name: 'User',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+          ],
+          blockAttributes: [],
+        },
+        Task: {
+          name: 'Task',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+            { name: 'assigneeId', type: 'number', optional: true, attributes: [{ name: 'relation', args: ['User'] }] },
+            { name: 'watcherIds', type: 'number[]', optional: true, attributes: [{ name: 'relation', args: ['User'] }] },
+          ],
+          blockAttributes: [],
+        },
+      },
+    })
+    expect(errors).toEqual([])
+  })
+
+  it('should error when a string @relation points at a numeric id [#117]', () => {
+    const errors = validateSchema({
+      enums: {},
+      tables: {
+        User: {
+          name: 'User',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+          ],
+          blockAttributes: [],
+        },
+        Task: {
+          name: 'Task',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+            { name: 'assigneeId', type: 'string', optional: true, attributes: [{ name: 'relation', args: ['User'] }] },
+          ],
+          blockAttributes: [],
+        },
+      },
+    })
+    expect(errors).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("must match the type of the id it references") })
+    )
+  })
+
+  it('should error when @relation type does not match the target id type', () => {
     const errors = validateSchema({
       enums: {},
       tables: {
@@ -1050,7 +1101,7 @@ describe('validateSchema @relation rules', () => {
       },
     })
     expect(errors).toContainEqual(
-      expect.objectContaining({ message: expect.stringContaining("only allowed on string-based fields") })
+      expect.objectContaining({ message: expect.stringContaining("must match the type of the id it references") })
     )
   })
 

--- a/packages/cli/tests/unit/types-generator.test.ts
+++ b/packages/cli/tests/unit/types-generator.test.ts
@@ -444,6 +444,34 @@ describe('generateTypes', () => {
       expect(result).toContain("export type UserId = User['id']")
     })
 
+    it('should emit an array alias for a number[] relation [#117]', () => {
+      const ast: SchemaAST = {
+        enums: {},
+        tables: {
+          User: {
+            name: 'User',
+            fields: [
+              { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+            ],
+            blockAttributes: []
+          },
+          Task: {
+            name: 'Task',
+            fields: [
+              { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+              { name: 'watcherIds', type: 'number[]', optional: true, attributes: [{ name: 'relation', args: ['User'] }] },
+            ],
+            blockAttributes: []
+          }
+        }
+      }
+
+      const result = generateTypes(ast)
+
+      expect(result).toContain("export type UserId = User['id']")
+      expect(result).toContain('watcherIds?: UserId[]')
+    })
+
     it('should replace field type with relation alias', () => {
       const ast: SchemaAST = {
         enums: {},


### PR DESCRIPTION
Closes #117

## The bug

`@relation` shipped in `81bcdb2` restricted to string-based fields (`schema-parser.ts:471-478`). But **every `@id` example in the repo is numeric** — `README.md:45`, `docs/schema-syntax.md:76, 91, 184, 193, 207`. Against the documented shape, both branches were wrong:

| Schema | Before |
|---|---|
| `assigneeId: number? @relation(User)` | **rejected** — "only allowed on string-based fields, got 'number'" |
| `assigneeId: string? @relation(User)` (User.id is `number`) | **accepted, zero diagnostics** — emits `assigneeId?: UserId` where `UserId = User['id']` resolves to `number`, contradicting the declared `string` |

So `@relation` only behaved correctly when the target's `id` was `string` — which is exactly what every existing test used (`types-generator.test.ts:427, 447+`, `client-package-generator.test.ts:198+`). The broken path was untested.

## Fix

Replace the string-only restriction with a type-match check. Rule 2b (`schema-parser.ts:408-416`) already guarantees the `@id` field is named `id`, so it is a direct lookup:

```ts
const targetId = targetTable.fields.find(f => f.name === 'id')
const fkBaseType = field.type.replace(/\[\]$/, '')
if (fkBaseType !== targetId.type) { /* error naming both types */ }
```

Both generators (`types-generator.ts:52-59`, `client-package-generator.ts:26-33`) now key the array case off an `[]` suffix instead of the literal `'string[]'`, so `number[]` foreign keys emit `UserId[]`.

This is a **widening** — numeric foreign keys become legal, which is what makes the documented schema shape usable — plus a new, more accurate error replacing a less accurate one.

## Docs

`@relation` never appeared in `docs/schema-syntax.md` (zero occurrences of `relation`) despite being a shipped, about-to-be-frozen DSL attribute. Added a section that also states the scope plainly:

- typing/documentation only — no JOIN inference, no write-time FK integrity, no cascade; use `joinQuery()` to join explicitly
- the emitted alias is a **plain type alias, not branded**, so it is structurally identical to its underlying type — it documents, it does not enforce. Recorded as a deliberate 1.0 choice, since switching to branded types after 1.0 would require a cast at every assignment site.

## Verification

All four new/updated tests fail without the fix:

| Test | Without the fix |
|---|---|
| allows a numeric @relation when the target id is numeric | `expected [ …2 errors ] to deeply equal []` |
| errors when a string @relation points at a numeric id | `expected [] to deep equally contain …` — the silent flip |
| errors when @relation type does not match the target id type | old message, now more precise |
| emits an array alias for a number[] relation | `expected … to contain 'watcherIds?: UserId[]'` |

Full suite: cli 231 / core 508 / client 116 / skills 14. `typecheck` clean.

## Out of scope

Runtime behaviour is deliberately excluded. For whoever picks it up:

- **Inferred joins** are the cheap one — JOIN already exists (`packages/core/src/core/join-query-builder.ts`, exported and reachable from the generated client). Needs relation metadata threaded into `GeneratedSchema` (`packages/client/src/runtime.ts:46-53`), a public-surface change.
- **FK integrity on write** costs a read-before-write per mutation — an extra Sheets round-trip inside GAS quota limits.
- **Cascade delete** is blocked on a cross-table transaction primitive that does not exist; locking is per-adapter and scoped to ID allocation.

Parse-and-types-only stays coherent: `@default`, `@updatedAt` and `@unique` are already parse-only against `GeneratedSchema`, and the `@relation(Target)` syntax is forward-compatible — adding runtime behaviour later adds metadata, not new syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)