### PR TITLE
fix(client): unify runtime schema and honor columnTypes in the local-first path

### DIFF
--- a/packages/cli/src/generator/client-package-generator.ts
+++ b/packages/cli/src/generator/client-package-generator.ts
@@ -142,7 +142,45 @@ function generateTableSchema(table: TableAST): string {
     parts.push(`columnTypes: { ${columnTypeEntries.join(', ')} }`)
   }
 
+  const indexEntries = buildIndexEntries(table)
+  if (indexEntries.length > 0) {
+    parts.push(`indexes: [${indexEntries.join(', ')}]`)
+  }
+
   return `{ ${parts.join(', ')} }`
+}
+
+/**
+ * Build the runtime index definitions for a table from its block attributes.
+ *
+ * `@@index` becomes a plain index and `@@unique` a unique one. Duplicate field
+ * combinations collapse, with unique winning over non-unique.
+ */
+function buildIndexEntries(table: TableAST): string[] {
+  const byKey = new Map<string, { fields: string[]; unique: boolean }>()
+
+  const add = (fields: string[], unique: boolean): void => {
+    if (fields.length === 0) return
+    const key = fields.join('|')
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.unique = existing.unique || unique
+      return
+    }
+    byKey.set(key, { fields: [...fields], unique })
+  }
+
+  for (const attr of table.blockAttributes) {
+    if (attr.name === 'index') add(attr.fields, false)
+    else if (attr.name === 'unique') add(attr.fields, true)
+  }
+
+  return Array.from(byKey.values()).map(({ fields, unique }) => {
+    const fieldList = fields.map(f => `'${escapeStringLiteral(f)}'`).join(', ')
+    return unique
+      ? `{ fields: [${fieldList}], unique: true }`
+      : `{ fields: [${fieldList}] }`
+  })
 }
 
 /**

--- a/packages/cli/tests/unit/client-package-generator.test.ts
+++ b/packages/cli/tests/unit/client-package-generator.test.ts
@@ -158,6 +158,61 @@ describe('generateClientCode', () => {
 
     expect(result).not.toContain('columnTypes:')
   })
+
+  it('emits indexes from @@index and @@unique block attributes (#135)', () => {
+    const schemaWithIndexes: SchemaAST = {
+      enums: {},
+      tables: {
+        Post: {
+          name: 'Post',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+            { name: 'slug', type: 'string', optional: false, attributes: [] },
+            { name: 'authorId', type: 'number', optional: false, attributes: [] },
+            { name: 'status', type: 'string', optional: false, attributes: [] },
+          ],
+          blockAttributes: [
+            { name: 'index', fields: ['authorId'] },
+            { name: 'index', fields: ['authorId', 'status'] },
+            { name: 'unique', fields: ['slug'] },
+          ],
+        },
+      },
+    }
+    const result = generateClientCode(schemaWithIndexes)
+
+    expect(result).toContain(
+      "indexes: [{ fields: ['authorId'] }, { fields: ['authorId', 'status'] }, { fields: ['slug'], unique: true }]"
+    )
+  })
+
+  it('collapses a field combination declared both @@index and @@unique', () => {
+    const schemaWithDuplicate: SchemaAST = {
+      enums: {},
+      tables: {
+        Post: {
+          name: 'Post',
+          fields: [
+            { name: 'id', type: 'number', optional: false, attributes: [{ name: 'id', args: [] }] },
+            { name: 'slug', type: 'string', optional: false, attributes: [] },
+          ],
+          blockAttributes: [
+            { name: 'index', fields: ['slug'] },
+            { name: 'unique', fields: ['slug'] },
+          ],
+        },
+      },
+    }
+    const result = generateClientCode(schemaWithDuplicate)
+
+    expect(result).toContain("indexes: [{ fields: ['slug'], unique: true }]")
+  })
+
+  it('omits indexes when the table declares none', () => {
+    const result = generateClientCode(simpleSchema)
+
+    expect(result).not.toContain('indexes:')
+  })
 })
 
 describe('generateClientIndex', () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -77,6 +77,10 @@ export type {
   DataStore,
   SheetsDB,
   TableHandle,
+  RuntimeSchema,
+  RuntimeTableSchema,
+  ColumnType,
+  IndexDefinition,
 } from "./runtime.js";
 
 // =============================================================================

--- a/packages/client/src/local/create-client-db.ts
+++ b/packages/client/src/local/create-client-db.ts
@@ -11,17 +11,17 @@ import { SyncEngine } from './sync-engine.js'
 import type { SyncEngineOptions } from './sync-engine.js'
 import type { SyncTransport, ConflictStrategy } from './sync-transport.js'
 import type { MutationStorage } from './mutation-queue.js'
-import type { IndexDefinition } from '@gsquery/core'
+import type { RuntimeSchema } from '@gsquery/core'
 import { composeName } from './naming.js'
 
-/** Schema definition for createClientDB */
-export interface ClientDBSchema {
-  tables: Record<string, {
-    columns: readonly string[]
-    sheetName?: string
-    indexes?: IndexDefinition[]
-  }>
-}
+/**
+ * Schema definition for createClientDB.
+ *
+ * Alias of the shared {@link RuntimeSchema} — the same shape a generated
+ * client exports, so `createClientDB({ schema })` accepts a generated schema
+ * and honors its `columnTypes` instead of silently discarding them (#135).
+ */
+export type ClientDBSchema = RuntimeSchema
 
 export interface CreateClientDBOptions<Tables extends Record<string, RowWithId>> {
   schema: ClientDBSchema
@@ -88,6 +88,7 @@ export async function createClientDB<Tables extends Record<string, RowWithId>>(
     const adapterOpts: LocalAdapterOptions = {
       tableName,
       indexes: tableSchema.indexes,
+      columnTypes: tableSchema.columnTypes,
       idMode: 'client',
       mutationStorage,
       disableIDB: disableIDB ?? false,

--- a/packages/client/src/local/local-adapter.ts
+++ b/packages/client/src/local/local-adapter.ts
@@ -18,8 +18,8 @@ import type {
   IdMode,
   UpdateData,
 } from '@gsquery/core'
-import { IndexStore, evaluateCondition, compareRows } from '@gsquery/core'
-import type { IndexDefinition } from '@gsquery/core'
+import { IndexStore, evaluateCondition, compareRows, deserializeRow } from '@gsquery/core'
+import type { IndexDefinition, ColumnType } from '@gsquery/core'
 import { MutationQueue } from './mutation-queue.js'
 import type { MutationStorage } from './mutation-queue.js'
 import { composeName } from './naming.js'
@@ -90,6 +90,11 @@ export interface LocalAdapterOptions<T extends RowWithId = RowWithId> {
   tableName: string
   initialData?: T[]
   indexes?: IndexDefinition[]
+  /**
+   * Column types for schema-driven deserialization of rows arriving from the
+   * server (see replaceAll). Without it, pulled values are stored verbatim.
+   */
+  columnTypes?: Record<string, ColumnType>
   idMode?: IdMode
   /** Custom storage for MutationQueue (defaults to localStorage) */
   mutationStorage?: MutationStorage
@@ -107,6 +112,7 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
   private idIndex: Map<string | number, number> = new Map()
   private indexStore: IndexStore<T>
   private idMode: IdMode
+  private readonly columnTypes: Record<string, ColumnType> | undefined
 
   readonly tableName: string
   readonly queue: MutationQueue<T>
@@ -122,6 +128,7 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
     this.idMode = options.idMode ?? 'client'
     this.idbEnabled = !options.disableIDB && typeof indexedDB !== 'undefined'
     this.indexStore = new IndexStore<T>(options.indexes ?? [])
+    this.columnTypes = options.columnTypes
     this.namespace = options.namespace
 
     // Accept pre-opened shared IDB handle
@@ -375,9 +382,20 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
 
   // ── Additional methods for SyncEngine ──────────────────────────────
 
-  /** Replace all data (called by SyncEngine after pull) */
+  /**
+   * Replace all data (called by SyncEngine after pull).
+   *
+   * Rows coming off the wire carry transport representations (a datetime is an
+   * ISO string, a string[] is JSON text), so they are run through the same
+   * schema-driven conversion the server path applies — otherwise the local
+   * values contradict the generated model types (#135). The conversion is
+   * idempotent, so already-typed rows (locally created, or replayed from a
+   * conflict resolution) pass through untouched.
+   */
   replaceAll(rows: T[]): void {
-    this.data = [...rows]
+    this.data = this.columnTypes
+      ? rows.map(row => deserializeRow(row, this.columnTypes))
+      : [...rows]
     this.rebuildIndex()
     this.schedulePersist()
   }

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -10,7 +10,8 @@ import type {
   DataStore,
   SheetsDBConfig,
   IdMode,
-  ColumnType
+  RuntimeSchema,
+  RuntimeTableSchema
 } from '@gsquery/core'
 import { 
   createSheetsDB, 
@@ -42,15 +43,12 @@ export interface ClientOptions {
 
 /**
  * Generated schema interface (provided by generate command)
+ *
+ * Alias of the shared {@link RuntimeSchema}: the exact shape `createClientDB`
+ * consumes, so a generated schema drives both the server and the local-first
+ * path with the same `columnTypes` and `indexes` (#135).
  */
-export interface GeneratedSchema {
-  tables: Record<string, {
-    columns: readonly string[]
-    sheetName?: string
-    /** Column types for schema-driven (de)serialization (e.g. datetime -> 'date'). */
-    columnTypes?: Record<string, ColumnType>
-  }>
-}
+export type GeneratedSchema = RuntimeSchema
 
 /**
  * Client factory result type
@@ -85,14 +83,14 @@ export function isNodeEnvironment(): boolean {
  */
 export function createStore<T extends RowWithId>(
   tableName: string,
-  tableSchema: { columns: readonly string[]; sheetName?: string; columnTypes?: Record<string, ColumnType> },
+  tableSchema: RuntimeTableSchema,
   options: ClientOptions
 ): DataStore<T> {
   const idMode = options.idMode || 'auto'
 
   // Mock mode always uses MockAdapter
   if (options.mock) {
-    return new MockAdapter<T>({ idMode })
+    return new MockAdapter<T>({ idMode, indexes: tableSchema.indexes })
   }
 
   // If spreadsheetId is provided, use SheetsAdapter
@@ -238,4 +236,8 @@ export type {
   DataStore,
   SheetsDB,
   TableHandle,
+  RuntimeSchema,
+  RuntimeTableSchema,
 }
+
+export type { ColumnType, IndexDefinition } from '@gsquery/core'

--- a/packages/client/tests/unit/local/column-types.test.ts
+++ b/packages/client/tests/unit/local/column-types.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Local-first columnTypes deserialization (#135)
+ *
+ * The generated schema declares `datetime` columns as ColumnType 'date'. The
+ * server path (SheetsAdapter) turns those into real Dates; the local-first path
+ * must do the same for rows arriving from a pull, otherwise the model types
+ * claim `Date` while the runtime value is an ISO string.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createClientDB } from '../../../src/local/create-client-db.js'
+import type { ClientDBSchema } from '../../../src/local/create-client-db.js'
+import type { GeneratedSchema } from '../../../src/runtime.js'
+import { MockTransport } from '../../../src/transports/mock-transport.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+
+interface Event {
+  id: string
+  title: string
+  startsAt: Date
+  tags: string[]
+}
+
+type Tables = {
+  Event: Event
+}
+
+const schema = {
+  tables: {
+    Event: {
+      columns: ['id', 'title', 'startsAt', 'tags'] as const,
+      columnTypes: { startsAt: 'date', tags: 'string[]' },
+      indexes: [{ fields: ['title'] }],
+    },
+  },
+} satisfies ClientDBSchema
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+describe('createClientDB columnTypes', () => {
+  let transport: MockTransport
+
+  beforeEach(() => {
+    transport = new MockTransport()
+  })
+
+  it('deserializes pulled date columns into Date instances', async () => {
+    transport.setServerData('Event', [
+      { id: 'e1', title: 'Launch', startsAt: '2024-03-01T10:00:00.000Z', tags: '["a","b"]' },
+    ])
+
+    const { db, sync } = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+    })
+
+    await sync.pull()
+
+    const event = db.from('Event').findById('e1')
+    expect(event.startsAt).toBeInstanceOf(Date)
+    expect((event.startsAt as Date).toISOString()).toBe('2024-03-01T10:00:00.000Z')
+    expect(event.tags).toEqual(['a', 'b'])
+  })
+
+  it('keeps pending local mutations typed after a pull merge', async () => {
+    transport.setServerData('Event', [
+      { id: 'e1', title: 'Launch', startsAt: '2024-03-01T10:00:00.000Z', tags: '[]' },
+    ])
+
+    const { db, sync } = await createClientDB<Tables>({
+      schema,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+    })
+
+    db.from('Event').create({
+      id: 'e2',
+      title: 'Local',
+      startsAt: new Date('2024-05-05T00:00:00.000Z'),
+      tags: [],
+    })
+
+    await sync.pull()
+
+    expect(db.from('Event').findById('e1').startsAt).toBeInstanceOf(Date)
+    // Locally created rows already hold a Date and must not be mangled
+    expect(db.from('Event').findById('e2').startsAt).toBeInstanceOf(Date)
+  })
+
+  it('accepts a schema without columnTypes (backward compatible)', async () => {
+    const plainSchema: ClientDBSchema = {
+      tables: {
+        Event: { columns: ['id', 'title', 'startsAt', 'tags'] },
+      },
+    }
+
+    transport.setServerData('Event', [
+      { id: 'e1', title: 'Launch', startsAt: '2024-03-01T10:00:00.000Z', tags: '[]' },
+    ])
+
+    const { db, sync } = await createClientDB<Tables>({
+      schema: plainSchema,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+    })
+
+    await sync.pull()
+
+    // No columnTypes -> untouched raw values, exactly as before
+    expect(db.from('Event').findById('e1').startsAt).toBe('2024-03-01T10:00:00.000Z')
+  })
+
+  it('accepts a generated schema (GeneratedSchema is the same shape)', async () => {
+    const generated: GeneratedSchema = {
+      tables: {
+        Event: {
+          columns: ['id', 'title', 'startsAt', 'tags'],
+          columnTypes: { startsAt: 'date' },
+          indexes: [{ fields: ['title'] }],
+        },
+      },
+    }
+
+    transport.setServerData('Event', [
+      { id: 'e1', title: 'Launch', startsAt: '2024-03-01T10:00:00.000Z', tags: '[]' },
+    ])
+
+    const { db, sync } = await createClientDB<Tables>({
+      schema: generated,
+      transport,
+      disableIDB: true,
+      mutationStorage: createMemoryStorage(),
+    })
+
+    await sync.pull()
+
+    expect(db.from('Event').findById('e1').startsAt).toBeInstanceOf(Date)
+  })
+})

--- a/packages/core/src/core/column-conversion.ts
+++ b/packages/core/src/core/column-conversion.ts
@@ -1,0 +1,96 @@
+/**
+ * Column type conversion helpers
+ *
+ * Shared, adapter-independent implementation of the schema-driven
+ * deserialization that turns raw transport/sheet values into the runtime types
+ * the generated models declare (`datetime` -> `Date`, `string[]` -> array, ...).
+ *
+ * Used by the local-first client (#135) so that rows arriving from a sync pull
+ * get the same treatment as rows read through SheetsAdapter.
+ *
+ * TODO: SheetsAdapter still carries a private copy of this logic
+ * (`deserializeByType`). It should delegate here once the in-flight
+ * serialization work on that file lands, so there is exactly one
+ * implementation.
+ */
+import type { ColumnType } from '../adapters/sheets-adapter'
+
+/**
+ * Convert a single raw value to its runtime representation for `colType`.
+ *
+ * Idempotent: values that are already deserialized (a `Date` for a 'date'
+ * column, an array for a 'string[]' column) are returned unchanged.
+ */
+export function deserializeColumnValue(value: unknown, colType: ColumnType): unknown {
+  if (value === '' || value === null || value === undefined) {
+    // Return appropriate empty value for type
+    if (colType === 'string[]' || colType === 'number[]') return []
+    if (colType === 'object' || colType === 'json') return null
+    if (colType === 'boolean') return false
+    if (colType === 'number') return 0
+    return value
+  }
+
+  switch (colType) {
+    case 'string[]':
+    case 'number[]':
+    case 'object':
+    case 'json':
+      if (typeof value === 'string') {
+        try {
+          return JSON.parse(value)
+        } catch {
+          return colType.endsWith('[]') ? [] : null
+        }
+      }
+      return value
+    case 'boolean':
+      if (typeof value === 'string') {
+        return value.toLowerCase() === 'true'
+      }
+      return Boolean(value)
+    case 'number':
+      return Number(value)
+    case 'date': {
+      // Date columns deserialize to a real Date so the runtime value matches
+      // the generated `Date` type (#97).
+      if (value instanceof Date) return value
+      if (typeof value === 'string' || typeof value === 'number') {
+        const parsed = new Date(value)
+        if (!isNaN(parsed.getTime())) return parsed
+      }
+      return value
+    }
+    default:
+      return value
+  }
+}
+
+/**
+ * Apply {@link deserializeColumnValue} to every declared column of a row.
+ *
+ * Returns the row untouched when no column types are declared, so callers
+ * without a typed schema keep their existing behavior. Columns absent from the
+ * row are left absent rather than being filled with empty values.
+ */
+export function deserializeRow<T extends object>(
+  row: T,
+  columnTypes: Record<string, ColumnType> | undefined
+): T {
+  if (!columnTypes) return row
+
+  const entries = Object.keys(columnTypes)
+  if (entries.length === 0) return row
+
+  let converted: Record<string, unknown> | undefined
+  for (const col of entries) {
+    if (!(col in row)) continue
+    const raw = (row as Record<string, unknown>)[col]
+    const next = deserializeColumnValue(raw, columnTypes[col])
+    if (next === raw) continue
+    if (!converted) converted = { ...(row as Record<string, unknown>) }
+    converted[col] = next
+  }
+
+  return (converted as T | undefined) ?? row
+}

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -1,6 +1,8 @@
 /**
  * Core types for gas-sheets-query
  */
+import type { ColumnType } from '../adapters/sheets-adapter'
+import type { IndexDefinition } from './index-store'
 
 /**
  * ID generation mode for insert operations
@@ -196,6 +198,38 @@ export type InferTablesFromConfig<
   Tables extends Record<string, TableSchemaTyped>
 > = {
   [K in keyof Tables]: InferRowFromSchema<Tables[K]>
+}
+
+// ============================================================================
+// Runtime schema (shared by generated clients and the local-first client)
+// ============================================================================
+
+/**
+ * Table description consumed at runtime by every client entry point:
+ * `createClientFactory` (server path) and `createClientDB` (local-first path).
+ *
+ * Both used to declare their own near-identical shape — one with
+ * `columnTypes`, the other with `indexes` — which made them silently
+ * cross-assignable and dropped date deserialization on the local-first path
+ * (#135). One type carries both, and every consumer honors both.
+ */
+export interface RuntimeTableSchema {
+  /** Column names in order (first column should be 'id') */
+  columns: readonly string[]
+  /** Sheet name (defaults to the table name if not specified) */
+  sheetName?: string
+  /**
+   * Column types for schema-driven (de)serialization (e.g. datetime -> 'date').
+   * Optional: without it, values are passed through as stored.
+   */
+  columnTypes?: Record<string, ColumnType>
+  /** Index definitions used to accelerate equality lookups */
+  indexes?: IndexDefinition[]
+}
+
+/** Runtime schema: the table map a generated client exports. */
+export interface RuntimeSchema {
+  tables: Record<string, RuntimeTableSchema>
 }
 
 // ============================================================================

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export type {
   AddColumnOptions,
   TableSchema,
   SheetsDBConfig,
+  RuntimeTableSchema,
+  RuntimeSchema,
   // Schema-based type inference
   TypeSample,
   TableSchemaTyped,
@@ -48,6 +50,9 @@ export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter
 
 // Query utilities
 export { evaluateCondition, compareRows } from './core/query-utils'
+
+// Column type conversion
+export { deserializeColumnValue, deserializeRow } from './core/column-conversion'
 
 // Index Store
 export { IndexStore, createIndexKey, serializeValues } from './core/index-store'

--- a/packages/core/tests/unit/column-conversion.test.ts
+++ b/packages/core/tests/unit/column-conversion.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Column conversion helpers (#135)
+ */
+import { describe, it, expect } from 'vitest'
+import { deserializeColumnValue, deserializeRow } from '../../src/index'
+import type { ColumnType } from '../../src/index'
+
+describe('deserializeColumnValue', () => {
+  it('parses ISO strings into Date for date columns', () => {
+    const value = deserializeColumnValue('2024-03-01T10:00:00.000Z', 'date')
+    expect(value).toBeInstanceOf(Date)
+    expect((value as Date).toISOString()).toBe('2024-03-01T10:00:00.000Z')
+  })
+
+  it('passes an existing Date through unchanged (idempotent)', () => {
+    const date = new Date('2024-03-01T10:00:00.000Z')
+    expect(deserializeColumnValue(date, 'date')).toBe(date)
+  })
+
+  it('leaves an unparseable date value as-is', () => {
+    expect(deserializeColumnValue('not-a-date', 'date')).toBe('not-a-date')
+  })
+
+  it('parses JSON for array and object columns', () => {
+    expect(deserializeColumnValue('["a","b"]', 'string[]')).toEqual(['a', 'b'])
+    expect(deserializeColumnValue('[1,2]', 'number[]')).toEqual([1, 2])
+    expect(deserializeColumnValue('{"k":1}', 'object')).toEqual({ k: 1 })
+  })
+
+  it('returns type-appropriate empty values for blank cells', () => {
+    expect(deserializeColumnValue('', 'string[]')).toEqual([])
+    expect(deserializeColumnValue(null, 'object')).toBeNull()
+    expect(deserializeColumnValue(undefined, 'boolean')).toBe(false)
+    expect(deserializeColumnValue('', 'number')).toBe(0)
+  })
+
+  it('coerces boolean and number columns', () => {
+    expect(deserializeColumnValue('TRUE', 'boolean')).toBe(true)
+    expect(deserializeColumnValue('false', 'boolean')).toBe(false)
+    expect(deserializeColumnValue('42', 'number')).toBe(42)
+  })
+})
+
+describe('deserializeRow', () => {
+  const columnTypes: Record<string, ColumnType> = {
+    startsAt: 'date',
+    tags: 'string[]',
+  }
+
+  it('converts every declared column', () => {
+    const row = deserializeRow(
+      { id: 'e1', title: 'Launch', startsAt: '2024-03-01T10:00:00.000Z', tags: '["a"]' },
+      columnTypes
+    )
+
+    expect(row.startsAt).toBeInstanceOf(Date)
+    expect(row.tags).toEqual(['a'])
+    expect(row.title).toBe('Launch')
+  })
+
+  it('returns the same object when no column types are declared', () => {
+    const row = { id: 'e1', startsAt: '2024-03-01T10:00:00.000Z' }
+    expect(deserializeRow(row, undefined)).toBe(row)
+    expect(deserializeRow(row, {})).toBe(row)
+  })
+
+  it('returns the same object when nothing needed converting', () => {
+    const row = { id: 'e1', startsAt: new Date(0), tags: ['a'] }
+    expect(deserializeRow(row, columnTypes)).toBe(row)
+  })
+
+  it('does not invent columns absent from the row', () => {
+    const row = deserializeRow({ id: 'e1' }, columnTypes)
+    expect('tags' in row).toBe(false)
+    expect('startsAt' in row).toBe(false)
+  })
+
+  it('does not mutate the input row', () => {
+    const row = { id: 'e1', startsAt: '2024-03-01T10:00:00.000Z' }
+    const converted = deserializeRow(row, columnTypes)
+    expect(row.startsAt).toBe('2024-03-01T10:00:00.000Z')
+    expect(converted).not.toBe(row)
+  })
+})


### PR DESCRIPTION
## Summary

`ClientDBSchema` (indexes, no `columnTypes`) and `GeneratedSchema` (`columnTypes`, no indexes) had diverged while remaining cross-assignable: passing a generated schema to `createClientDB` type-checked but silently discarded date deserialization, so pulled rows carried ISO strings where the generated types promised `Date`.

Both are now aliases of a shared `RuntimeTableSchema`/`RuntimeSchema` in core `types.ts`. Conversion lives in a new additive core module `column-conversion.ts` (`deserializeColumnValue`/`deserializeRow`) applied in `LocalAdapter.replaceAll()` — the single choke point for all server-originated writes (pull, pending-mutation merge, conflict resolution). Idempotent and identity-preserving, so plain schemas without `columnTypes` behave exactly as before. The CLI client generator now emits `indexes` from `@@index`/`@@unique`.

Note for reviewers: the deserialize logic is intentionally a small duplication of `SheetsAdapter.deserializeByType` to avoid colliding with the formula-injection branch editing that file; a TODO in `column-conversion.ts` marks the delegate-and-dedupe cleanup once both are merged.

## Related Issues

Closes #135

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (896 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_