### PR TITLE
fix(core): lock all read-then-write adapter paths and migrations; reject duplicate client IDs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -544,6 +544,7 @@ Options:
 | `SheetsQueryError` | Base error class |
 | `TableNotFoundError` | Table not found |
 | `RowNotFoundError` | Row not found |
+| `DuplicateIdError` | Insert would duplicate an existing id (`idMode: 'client'`) |
 | `NoResultsError` | No query results (`firstOrFail`) |
 | `MissingStoreError` | DataStore not found |
 | `ValidationError` | Validation failed |

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -4,6 +4,8 @@
  */
 import type { RowWithId, DataStore, QueryOptions, BatchUpdateItem, IdMode, UpdateData } from '../core/types'
 import { evaluateCondition, compareRows } from '../core/query-utils'
+import { DuplicateIdError } from '../core/errors'
+import { withScriptLock } from '../core/script-lock'
 
 /** Column type definition for schema-based serialization */
 export type ColumnType = 
@@ -277,20 +279,54 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   /**
    * Run a function while holding the script lock (when LockService is available).
    * The lock is held for the entire duration of fn so that read-allocate-write
-   * sequences stay atomic across concurrent executions.
+   * and find-then-write sequences stay atomic across concurrent executions
+   * (#80, #128). Degrades to running fn unlocked outside GAS.
    */
   private withLock<R>(fn: () => R): R {
-    let lock: GoogleAppsScript.Lock.Lock | null = null
-    try {
-      if (typeof LockService !== 'undefined') {
-        lock = LockService.getScriptLock()
-        lock.waitLock(10000)
+    return withScriptLock(fn)
+  }
+
+  /**
+   * Read the id of a client-mode row, throwing when the caller omitted it.
+   */
+  private requireClientId(data: Omit<T, 'id'> | T): string | number {
+    const record = data as Record<string, unknown>
+    if (!(this.idColumn in record)) {
+      throw new Error(`ID is required in client mode (idMode: 'client')`)
+    }
+    return record[this.idColumn] as string | number
+  }
+
+  /** Read every id currently on the sheet, keyed as strings for comparison. */
+  private readExistingIdKeys(): Set<string> {
+    const sheet = this.getSheet()
+    const lastRow = sheet.getLastRow()
+    const keys = new Set<string>()
+
+    if (lastRow <= 1) return keys
+
+    const idColIndex = this.columns.indexOf(this.idColumn) + 1
+    const ids = sheet.getRange(2, idColIndex, lastRow - 1, 1).getValues().flat()
+    for (const id of ids) {
+      if (id === '' || id === null || id === undefined) continue
+      keys.add(String(id))
+    }
+    return keys
+  }
+
+  /**
+   * Reject client-supplied ids that already exist on the sheet, or that repeat
+   * within the same batch. Must be called inside withLock() together with the
+   * write, otherwise a concurrent execution can insert the same id in between.
+   */
+  private assertClientIdsAvailable(ids: (string | number)[]): void {
+    const existing = this.readExistingIdKeys()
+    for (const id of ids) {
+      const key = String(id)
+      if (existing.has(key)) {
+        throw new DuplicateIdError(id, this.sheetName)
       }
-      return fn()
-    } finally {
-      if (lock) {
-        lock.releaseLock()
-      }
+      existing.add(key)
     }
   }
 
@@ -400,14 +436,17 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     const sheet = this.getSheet()
 
     if (this.idMode === 'client') {
-      // Client mode: use client-provided ID
-      if (!(this.idColumn in (data as Record<string, unknown>))) {
-        throw new Error(`ID is required in client mode (idMode: 'client')`)
-      }
-      const newRow = data as T
-      const rowValues = this.objectToRow(newRow)
-      sheet.appendRow(rowValues)
-      return newRow
+      // Client mode: use client-provided ID. The uniqueness check and the write
+      // share one lock so a concurrent execution cannot slip in the same id
+      // between them, which would leave a row unreachable by id (#128).
+      const id = this.requireClientId(data)
+      return this.withLock(() => {
+        this.assertClientIdsAvailable([id])
+        const newRow = data as T
+        const rowValues = this.objectToRow(newRow)
+        sheet.appendRow(rowValues)
+        return newRow
+      })
     } else {
       // Auto mode: allocate the ID and write the row atomically under the lock,
       // otherwise concurrent executions can allocate the same ID.
@@ -422,34 +461,52 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   update(id: string | number, data: UpdateData<T>): T | undefined {
-    const rowIndex = this.findRowIndexById(id)
-    if (rowIndex === -1) return undefined
-
-    this.invalidateDataCache()
     const sheet = this.getSheet()
-    const currentValues = sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()[0]
-    const currentRow = this.rowToObject(currentValues)
 
-    const updatedRow = { ...currentRow, ...data } as T
-    // id is immutable via update; ignore any attempt to change it (#98).
-    ;(updatedRow as Record<string, unknown>)[this.idColumn] =
-      (currentRow as Record<string, unknown>)[this.idColumn]
-    const rowValues = this.objectToRow(updatedRow)
-    
-    sheet.getRange(rowIndex, 1, 1, this.columns.length).setValues([rowValues])
-    
-    return updatedRow
+    // Locating the row and writing to that row number must be atomic: a
+    // concurrent deleteRow above the target shifts rows up and the write would
+    // land on a different record (#128).
+    return this.withLock(() => {
+      const rowIndex = this.findRowIndexById(id)
+      if (rowIndex === -1) return undefined
+
+      this.invalidateDataCache()
+      const currentValues = sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()[0]
+
+      // Cheap re-verification of the row we are about to overwrite — free here
+      // because the row was read anyway, and it still guards the unlocked
+      // (LockService-less) path.
+      const currentId = currentValues[this.columns.indexOf(this.idColumn)]
+      if (currentId !== id && String(currentId) !== String(id)) return undefined
+
+      const currentRow = this.rowToObject(currentValues)
+
+      const updatedRow = { ...currentRow, ...data } as T
+      // id is immutable via update; ignore any attempt to change it (#98).
+      ;(updatedRow as Record<string, unknown>)[this.idColumn] =
+        (currentRow as Record<string, unknown>)[this.idColumn]
+      const rowValues = this.objectToRow(updatedRow)
+
+      sheet.getRange(rowIndex, 1, 1, this.columns.length).setValues([rowValues])
+
+      return updatedRow
+    })
   }
 
   delete(id: string | number): boolean {
-    const rowIndex = this.findRowIndexById(id)
-    if (rowIndex === -1) return false
-
-    this.invalidateDataCache()
     const sheet = this.getSheet()
-    sheet.deleteRow(rowIndex)
 
-    return true
+    // Same find-then-write race as update(): without the lock a concurrent
+    // delete above the target makes this remove the wrong row (#128).
+    return this.withLock(() => {
+      const rowIndex = this.findRowIndexById(id)
+      if (rowIndex === -1) return false
+
+      this.invalidateDataCache()
+      sheet.deleteRow(rowIndex)
+
+      return true
+    })
   }
 
   batchInsert(items: (Omit<T, 'id'> | T)[]): T[] {
@@ -466,19 +523,24 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     }
 
     if (this.idMode === 'client') {
-      // Client mode: use client-provided IDs (no server-side allocation)
+      // Client mode: no server-side allocation, but the write position
+      // (getLastRow) and the uniqueness check are still read-then-write, so
+      // they belong inside the lock — two concurrent batches otherwise compute
+      // the same start row and the second overwrites the first (#128).
       const results: T[] = []
       const rowsToInsert: unknown[][] = []
+      const ids: (string | number)[] = []
       for (const data of items) {
-        if (!(this.idColumn in (data as Record<string, unknown>))) {
-          throw new Error(`ID is required in client mode (idMode: 'client')`)
-        }
+        ids.push(this.requireClientId(data))
         const newRow = data as T
         results.push(newRow)
         rowsToInsert.push(this.objectToRow(newRow))
       }
-      writeRows(rowsToInsert)
-      return results
+      return this.withLock(() => {
+        this.assertClientIdsAvailable(ids)
+        writeRows(rowsToInsert)
+        return results
+      })
     }
 
     // Auto mode: allocate IDs (incl. the getLastRow used for the write

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -56,6 +56,27 @@ export class RowNotFoundError extends SheetsQueryError {
 }
 
 /**
+ * Thrown when an insert would create a row whose id already exists.
+ *
+ * Only client-supplied ids can collide (`idMode: 'client'`); auto-mode ids are
+ * allocated under the write lock. A duplicate id is unreachable by id lookups,
+ * so it is rejected instead of written (#128).
+ */
+export class DuplicateIdError extends SheetsQueryError {
+  constructor(
+    public readonly id: string | number,
+    public readonly tableName?: string
+  ) {
+    const tableInfo = tableName ? ` in table "${tableName}"` : ''
+    super(
+      `Row with id "${id}" already exists${tableInfo}`,
+      'DUPLICATE_ID'
+    )
+    this.name = 'DuplicateIdError'
+  }
+}
+
+/**
  * Thrown when a query returns no results but one was expected
  */
 export class NoResultsError extends SheetsQueryError {

--- a/packages/core/src/core/migration.ts
+++ b/packages/core/src/core/migration.ts
@@ -5,6 +5,7 @@
  */
 import type { Row, RowWithId, DataStore } from './types'
 import { SheetsQueryError } from './errors'
+import { withScriptLockAsync } from './script-lock'
 
 // ============================================================================
 // Migration Types
@@ -364,11 +365,20 @@ export class MigrationRunner {
   /**
    * Run all pending migrations
    * @param options - Optional: specify target version
+   *
+   * Holds the script lock for the whole run so two concurrent GAS executions
+   * cannot apply the same migration twice. The pending list is read *after*
+   * the lock is acquired, because another execution may have applied
+   * migrations while this one was waiting (#128).
    */
   async migrate(options?: { to?: number }): Promise<MigrationResult> {
+    return withScriptLockAsync(() => this.runMigrations(options))
+  }
+
+  private async runMigrations(options?: { to?: number }): Promise<MigrationResult> {
     const pending = this.getPendingMigrations()
     const applied: { version: number; name: string }[] = []
-    
+
     for (const migration of pending) {
       // Stop if we've reached the target version
       if (options?.to !== undefined && migration.version > options.to) {
@@ -410,10 +420,18 @@ export class MigrationRunner {
   
   /**
    * Rollback the last applied migration
+   *
+   * Locked for the same reason as migrate(): the applied list is re-read after
+   * the lock is acquired so a migration another execution already rolled back
+   * is not rolled back twice (#128).
    */
   async rollback(): Promise<RollbackResult> {
+    return withScriptLockAsync(() => this.runRollback())
+  }
+
+  private async runRollback(): Promise<RollbackResult> {
     const applied = this.getAppliedMigrations()
-    
+
     if (applied.length === 0) {
       throw new NoMigrationsToRollbackError()
     }
@@ -459,17 +477,21 @@ export class MigrationRunner {
    * Rollback all migrations (reset to version 0)
    */
   async rollbackAll(): Promise<{ rolledBack: { version: number; name: string }[]; currentVersion: number }> {
-    const rolledBack: { version: number; name: string }[] = []
-    
-    while (this.getCurrentVersion() > 0) {
-      const result = await this.rollback()
-      rolledBack.push(result.rolledBack)
-    }
-    
-    return {
-      rolledBack,
-      currentVersion: 0
-    }
+    // One lock for the whole sequence (the per-rollback lock is re-entrant), so
+    // the schema is never observed half-rolled-back by another execution.
+    return withScriptLockAsync(async () => {
+      const rolledBack: { version: number; name: string }[] = []
+
+      while (this.getCurrentVersion() > 0) {
+        const result = await this.rollback()
+        rolledBack.push(result.rolledBack)
+      }
+
+      return {
+        rolledBack,
+        currentVersion: 0
+      }
+    })
   }
   
   /**

--- a/packages/core/src/core/script-lock.ts
+++ b/packages/core/src/core/script-lock.ts
@@ -1,0 +1,87 @@
+/**
+ * Script-lock helpers shared by every write path that must stay atomic across
+ * concurrent GAS executions (#80, #128).
+ *
+ * Apps Script runs the same code concurrently for different users, so any
+ * read-then-write sequence against a sheet (find a row index, then write to
+ * that row number) is only safe while the script lock is held for the whole
+ * sequence. LockService is absent outside GAS (Node tests, bundlers), in which
+ * case these helpers degrade to running the callback unlocked.
+ */
+
+/** Default time (ms) to wait for the script lock before giving up. */
+export const DEFAULT_LOCK_TIMEOUT_MS = 10000
+
+/**
+ * Re-entrancy depth for the current execution.
+ *
+ * A GAS execution is single-threaded and already owns the lock once acquired,
+ * so nested calls (a MigrationRunner holding the lock while SheetsAdapter
+ * updates rows through it) must reuse the outer acquisition instead of asking
+ * LockService for a second one, which would deadlock against itself.
+ */
+let lockDepth = 0
+
+/** Acquires the script lock, or returns null when LockService is unavailable. */
+function acquireLock(timeoutMs: number): GoogleAppsScript.Lock.Lock | null {
+  if (typeof LockService === 'undefined') return null
+  const lock = LockService.getScriptLock()
+  lock.waitLock(timeoutMs)
+  return lock
+}
+
+/**
+ * Runs `fn` while holding the script lock, releasing it once `fn` returns or
+ * throws. Re-entrant: a nested call runs under the lock already held.
+ */
+export function withScriptLock<R>(fn: () => R, timeoutMs: number = DEFAULT_LOCK_TIMEOUT_MS): R {
+  if (lockDepth > 0) {
+    lockDepth++
+    try {
+      return fn()
+    } finally {
+      lockDepth--
+    }
+  }
+
+  const lock = acquireLock(timeoutMs)
+  lockDepth++
+  try {
+    return fn()
+  } finally {
+    lockDepth--
+    if (lock) {
+      lock.releaseLock()
+    }
+  }
+}
+
+/**
+ * Async counterpart of {@link withScriptLock}: the lock is held until the
+ * returned promise settles. GAS resolves promises inside the one execution
+ * that created them, so the re-entrancy depth stays accurate there.
+ */
+export async function withScriptLockAsync<R>(
+  fn: () => Promise<R>,
+  timeoutMs: number = DEFAULT_LOCK_TIMEOUT_MS
+): Promise<R> {
+  if (lockDepth > 0) {
+    lockDepth++
+    try {
+      return await fn()
+    } finally {
+      lockDepth--
+    }
+  }
+
+  const lock = acquireLock(timeoutMs)
+  lockDepth++
+  try {
+    return await fn()
+  } finally {
+    lockDepth--
+    if (lock) {
+      lock.releaseLock()
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   SheetsQueryError,
   TableNotFoundError,
   RowNotFoundError,
+  DuplicateIdError,
   NoResultsError,
   MissingStoreError,
   ValidationError,

--- a/packages/core/tests/unit/concurrent-write-locking.test.ts
+++ b/packages/core/tests/unit/concurrent-write-locking.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Concurrency tests for the SheetsAdapter write paths and the MigrationRunner
+ * (#128).
+ *
+ * GAS runs concurrent executions against the same spreadsheet, so every
+ * read-then-write sequence must be held inside one script lock. These tests
+ * model a second execution by driving TWO adapter instances over ONE shared
+ * FakeSheet and firing the second one from inside the first one's operation,
+ * at the exact point where the interleaving is harmful.
+ *
+ * The fake `LockService` here is exclusive (unlike the always-available no-op
+ * one from `installGasFakes`): while a lock is held, the simulated second
+ * execution is deferred instead of running, which is what `waitLock` does in
+ * production. If the operation under test is not locked, the intruder runs
+ * mid-operation and corrupts the sheet — that is the regression being pinned.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import type { SheetsAdapterOptions } from '../../src/adapters/sheets-adapter'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { createMigrationRunner } from '../../src/core/migration'
+import type { Migration, MigrationRecord, StoreResolver } from '../../src/core/migration'
+import { NoMigrationsToRollbackError } from '../../src/core/migration'
+import { DuplicateIdError } from '../../src/core/errors'
+import { FakeSheet } from '../../src/testing/fake-sheet'
+import { FakeSpreadsheet } from '../../src/testing/fake-spreadsheet'
+import { installGasFakes } from '../../src/testing/install'
+import { fromArrays } from '../../src/testing/loaders'
+import type { DataStore, Row, RowWithId } from '../../src/core/types'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+const SHEET_NAME = 'Users'
+const COLUMNS = ['id', 'name', 'age']
+
+interface TestRow extends RowWithId {
+  id: string | number
+  name: string
+  age: number
+}
+
+const BASE_OPTIONS: SheetsAdapterOptions = {
+  spreadsheetId: SPREADSHEET_ID,
+  sheetName: SHEET_NAME,
+  columns: COLUMNS
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/** Shared state of the exclusive script-lock fake. */
+interface LockState {
+  held: boolean
+  acquisitions: number
+}
+
+/**
+ * Installs a `LockService` whose script lock is genuinely exclusive: a second
+ * `waitLock()` while the lock is held throws, so any test that accidentally
+ * re-acquires (rather than deferring) fails loudly instead of silently passing.
+ */
+function installExclusiveLock(): LockState {
+  const state: LockState = { held: false, acquisitions: 0 }
+  const lock = {
+    waitLock(): void {
+      if (state.held) {
+        throw new Error('waitLock: script lock is already held by another execution')
+      }
+      state.held = true
+      state.acquisitions++
+    },
+    tryLock(): boolean {
+      if (state.held) return false
+      state.held = true
+      state.acquisitions++
+      return true
+    },
+    releaseLock(): void {
+      state.held = false
+    },
+    hasLock(): boolean {
+      return state.held
+    }
+  }
+  ;(globalThis as Record<string, unknown>).LockService = { getScriptLock: () => lock }
+  return state
+}
+
+/**
+ * A simulated second GAS execution. `run()` executes it immediately when the
+ * script lock is free, and defers it until `drain()` when the lock is held —
+ * mirroring an execution parked in `waitLock`.
+ */
+function concurrentExecution(lockState: LockState, work: () => void) {
+  const deferred: (() => void)[] = []
+  return {
+    run(): void {
+      if (lockState.held) {
+        deferred.push(work)
+      } else {
+        work()
+      }
+    },
+    drain(): void {
+      while (deferred.length > 0) {
+        deferred.shift()!()
+      }
+    },
+    get wasDeferred(): boolean {
+      return deferred.length > 0
+    }
+  }
+}
+
+/**
+ * Fires `run` once, right after the first ID-column scan reads its values —
+ * i.e. between "find the row index" and "write to that row index".
+ */
+function interruptAfterIdScan(sheet: FakeSheet, run: () => void): void {
+  let armed = true
+  const original = sheet.getRange.bind(sheet)
+  vi.spyOn(sheet, 'getRange').mockImplementation(
+    (row: number, col: number, numRows = 1, numCols = 1) => {
+      const range = original(row, col, numRows, numCols)
+      if (armed && row === 2 && numCols === 1) {
+        armed = false
+        const getValues = range.getValues.bind(range)
+        range.getValues = () => {
+          const values = getValues()
+          run()
+          return values
+        }
+      }
+      return range
+    }
+  )
+}
+
+/** Fires `run` once, right after the first `getLastRow()` reads its value. */
+function interruptAfterLastRow(sheet: FakeSheet, run: () => void): void {
+  let armed = true
+  const original = sheet.getLastRow.bind(sheet)
+  vi.spyOn(sheet, 'getLastRow').mockImplementation(() => {
+    const lastRow = original()
+    if (armed) {
+      armed = false
+      run()
+    }
+    return lastRow
+  })
+}
+
+/** Registers one shared FakeSheet as the fake spreadsheet and returns it. */
+function setupSharedSheet(rows: unknown[][]): FakeSheet {
+  const spreadsheet: FakeSpreadsheet = fromArrays({ [SHEET_NAME]: rows })
+  installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+  return spreadsheet.getSheetByName(SHEET_NAME)!
+}
+
+/** Raw grid rows below the header, as written on the sheet. */
+function dataRows(sheet: FakeSheet): unknown[][] {
+  const lastRow = sheet.getLastRow()
+  if (lastRow <= 1) return []
+  return sheet.getRange(2, 1, lastRow - 1, COLUMNS.length).getValues()
+}
+
+function idsOnSheet(sheet: FakeSheet): unknown[] {
+  return dataRows(sheet).map(row => row[0])
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  delete (globalThis as Record<string, unknown>).SpreadsheetApp
+  delete (globalThis as Record<string, unknown>).LockService
+})
+
+// ---------------------------------------------------------------------------
+// Interleaved concurrency
+// ---------------------------------------------------------------------------
+
+describe('SheetsAdapter concurrency (#128)', () => {
+  describe('update()', () => {
+    it('does not write to a stale row index when another execution deletes a row above', () => {
+      const sheet = setupSharedSheet([
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30],
+        [2, 'Bob', 25],
+        [3, 'Carol', 35]
+      ])
+      const lockState = installExclusiveLock()
+
+      const writer = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+      const deleter = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+
+      const other = concurrentExecution(lockState, () => {
+        deleter.delete(1)
+      })
+      interruptAfterIdScan(sheet, () => other.run())
+
+      writer.update(3, { name: 'Carol Updated' })
+      other.drain()
+
+      // Exactly two rows survive: id 2 untouched, id 3 updated in place.
+      expect(idsOnSheet(sheet)).toEqual([2, 3])
+      expect(dataRows(sheet)[1]).toEqual([3, 'Carol Updated', 35])
+    })
+  })
+
+  describe('delete()', () => {
+    it('does not delete the wrong row when another execution deletes a row above', () => {
+      const sheet = setupSharedSheet([
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30],
+        [2, 'Bob', 25],
+        [3, 'Carol', 35],
+        [4, 'Dave', 40]
+      ])
+      const lockState = installExclusiveLock()
+
+      const first = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+      const second = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+
+      const other = concurrentExecution(lockState, () => {
+        second.delete(1)
+      })
+      interruptAfterIdScan(sheet, () => other.run())
+
+      first.delete(3)
+      other.drain()
+
+      // Ids 1 and 3 were the deletion targets, so 2 and 4 must remain.
+      expect(idsOnSheet(sheet)).toEqual([2, 4])
+    })
+  })
+
+  describe('batchInsert() in client mode', () => {
+    it('does not overwrite rows written by a concurrent client-mode batch insert', () => {
+      const sheet = setupSharedSheet([['id', 'name', 'age']])
+      const lockState = installExclusiveLock()
+
+      const first = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+      const second = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+      const other = concurrentExecution(lockState, () => {
+        second.batchInsert([
+          { id: 'c', name: 'Carol', age: 35 },
+          { id: 'd', name: 'Dave', age: 40 }
+        ])
+      })
+      interruptAfterLastRow(sheet, () => other.run())
+
+      first.batchInsert([
+        { id: 'a', name: 'Alice', age: 30 },
+        { id: 'b', name: 'Bob', age: 25 }
+      ])
+      other.drain()
+
+      expect(idsOnSheet(sheet).sort()).toEqual(['a', 'b', 'c', 'd'])
+    })
+  })
+
+  describe('insert() in client mode', () => {
+    it('rejects an id a concurrent execution inserted first', () => {
+      const sheet = setupSharedSheet([['id', 'name', 'age']])
+      const lockState = installExclusiveLock()
+
+      const first = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+      const second = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+      second.insert({ id: 'dup', name: 'Winner', age: 1 })
+
+      expect(() => first.insert({ id: 'dup', name: 'Loser', age: 2 })).toThrow(DuplicateIdError)
+      expect(idsOnSheet(sheet)).toEqual(['dup'])
+      expect(lockState.acquisitions).toBeGreaterThan(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Lock coverage: acquire before the read, release after the write
+// ---------------------------------------------------------------------------
+
+describe('SheetsAdapter lock coverage (#128)', () => {
+  function setupCapturedLock(sheet: FakeSheet) {
+    const spreadsheet = new FakeSpreadsheet('TestSpreadsheet', [sheet])
+    installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+
+    const lockService = (globalThis as Record<string, unknown>).LockService as {
+      getScriptLock: () => { waitLock: (ms: number) => void; releaseLock: () => void }
+    }
+    const lock = lockService.getScriptLock()
+    vi.spyOn(lock, 'waitLock')
+    vi.spyOn(lock, 'releaseLock')
+    vi.spyOn(lockService, 'getScriptLock').mockReturnValue(lock)
+    return lock as unknown as {
+      waitLock: ReturnType<typeof vi.fn>
+      releaseLock: ReturnType<typeof vi.fn>
+    }
+  }
+
+  function order(spy: { mock: { invocationCallOrder: number[] } }): number {
+    return spy.mock.invocationCallOrder[0]
+  }
+
+  /**
+   * Spies `getRange` and every `setValues` it hands out, so writes can be
+   * ordered against lock acquisition/release.
+   */
+  function captureWrites(sheet: FakeSheet) {
+    const writes: ReturnType<typeof vi.fn>[] = []
+    const original = sheet.getRange.bind(sheet)
+    const getRange = vi
+      .spyOn(sheet, 'getRange')
+      .mockImplementation((row: number, col: number, numRows = 1, numCols = 1) => {
+        const range = original(row, col, numRows, numCols)
+        const write = vi.fn(range.setValues.bind(range))
+        range.setValues = write
+        writes.push(write)
+        return range
+      })
+
+    return {
+      getRange,
+      lastWrite: () => writes.filter(write => write.mock.calls.length > 0).pop()
+    }
+  }
+
+  it('update() holds the lock across the row scan and the write', () => {
+    const sheet = fromArrays({
+      [SHEET_NAME]: [
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30]
+      ]
+    }).getSheetByName(SHEET_NAME)!
+    const lock = setupCapturedLock(sheet)
+    const { getRange, lastWrite } = captureWrites(sheet)
+
+    new SheetsAdapter<TestRow>(BASE_OPTIONS).update(1, { name: 'Updated' })
+
+    const write = lastWrite()
+    expect(write).toBeDefined()
+    expect(order(lock.waitLock)).toBeLessThan(order(getRange))
+    expect(order(lock.releaseLock)).toBeGreaterThan(order(write!))
+  })
+
+  it('delete() holds the lock across the row scan and deleteRow', () => {
+    const sheet = fromArrays({
+      [SHEET_NAME]: [
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30]
+      ]
+    }).getSheetByName(SHEET_NAME)!
+    const lock = setupCapturedLock(sheet)
+    vi.spyOn(sheet, 'deleteRow')
+
+    new SheetsAdapter<TestRow>(BASE_OPTIONS).delete(1)
+
+    const deleteRow = sheet.deleteRow as unknown as { mock: { invocationCallOrder: number[] } }
+    expect(order(lock.waitLock)).toBeLessThan(order(deleteRow))
+    expect(order(lock.releaseLock)).toBeGreaterThan(order(deleteRow))
+  })
+
+  it('client-mode insert() holds the lock across the uniqueness check and appendRow', () => {
+    const sheet = fromArrays({ [SHEET_NAME]: [['id', 'name', 'age']] }).getSheetByName(SHEET_NAME)!
+    const lock = setupCapturedLock(sheet)
+    vi.spyOn(sheet, 'appendRow')
+
+    new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+      .insert({ id: 'a', name: 'Alice', age: 30 })
+
+    const appendRow = sheet.appendRow as unknown as { mock: { invocationCallOrder: number[] } }
+    expect(order(lock.waitLock)).toBeLessThan(order(appendRow))
+    expect(order(lock.releaseLock)).toBeGreaterThan(order(appendRow))
+  })
+
+  it('client-mode batchInsert() holds the lock across the batch write', () => {
+    const sheet = fromArrays({ [SHEET_NAME]: [['id', 'name', 'age']] }).getSheetByName(SHEET_NAME)!
+    const lock = setupCapturedLock(sheet)
+    const { lastWrite } = captureWrites(sheet)
+
+    new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' }).batchInsert([
+      { id: 'a', name: 'Alice', age: 30 },
+      { id: 'b', name: 'Bob', age: 25 }
+    ])
+
+    const write = lastWrite()
+    expect(write).toBeDefined()
+    expect(order(lock.waitLock)).toBeLessThan(order(write!))
+    expect(order(lock.releaseLock)).toBeGreaterThan(order(write!))
+  })
+
+  it('keeps working when LockService is unavailable (Node)', () => {
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      [1, 'Alice', 30]
+    ])
+    delete (globalThis as Record<string, unknown>).LockService
+
+    const adapter = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+    expect(adapter.update(1, { name: 'Updated' })?.name).toBe('Updated')
+    expect(adapter.delete(1)).toBe(true)
+
+    const clientAdapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+    expect(clientAdapter.insert({ id: 'x', name: 'X', age: 1 }).id).toBe('x')
+    expect(clientAdapter.batchInsert([{ id: 'y', name: 'Y', age: 2 }])).toHaveLength(1)
+    expect(idsOnSheet(sheet)).toEqual(['x', 'y'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Client-mode ID uniqueness
+// ---------------------------------------------------------------------------
+
+describe('SheetsAdapter client-mode ID uniqueness (#128)', () => {
+  it('insert() throws DuplicateIdError for an id already on the sheet', () => {
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      ['a', 'Alice', 30]
+    ])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    expect(() => adapter.insert({ id: 'a', name: 'Clone', age: 1 })).toThrow(DuplicateIdError)
+    expect(idsOnSheet(sheet)).toEqual(['a'])
+  })
+
+  it('matches ids across string/number representations', () => {
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      [7, 'Alice', 30]
+    ])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    expect(() => adapter.insert({ id: '7', name: 'Clone', age: 1 })).toThrow(DuplicateIdError)
+    expect(idsOnSheet(sheet)).toEqual([7])
+  })
+
+  it('carries the offending id and a stable error code', () => {
+    setupSharedSheet([
+      ['id', 'name', 'age'],
+      ['a', 'Alice', 30]
+    ])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    try {
+      adapter.insert({ id: 'a', name: 'Clone', age: 1 })
+      expect.unreachable('insert should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateIdError)
+      expect((error as DuplicateIdError).id).toBe('a')
+      expect((error as DuplicateIdError).code).toBe('DUPLICATE_ID')
+    }
+  })
+
+  it('batchInsert() throws before writing anything when an id already exists', () => {
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      ['a', 'Alice', 30]
+    ])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'b', name: 'Bob', age: 25 },
+        { id: 'a', name: 'Clone', age: 1 }
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(idsOnSheet(sheet)).toEqual(['a'])
+  })
+
+  it('batchInsert() rejects ids duplicated within the same batch', () => {
+    const sheet = setupSharedSheet([['id', 'name', 'age']])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'a', name: 'Alice', age: 30 },
+        { id: 'a', name: 'Clone', age: 1 }
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(idsOnSheet(sheet)).toEqual([])
+  })
+
+  it('still accepts distinct ids', () => {
+    const sheet = setupSharedSheet([['id', 'name', 'age']])
+    const adapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })
+
+    adapter.insert({ id: 'a', name: 'Alice', age: 30 })
+    adapter.batchInsert([
+      { id: 'b', name: 'Bob', age: 25 },
+      { id: 'c', name: 'Carol', age: 35 }
+    ])
+
+    expect(idsOnSheet(sheet)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MigrationRunner locking
+// ---------------------------------------------------------------------------
+
+describe('MigrationRunner locking (#128)', () => {
+  function migrationsStore(): MockAdapter<MigrationRecord> {
+    return new MockAdapter<MigrationRecord>()
+  }
+
+  function runnerWith(
+    store: DataStore<MigrationRecord>,
+    migrations: Migration[],
+    resolver: StoreResolver = <T extends Row>() =>
+      new MockAdapter<T & RowWithId>() as unknown as DataStore<T>
+  ) {
+    return createMigrationRunner({ migrationsStore: store, storeResolver: resolver, migrations })
+  }
+
+  /** Installs a lock whose acquisition runs `onAcquire` (a concurrent execution finishing). */
+  function installLockWithSideEffect(onAcquire: () => void) {
+    const lock = {
+      waitLock: vi.fn(onAcquire),
+      tryLock: vi.fn(() => true),
+      releaseLock: vi.fn(),
+      hasLock: vi.fn(() => true)
+    }
+    ;(globalThis as Record<string, unknown>).LockService = { getScriptLock: () => lock }
+    return lock
+  }
+
+  it('migrate() re-reads pending migrations after acquiring the lock', async () => {
+    const store = migrationsStore()
+    const up = vi.fn()
+    const migrations: Migration[] = [
+      { version: 1, name: 'first', up, down: vi.fn() }
+    ]
+    const runner = runnerWith(store, migrations)
+
+    // Another execution applied version 1 while this one waited for the lock.
+    installLockWithSideEffect(() => {
+      store.insert({ version: 1, name: 'first', appliedAt: new Date().toISOString() })
+    })
+
+    const result = await runner.migrate()
+
+    expect(up).not.toHaveBeenCalled()
+    expect(result.applied).toEqual([])
+    expect(store.findAll()).toHaveLength(1)
+  })
+
+  it('migrate() holds the lock across the whole run', async () => {
+    const store = migrationsStore()
+    const insertSpy = vi.spyOn(store, 'insert')
+    const lock = installLockWithSideEffect(() => {})
+    const runner = runnerWith(store, [
+      { version: 1, name: 'first', up: vi.fn(), down: vi.fn() }
+    ])
+
+    await runner.migrate()
+
+    expect(lock.waitLock).toHaveBeenCalled()
+    expect(lock.releaseLock).toHaveBeenCalled()
+    const acquire = lock.waitLock.mock.invocationCallOrder[0]
+    const write = insertSpy.mock.invocationCallOrder[0]
+    const release = lock.releaseLock.mock.invocationCallOrder[0]
+    expect(acquire).toBeLessThan(write)
+    expect(release).toBeGreaterThan(write)
+  })
+
+  it('rollback() re-reads applied migrations after acquiring the lock', async () => {
+    const store = migrationsStore()
+    store.insert({ version: 1, name: 'first', appliedAt: new Date().toISOString() })
+    const down = vi.fn()
+    const runner = runnerWith(store, [{ version: 1, name: 'first', up: vi.fn(), down }])
+
+    // Another execution rolled the same migration back while this one waited.
+    installLockWithSideEffect(() => {
+      for (const record of store.findAll()) store.delete(record.id)
+    })
+
+    await expect(runner.rollback()).rejects.toBeInstanceOf(NoMigrationsToRollbackError)
+    expect(down).not.toHaveBeenCalled()
+  })
+
+  it('does not deadlock when a migration writes through a locking adapter', async () => {
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      [1, 'Alice', '']
+    ])
+    // Exclusive lock: a second, non-reentrant acquisition would throw.
+    installExclusiveLock()
+
+    const users = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+    const resolver: StoreResolver = <T extends Row>() => users as unknown as DataStore<T>
+    const runner = runnerWith(
+      migrationsStore(),
+      [
+        {
+          version: 1,
+          name: 'default-age',
+          up: schema => schema.addColumn(SHEET_NAME, 'age', { default: 99 }),
+          down: schema => schema.removeColumn(SHEET_NAME, 'age')
+        }
+      ],
+      resolver
+    )
+
+    await expect(runner.migrate()).resolves.toMatchObject({ currentVersion: 1 })
+    users.clearCache()
+    expect(dataRows(sheet)[0]).toEqual([1, 'Alice', 99])
+  })
+
+  it('migrate() still runs when LockService is unavailable (Node)', async () => {
+    delete (globalThis as Record<string, unknown>).LockService
+    const store = migrationsStore()
+    const runner = runnerWith(store, [
+      { version: 1, name: 'first', up: vi.fn(), down: vi.fn() }
+    ])
+
+    const result = await runner.migrate()
+    expect(result.currentVersion).toBe(1)
+  })
+})

--- a/website/docs/error-handling.md
+++ b/website/docs/error-handling.md
@@ -9,6 +9,7 @@ Error
  └── SheetsQueryError (base)
       ├── TableNotFoundError
       ├── RowNotFoundError
+      ├── DuplicateIdError
       ├── NoResultsError
       ├── MissingStoreError
       ├── ValidationError
@@ -57,6 +58,26 @@ try {
   if (e instanceof RowNotFoundError) {
     console.log(e.code)      // 'ROW_NOT_FOUND'
     console.log(e.id)        // 999
+    console.log(e.tableName) // 'users'
+  }
+}
+```
+
+### DuplicateIdError
+
+Thrown by `insert()`/`batchInsert()` on a `idMode: 'client'` store when the
+supplied id already exists (including a duplicate inside the same batch). The
+check runs under the write lock, so a concurrent execution that inserts the
+same id first wins and this one throws instead of writing a row that no id
+lookup could ever reach.
+
+```ts
+try {
+  db.from('users').insert({ id: 'u-1', name: 'Alice' })
+} catch (e) {
+  if (e instanceof DuplicateIdError) {
+    console.log(e.code)      // 'DUPLICATE_ID'
+    console.log(e.id)        // 'u-1'
     console.log(e.tableName) // 'users'
   }
 }


### PR DESCRIPTION
## Summary

`withLock` only covered auto-mode insert/batchInsert; every other read-then-write path raced concurrent GAS executions: `update`/`delete` could hit a stale row index and modify the wrong record, client-mode `batchInsert` could overwrite another writer's rows, and `migrate()`/`rollback()` ran unlocked.

The lock is extracted into `core/script-lock.ts` (`withScriptLock`/`withScriptLockAsync`) and made **re-entrant** via an execution-scoped depth counter — required so a migration holding the lock can write through the adapter without deadlocking itself. `update`/`delete` now run find-index + write inside one lock and `update` re-verifies the ID cell before overwriting; client-mode insert/batchInsert check ID uniqueness and compute the write position under the lock, throwing the new typed `DuplicateIdError` before writing anything; `migrate`/`rollback`/`rollbackAll` hold the lock and re-read pending/applied lists after acquiring it. Node graceful degradation (no `LockService`) is preserved.

New `concurrent-write-locking.test.ts` drives two adapter instances over one shared `FakeSheet` with an exclusive-lock fake; 16 of its 20 tests fail on `origin/dev` code and all pass after.

**Behavior change**: client-mode insert of an already-present ID now throws `DuplicateIdError` instead of silently appending an unreachable duplicate row.

## Related Issues

Closes #128

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (898 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_