### PR TITLE
fix(core): export type-only names via export type, add regression guards

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,6 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Guard (#134): errors on a type re-exported in value position, which would
+    // otherwise land in .d.ts as a value export that the bundled JS cannot provide.
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/core/src/adapters/mock-adapter.ts
+++ b/packages/core/src/adapters/mock-adapter.ts
@@ -2,7 +2,8 @@
  * Mock adapter for testing - in-memory data storage
  */
 import type { RowWithId, DataStore, QueryOptions, WhereCondition, BatchUpdateItem, IdMode, UpdateData } from '../core/types'
-import { IndexStore, IndexDefinition } from '../core/index-store'
+import { IndexStore } from '../core/index-store'
+import type { IndexDefinition } from '../core/index-store'
 import { evaluateCondition, compareRows } from '../core/query-utils'
 
 /** MockAdapter configuration options */

--- a/packages/core/src/core/sheets-db.ts
+++ b/packages/core/src/core/sheets-db.ts
@@ -13,7 +13,8 @@ import type {
 } from './types'
 import { Repository } from './repository'
 import { QueryBuilder, createQueryBuilder } from './query-builder'
-import { JoinQueryBuilder, createJoinQueryBuilder, StoreResolver } from './join-query-builder'
+import { JoinQueryBuilder, createJoinQueryBuilder } from './join-query-builder'
+import type { StoreResolver } from './join-query-builder'
 import { TableNotFoundError, MissingStoreError } from './errors'
 import { MockAdapter } from '../adapters/mock-adapter'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,22 +32,25 @@ export type {
 export { Repository } from './core/repository'
 export { QueryBuilder, createQueryBuilder } from './core/query-builder'
 export type { AggSpec, AggResult, GroupedAggResult, HavingCondition } from './core/query-builder'
-export { JoinQueryBuilder, createJoinQueryBuilder, JoinConfig, StoreResolver } from './core/join-query-builder'
+export { JoinQueryBuilder, createJoinQueryBuilder } from './core/join-query-builder'
+export type { JoinConfig, StoreResolver } from './core/join-query-builder'
 
 // SheetsDB factory functions
 export { createSheetsDB, defineSheetsDB } from './core/sheets-db'
 export type { SheetsDB, TableHandle, CreateSheetsDBOptions, DefineSheetsDBOptions } from './core/sheets-db'
 
 // Adapters
-export { MockAdapter, MockAdapterOptions } from './adapters/mock-adapter'
-export { SheetsAdapter, SheetsAdapterOptions } from './adapters/sheets-adapter'
-export type { ColumnType } from './adapters/sheets-adapter'
+export { MockAdapter } from './adapters/mock-adapter'
+export type { MockAdapterOptions } from './adapters/mock-adapter'
+export { SheetsAdapter } from './adapters/sheets-adapter'
+export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter'
 
 // Query utilities
 export { evaluateCondition, compareRows } from './core/query-utils'
 
 // Index Store
-export { IndexStore, IndexDefinition, createIndexKey, serializeValues } from './core/index-store'
+export { IndexStore, createIndexKey, serializeValues } from './core/index-store'
+export type { IndexDefinition } from './core/index-store'
 
 // Errors
 export {

--- a/packages/core/tests/unit/dist-exports.test.ts
+++ b/packages/core/tests/unit/dist-exports.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression guard for #134.
+ *
+ * `export { SomeInterface } from './mod'` type-checks and emits a *value*
+ * re-export into dist/types/index.d.ts, but esbuild erases the type from
+ * dist/index.mjs. Consumers then write `import { SomeInterface } from
+ * '@gsquery/core'`, type-check cleanly, and crash at ESM link time with
+ * "does not provide an export named". Every value export the .d.ts declares
+ * must therefore exist on the built module.
+ *
+ * `verbatimModuleSyntax` in tsconfig.json catches this at compile time; this
+ * test verifies the built artifacts themselves. It needs a prior `pnpm build`
+ * and is skipped when dist/ is absent (CI always builds first).
+ */
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const dtsPath = join(packageRoot, 'dist', 'types', 'index.d.ts')
+const modulePath = join(packageRoot, 'dist', 'index.mjs')
+const built = existsSync(dtsPath) && existsSync(modulePath)
+
+/** Names the .d.ts re-exports in value position (i.e. not via `export type`). */
+function readDeclaredValueExports(source: string): string[] {
+  const names: string[] = []
+
+  // `export { a, b as c } from '...'` / `export { a, b }` — but not `export type { ... }`.
+  for (const match of source.matchAll(/\bexport\s*(type\s+)?\{([^}]*)\}/g)) {
+    if (match[1] !== undefined) continue
+    for (const raw of match[2].split(',')) {
+      const specifier = raw.trim()
+      // Inline type modifier: `export { type Foo }` is already type-only.
+      if (specifier === '' || specifier.startsWith('type ')) continue
+      const parts = specifier.split(/\s+as\s+/)
+      names.push((parts[1] ?? parts[0]).trim())
+    }
+  }
+
+  // `export declare class Foo` / `export declare function foo` / `export declare const foo`
+  for (const match of source.matchAll(
+    /\bexport\s+declare\s+(?:abstract\s+)?(?:class|function|const|let|var|enum)\s+([A-Za-z_$][\w$]*)/g
+  )) {
+    names.push(match[1])
+  }
+
+  return [...new Set(names)]
+}
+
+describe.skipIf(!built)('built package exports', () => {
+  it('declares no value export that the ESM bundle is missing', async () => {
+    const declared = readDeclaredValueExports(readFileSync(dtsPath, 'utf-8'))
+    const runtime = await import(modulePath)
+
+    expect(declared.length).toBeGreaterThan(0)
+    const missing = declared.filter((name) => !(name in runtime))
+    expect(missing).toEqual([])
+  })
+
+  it('keeps type-only names out of value position', async () => {
+    const source = readFileSync(dtsPath, 'utf-8')
+    const declared = readDeclaredValueExports(source)
+    const runtime = await import(modulePath)
+
+    // The five names from #134: types, so absent at runtime and re-exported
+    // by the .d.ts only via `export type`.
+    const typeOnly = [
+      'JoinConfig',
+      'StoreResolver',
+      'MockAdapterOptions',
+      'SheetsAdapterOptions',
+      'IndexDefinition'
+    ]
+
+    for (const name of typeOnly) {
+      expect(source).toContain(name)
+      expect(declared).not.toContain(name)
+      expect(name in runtime).toBe(false)
+    }
+  })
+})

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,6 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Guard (#134): errors on a type re-exported in value position, which would
+    // otherwise land in .d.ts as a value export that the bundled JS cannot provide.
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "declarationDir": "dist/types",
     "outDir": "dist",

--- a/packages/skills/tsconfig.json
+++ b/packages/skills/tsconfig.json
@@ -7,6 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    // Guard (#134): errors on a type re-exported in value position, which would
+    // otherwise land in .d.ts as a value export that the bundled JS cannot provide.
+    "verbatimModuleSyntax": true,
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    // Guard (#134): errors on a type re-exported in value position, which would
+    // otherwise land in .d.ts as a value export that the bundled JS cannot provide.
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
## Summary

`JoinConfig`, `StoreResolver`, `MockAdapterOptions`, `SheetsAdapterOptions`, and `IndexDefinition` were exported in value position from the core barrel: `dist/types` promised value exports that `dist/index.mjs` cannot provide, so `import { SheetsAdapterOptions } from '@gsquery/core'` type-checked but failed at ESM link time. All five are now `export type`; a sweep fixed two more internal value-position imports of the same class (`mock-adapter.ts`, `sheets-db.ts`).

Two regression guards added: `verbatimModuleSyntax` enabled across all four packages (TS1205 fails typecheck on recurrence), and `packages/core/tests/unit/dist-exports.test.ts` asserts every value export in the built `.d.ts` actually exists on the built `dist/index.mjs`. Both guards were verified to fire when the bug is reintroduced.

## Related Issues

Closes #134

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (880 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_