### PR TITLE
fix(core)!: exclude id from batchUpdate data, matching update()

### DIFF
--- a/packages/core/src/core/repository.ts
+++ b/packages/core/src/core/repository.ts
@@ -119,10 +119,14 @@ export class Repository<T extends RowWithId> {
   /**
    * Batch update multiple rows at once
    * Skips rows that don't exist (no error thrown)
+   *
+   * `data` excludes `id` (via {@link UpdateData}) for the same reason
+   * `update()` does — the primary key is immutable (#98/#113). A widened
+   * `Partial<T>` here let an id through the ordinary public API with no cast.
    */
-  batchUpdate(items: { id: string | number; data: Partial<T> }[]): T[] {
+  batchUpdate(items: BatchUpdateItem<T>[]): T[] {
     if (this.store.batchUpdate) {
-      return this.store.batchUpdate(items as BatchUpdateItem<T>[])
+      return this.store.batchUpdate(items)
     }
     // Fallback: update one by one
     const results: T[] = []

--- a/packages/core/src/core/sheets-db.ts
+++ b/packages/core/src/core/sheets-db.ts
@@ -8,7 +8,8 @@ import type {
   TableSchemaTyped,
   InferRowFromSchema,
   InferTablesFromConfig,
-  UpdateData
+  UpdateData,
+  BatchUpdateItem
 } from './types'
 import { Repository } from './repository'
 import { QueryBuilder, createQueryBuilder } from './query-builder'
@@ -47,8 +48,8 @@ export interface TableHandle<T extends RowWithId> {
   /** Batch insert multiple rows at once */
   batchInsert(data: (T | Omit<T, 'id'>)[]): T[]
 
-  /** Batch update multiple rows at once */
-  batchUpdate(items: { id: string | number; data: Partial<T> }[]): T[]
+  /** Batch update multiple rows at once (`data` excludes the immutable `id`) */
+  batchUpdate(items: BatchUpdateItem<T>[]): T[]
 }
 
 /**


### PR DESCRIPTION
Closes #113

Completes #113. The runtime guards (both adapters) land in #122; this closes the type hole above them.

## The hole

`update()` has excluded `id` since #98 — `UpdateData<T> = Partial<Omit<T, 'id'>>`. `batchUpdate` did not:

```ts
batchUpdate(items: { id: string | number; data: Partial<T> }[]): T[]
//                                              ^^^^^^^^^^ admits id
```

So the issue's claim that the corruption is "only reachable via a cast" is wrong — it compiled through the ordinary public API:

```ts
db.from('t').batchUpdate([{ id: 1, data: { id: 42 } }])   // compiled clean
repo.update(1, { id: 42 })                                // TS2353, correctly rejected
```

## Fix

Narrow both `Repository.batchUpdate` (`repository.ts:123`) and `TableHandle.batchUpdate` (`sheets-db.ts:51`) to `BatchUpdateItem<T>[]`, which already carries `UpdateData<T>`. The internal `as BatchUpdateItem<T>[]` cast in `Repository` disappears with it — it only existed to bridge the widened signature.

Verified with a `tsc --noEmit` probe against the real source:

```
batchUpdate([{ id: 1, data: { name: 'ok' } }])          -> no error
batchUpdate([{ id: 1, data: { id: 42, name: 'x' } }])   -> error TS2353: 'id' does not exist
                                                           in type 'Partial<Omit<Row, "id">>'
```

Full suite: core 508 / client 116 / cli 228 / skills 14. `typecheck` clean — which also proves no internal caller was relying on the widened shape.

## Breaking-change assessment

Marked `!` because it is a public signature narrowing, but the blast radius is empty:

- Searched `packages/*/tests`, `docs/`, `examples/`, `README.md` — **not one** call site passes `id` inside `data`. Every existing usage is `{ id: X, data: { <non-id fields> } }`.
- It breaks compilation only for code that passes an id in `data` — i.e. only code currently triggering the corruption.
- Same precedent as #98, which narrowed `update()` and was closed as non-breaking.

An intentional id change remains available as delete + insert.

## No automated type test

`packages/core/tsconfig.json` excludes `tests`, so a `@ts-expect-error` in a test file would not be verified by `pnpm typecheck`, and Vitest transpiles without typechecking. The narrowing is therefore verified by the probe above and by `typecheck` passing on `src`, but **nothing automatically guards against re-widening**. Adding `vitest --typecheck` for this one assertion did not seem worth the infrastructure; say the word if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)