### PR TITLE
fix(client): durable conflict resolution, per-table sync isolation, backoff and dead-lettering

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -27,6 +27,7 @@ export {
   MutationQueue,
   LocalAdapter,
   SyncEngine,
+  SyncError,
   createClientDB,
 } from "./local/index.js";
 
@@ -35,10 +36,12 @@ export type {
   MutationStorage,
   LocalAdapterOptions,
   SyncEngineOptions,
+  TableSyncError,
   CreateClientDBOptions,
   ClientDBResult,
   ClientDBSchema,
   SyncTransport,
+  SyncPushResult,
   Mutation,
   MutationType,
   MergedMutation,
@@ -47,6 +50,9 @@ export type {
   SyncEvent,
   SyncEventType,
   SyncEventListener,
+  PoisonedMutationInfo,
+  PoisonedMutationAction,
+  PoisonedMutationHandler,
 } from "./local/index.js";
 
 // Transports

--- a/packages/client/src/local/create-client-db.ts
+++ b/packages/client/src/local/create-client-db.ts
@@ -9,7 +9,11 @@ import { LocalAdapter, openSharedIDB } from './local-adapter.js'
 import type { LocalAdapterOptions } from './local-adapter.js'
 import { SyncEngine } from './sync-engine.js'
 import type { SyncEngineOptions } from './sync-engine.js'
-import type { SyncTransport, ConflictStrategy } from './sync-transport.js'
+import type {
+  SyncTransport,
+  ConflictStrategy,
+  PoisonedMutationHandler,
+} from './sync-transport.js'
 import type { MutationStorage } from './mutation-queue.js'
 import type { RuntimeSchema } from '@gsquery/core'
 import { composeName } from './naming.js'
@@ -28,6 +32,14 @@ export interface CreateClientDBOptions<Tables extends Record<string, RowWithId>>
   transport: SyncTransport
   conflictStrategy?: ConflictStrategy
   pushDebounceMs?: number
+  /** Consecutive push failures per table before a batch is dead-lettered (default 5, 0 = never) */
+  maxRetries?: number
+  /** First backoff step for a failing table's background attempts (default 1000ms, 0 = none) */
+  retryBaseDelayMs?: number
+  /** Ceiling for the exponential backoff (default 60000ms) */
+  maxRetryDelayMs?: number
+  /** Called when a table's batch has failed `maxRetries` times in a row */
+  onPoisonedMutation?: PoisonedMutationHandler
   /** Custom mutation storage (defaults to localStorage) */
   mutationStorage?: MutationStorage
   /** Disable IndexedDB (for testing in non-browser environments) */
@@ -60,12 +72,28 @@ export interface ClientDBResult<Tables extends Record<string, RowWithId>> {
 export async function createClientDB<Tables extends Record<string, RowWithId>>(
   options: CreateClientDBOptions<Tables>
 ): Promise<ClientDBResult<Tables>> {
-  const { schema, transport, conflictStrategy, pushDebounceMs, mutationStorage, disableIDB, namespace } = options
+  const {
+    schema,
+    transport,
+    conflictStrategy,
+    pushDebounceMs,
+    maxRetries,
+    retryBaseDelayMs,
+    maxRetryDelayMs,
+    onPoisonedMutation,
+    mutationStorage,
+    disableIDB,
+    namespace,
+  } = options
 
   const syncEngine = new SyncEngine({
     transport,
     conflictStrategy,
     pushDebounceMs,
+    maxRetries,
+    retryBaseDelayMs,
+    maxRetryDelayMs,
+    onPoisonedMutation,
   } satisfies SyncEngineOptions)
 
   const stores: Record<string, DataStore<any>> = {}

--- a/packages/client/src/local/index.ts
+++ b/packages/client/src/local/index.ts
@@ -5,8 +5,8 @@ export type { MutationQueueOptions, MutationStorage } from './mutation-queue.js'
 export { LocalAdapter, openSharedIDB } from './local-adapter.js'
 export type { LocalAdapterOptions } from './local-adapter.js'
 
-export { SyncEngine } from './sync-engine.js'
-export type { SyncEngineOptions } from './sync-engine.js'
+export { SyncEngine, SyncError } from './sync-engine.js'
+export type { SyncEngineOptions, TableSyncError } from './sync-engine.js'
 
 export { createClientDB } from './create-client-db.js'
 export type { CreateClientDBOptions, ClientDBResult, ClientDBSchema } from './create-client-db.js'
@@ -14,6 +14,7 @@ export type { CreateClientDBOptions, ClientDBResult, ClientDBSchema } from './cr
 // Types
 export type {
   SyncTransport,
+  SyncPushResult,
   Mutation,
   MutationType,
   MergedMutation,
@@ -22,4 +23,7 @@ export type {
   SyncEvent,
   SyncEventType,
   SyncEventListener,
+  PoisonedMutationInfo,
+  PoisonedMutationAction,
+  PoisonedMutationHandler,
 } from './sync-transport.js'

--- a/packages/client/src/local/sync-engine.ts
+++ b/packages/client/src/local/sync-engine.ts
@@ -6,23 +6,124 @@ import type {
   SyncTransport,
   SyncEvent,
   SyncEventListener,
+  SyncPushResult,
   ConflictStrategy,
   ConflictItem,
   MergedMutation,
+  PoisonedMutationAction,
+  PoisonedMutationHandler,
 } from './sync-transport.js'
 import type { LocalAdapter } from './local-adapter.js'
 import type { MutationQueue } from './mutation-queue.js'
+
+/** Default number of consecutive push failures before a batch is dead-lettered */
+const DEFAULT_MAX_RETRIES = 5
+/** Default first backoff step for a failing table */
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000
+/** Default ceiling for the exponential backoff */
+const DEFAULT_MAX_RETRY_DELAY_MS = 60_000
 
 export interface SyncEngineOptions {
   transport: SyncTransport
   conflictStrategy?: ConflictStrategy
   /** Debounce ms for auto-push after mutations (default: 0 = disabled) */
   pushDebounceMs?: number
+  /**
+   * Consecutive push failures for one table before its batch is treated as
+   * poisoned and reported via `onPoisonedMutation` / the `mutation-dead` event
+   * (default: 5). `0` disables dead-lettering.
+   */
+  maxRetries?: number
+  /**
+   * First step of the exponential backoff applied to a failing table's
+   * *background* attempts (default: 1000ms). `0` disables backoff.
+   */
+  retryBaseDelayMs?: number
+  /** Ceiling for the exponential backoff (default: 60000ms) */
+  maxRetryDelayMs?: number
+  /** Called when a table's batch has failed `maxRetries` times in a row */
+  onPoisonedMutation?: PoisonedMutationHandler
+}
+
+/** A single table's failure inside an otherwise partial sync */
+export interface TableSyncError {
+  table: string
+  error: Error
+}
+
+/**
+ * Thrown by sync/push/pull when one or more tables failed.
+ *
+ * Every table is attempted regardless of what the others do (#132), so this is
+ * raised only after the whole pass finishes and it carries one entry per failed
+ * table. The individual errors were already emitted as per-table `error` events.
+ */
+export class SyncError extends Error {
+  readonly tableErrors: readonly TableSyncError[]
+
+  constructor(tableErrors: TableSyncError[]) {
+    super(
+      `Sync failed for ${tableErrors.length} table(s): ` +
+        tableErrors.map(t => `${t.table}: ${t.error.message}`).join('; ')
+    )
+    this.name = 'SyncError'
+    this.tableErrors = tableErrors
+  }
+}
+
+/**
+ * Internal marker for a failure raised by the push phase, carrying the batch
+ * that failed so the dead-letter path can report and optionally discard it.
+ * Never leaves the engine — callers see `inner` instead.
+ */
+class PushPhaseError extends Error {
+  constructor(
+    readonly inner: Error,
+    readonly mutations: MergedMutation[],
+    readonly boundary: number
+  ) {
+    super(inner.message)
+    this.name = 'PushPhaseError'
+  }
+}
+
+/**
+ * The slice of LocalAdapter the engine touches, widened to RowWithId.
+ *
+ * A registered `LocalAdapter<T>` cannot be stored as `LocalAdapter<RowWithId>`
+ * (T appears in input positions), and `any` would erase the row shape for the
+ * whole engine — so bind against the two methods actually used instead.
+ */
+interface SyncAdapter {
+  getRawData(): RowWithId[]
+  replaceAll(rows: RowWithId[]): void
+}
+
+/** The slice of MutationQueue the engine touches, widened to RowWithId. */
+interface SyncQueue {
+  getMerged(): MergedMutation[]
+  currentSeq(): number
+  clearForRows(ids: Set<string | number>, maxSeq?: number): void
+  push(type: 'insert' | 'update' | 'delete', id: string | number, data?: Partial<RowWithId>): void
 }
 
 interface TableBinding {
-  adapter: LocalAdapter<any>
-  queue: MutationQueue<any>
+  adapter: SyncAdapter
+  queue: SyncQueue
+}
+
+/** Per-table failure bookkeeping for backoff and dead-lettering */
+interface TableRetryState {
+  /** Consecutive failures of any phase — drives the backoff window */
+  failures: number
+  /** Consecutive *push* failures — drives dead-lettering */
+  pushFailures: number
+  /** Epoch ms before which background attempts skip this table */
+  nextAttemptAt: number
+}
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err))
 }
 
 export class SyncEngine {
@@ -37,10 +138,20 @@ export class SyncEngine {
   private syncing = false
   private opChain: Promise<unknown> = Promise.resolve()
 
+  private readonly maxRetries: number
+  private readonly retryBaseDelayMs: number
+  private readonly maxRetryDelayMs: number
+  private readonly onPoisonedMutation?: PoisonedMutationHandler
+  private readonly retryStates = new Map<string, TableRetryState>()
+
   constructor(options: SyncEngineOptions) {
     this.transport = options.transport
     this.conflictStrategy = options.conflictStrategy ?? 'server-wins'
     this.pushDebounceMs = options.pushDebounceMs ?? 0
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+    this.retryBaseDelayMs = options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS
+    this.maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS
+    this.onPoisonedMutation = options.onPoisonedMutation
   }
 
   /** Register a table for sync */
@@ -92,6 +203,22 @@ export class SyncEngine {
 
   /** Full sync: push first (preserve local changes), then pull */
   async sync(tableName?: string): Promise<void> {
+    return this.runSync(tableName, false)
+  }
+
+  /** Push local mutations to server */
+  async push(tableName?: string): Promise<void> {
+    return this.runPush(tableName, false)
+  }
+
+  /** Pull server data to local */
+  async pull(tableName?: string): Promise<void> {
+    return this.serialize(() =>
+      this.runTables(tableName, false, name => this.pullTable(name))
+    )
+  }
+
+  private async runSync(tableName: string | undefined, background: boolean): Promise<void> {
     // Flag is set synchronously so overlapping sync() calls still drop rather
     // than queue up — auto-sync ticks must not pile up behind a slow transport.
     if (this.syncing) return
@@ -101,54 +228,171 @@ export class SyncEngine {
       try {
         this.emit({ type: 'sync-start', table: tableName })
 
-        const tableNames = tableName
-          ? [tableName]
-          : Array.from(this.tables.keys())
-
-        for (const name of tableNames) {
+        await this.runTables(tableName, background, async name => {
           await this.pushTable(name)
           await this.pullTable(name)
-        }
-
-        this.emit({ type: 'sync-complete', table: tableName })
-      } catch (err) {
-        this.emit({
-          type: 'error',
-          table: tableName,
-          error: err instanceof Error ? err : new Error(String(err)),
         })
-        throw err
+
+        // Only a pass in which every table succeeded is a completed sync;
+        // failures were already reported as per-table 'error' events.
+        this.emit({ type: 'sync-complete', table: tableName })
       } finally {
         this.syncing = false
       }
     })
   }
 
-  /** Push local mutations to server */
-  async push(tableName?: string): Promise<void> {
-    return this.serialize(async () => {
-      const tableNames = tableName
-        ? [tableName]
-        : Array.from(this.tables.keys())
-
-      for (const name of tableNames) {
-        await this.pushTable(name)
-      }
-    })
+  private async runPush(tableName: string | undefined, background: boolean): Promise<void> {
+    return this.serialize(() =>
+      this.runTables(tableName, background, name => this.pushTable(name))
+    )
   }
 
-  /** Pull server data to local */
-  async pull(tableName?: string): Promise<void> {
-    return this.serialize(async () => {
-      const tableNames = tableName
-        ? [tableName]
-        : Array.from(this.tables.keys())
+  /**
+   * Run `op` for each requested table, isolating failures.
+   *
+   * A table that throws no longer aborts the pass: its error is emitted and
+   * recorded, and the remaining tables still sync. Previously one permanently
+   * rejected mutation stalled every table forever (#132). Failures are raised
+   * together as a SyncError once the pass is done, so awaiting callers still
+   * see them.
+   */
+  private async runTables(
+    tableName: string | undefined,
+    background: boolean,
+    op: (name: string) => Promise<void>
+  ): Promise<void> {
+    const tableNames = tableName ? [tableName] : Array.from(this.tables.keys())
+    const errors: TableSyncError[] = []
 
-      for (const name of tableNames) {
-        await this.pullTable(name)
+    for (const name of tableNames) {
+      if (background && this.isBackedOff(name)) continue
+
+      try {
+        await op(name)
+        this.recordSuccess(name)
+      } catch (err) {
+        const error = err instanceof PushPhaseError ? err.inner : toError(err)
+        this.recordFailure(name)
+        if (err instanceof PushPhaseError) {
+          this.handlePushFailure(name, err)
+        }
+        this.emit({ type: 'error', table: name, error })
+        errors.push({ table: name, error })
       }
-    })
+    }
+
+    if (errors.length > 0) throw new SyncError(errors)
   }
+
+  // ── Retry / backoff / dead-letter ───────────────────────────────────
+
+  private retryState(tableName: string): TableRetryState {
+    let state = this.retryStates.get(tableName)
+    if (!state) {
+      state = { failures: 0, pushFailures: 0, nextAttemptAt: 0 }
+      this.retryStates.set(tableName, state)
+    }
+    return state
+  }
+
+  /**
+   * Whether a background attempt should skip this table for now.
+   *
+   * Only background attempts (auto-sync ticks, debounced pushes) back off —
+   * an explicit sync()/push()/pull() is the caller saying "retry now", and
+   * silently doing nothing there would be surprising.
+   */
+  private isBackedOff(tableName: string): boolean {
+    if (this.retryBaseDelayMs <= 0) return false
+    const state = this.retryStates.get(tableName)
+    return state !== undefined && state.nextAttemptAt > Date.now()
+  }
+
+  private recordSuccess(tableName: string): void {
+    const state = this.retryStates.get(tableName)
+    if (!state) return
+    state.failures = 0
+    state.nextAttemptAt = 0
+  }
+
+  private recordFailure(tableName: string): void {
+    const state = this.retryState(tableName)
+    state.failures += 1
+    if (this.retryBaseDelayMs > 0) {
+      const delay = Math.min(
+        this.retryBaseDelayMs * 2 ** (state.failures - 1),
+        this.maxRetryDelayMs
+      )
+      state.nextAttemptAt = Date.now() + delay
+    }
+  }
+
+  /** Reset the backoff window (and failure counters) for a table, or all tables. */
+  resetRetryState(tableName?: string): void {
+    if (tableName === undefined) {
+      this.retryStates.clear()
+      return
+    }
+    this.retryStates.delete(tableName)
+  }
+
+  /**
+   * Count a push failure and, once a batch has been rejected `maxRetries` times
+   * in a row, dead-letter it so the app can surface or drop it instead of the
+   * table retrying forever (#132).
+   *
+   * Only push failures count: a pull failure is a transport problem, not a
+   * poisoned mutation, and must never cost the app its pending writes.
+   */
+  private handlePushFailure(tableName: string, failure: PushPhaseError): void {
+    const state = this.retryState(tableName)
+    state.pushFailures += 1
+
+    if (this.maxRetries <= 0 || state.pushFailures < this.maxRetries) return
+
+    const binding = this.tables.get(tableName)
+    if (!binding) return
+
+    const attempts = state.pushFailures
+    // Restart the window either way, so a retained batch notifies the app again
+    // after another maxRetries attempts rather than going quiet forever.
+    state.pushFailures = 0
+
+    this.emit({
+      type: 'mutation-dead',
+      table: tableName,
+      error: failure.inner,
+      mutations: failure.mutations,
+      attempts,
+    })
+
+    let action: PoisonedMutationAction | void
+    try {
+      action = this.onPoisonedMutation?.({
+        table: tableName,
+        mutations: failure.mutations,
+        error: failure.inner,
+        attempts,
+      })
+    } catch {
+      // A throwing handler must not break sync — treat it as 'retain'.
+      action = undefined
+    }
+
+    if (action !== 'discard') return
+
+    // Respect the push boundary: writes enqueued after the batch was
+    // snapshotted were never rejected and must survive (#109).
+    binding.queue.clearForRows(
+      new Set(failure.mutations.map(m => m.id)),
+      failure.boundary
+    )
+    // The blockage is gone, so let the table resume on the very next attempt.
+    this.resetRetryState(tableName)
+  }
+
+  // ── Push / pull ─────────────────────────────────────────────────────
 
   private async pushTable(tableName: string): Promise<void> {
     const binding = this.tables.get(tableName)
@@ -161,77 +405,111 @@ export class SyncEngine {
     // Anything enqueued during the await below (higher seq) must survive the
     // clear, otherwise concurrent local writes are silently lost (#109).
     const boundary = binding.queue.currentSeq()
-    const result = await this.transport.push(tableName, merged)
 
-    if (result.success) {
-      const syncedIds = new Set(merged.map(m => m.id))
-      binding.queue.clearForRows(syncedIds, boundary)
-      this.emit({ type: 'push-complete', table: tableName, pushedCount: merged.length })
-      return
+    let result: SyncPushResult
+    try {
+      result = await this.transport.push(tableName, merged)
+    } catch (err) {
+      throw new PushPhaseError(toError(err), merged, boundary)
     }
 
-    if (result.conflicts && result.conflicts.length > 0) {
-      this.resolveConflicts(tableName, binding, result.conflicts, merged)
+    // Ids that may leave the queue. A transport that reports appliedIds is
+    // authoritative; otherwise infer: everything on success, nothing on failure.
+    // Clearing the non-conflicting rows of a rejected batch would drop writes
+    // the server never took (#131).
+    const settledIds: Set<string | number> = result.appliedIds
+      ? new Set(result.appliedIds)
+      : result.success
+        ? new Set(merged.map(m => m.id))
+        : new Set()
 
-      const syncedIds = new Set(merged.map(m => m.id))
-      // client-wins keeps the local row, so its mutation must be retained and
-      // re-pushed; clearing it would let the next pull overwrite the local edit
-      // with the server version (#110). Non-conflicting rows are still cleared.
-      if (this.conflictStrategy === 'client-wins') {
-        for (const conflict of result.conflicts) {
-          syncedIds.delete(conflict.id)
-        }
-      }
-      binding.queue.clearForRows(syncedIds, boundary)
-      this.emit({ type: 'push-complete', table: tableName, pushedCount: merged.length })
-      return
+    const conflicts = result.conflicts ?? []
+    if (conflicts.length > 0) {
+      this.resolveConflicts(binding, conflicts, settledIds)
     }
 
-    // success:false with no conflicts is a real push failure. Surface it so
-    // sync() aborts before pullTable can clobber the unpushed local state,
-    // rather than swallowing the failure (#110).
-    throw new Error(
-      `Push failed for table "${tableName}": server reported failure without conflicts`
-    )
+    binding.queue.clearForRows(settledIds, boundary)
+
+    if (!result.success && conflicts.length === 0) {
+      // success:false with no conflicts is a real push failure. Surface it so
+      // sync() skips pullTable for this table, rather than letting a stale
+      // snapshot clobber the unpushed local state (#110).
+      throw new PushPhaseError(
+        new Error(
+          `Push failed for table "${tableName}": server reported failure without conflicts`
+        ),
+        merged,
+        boundary
+      )
+    }
+
+    const state = this.retryStates.get(tableName)
+    if (state) state.pushFailures = 0
+    this.emit({ type: 'push-complete', table: tableName, pushedCount: merged.length })
   }
 
+  /**
+   * Apply each conflict's resolution locally and decide what happens to the
+   * pending mutation behind it, by adding to / removing from `settledIds`.
+   */
   private resolveConflicts(
-    _tableName: string,
     binding: TableBinding,
     conflicts: ConflictItem[],
-    _merged: MergedMutation[]
+    settledIds: Set<string | number>
   ): void {
     for (const conflict of conflicts) {
-      let resolvedRow: RowWithId
+      if (this.conflictStrategy === 'client-wins') {
+        // Keep the local row *and* its mutation, so the next push re-sends it;
+        // clearing it would let the next pull overwrite the local edit with the
+        // server version (#110).
+        settledIds.delete(conflict.id)
+        continue
+      }
+
+      const resolved =
+        typeof this.conflictStrategy === 'function'
+          ? this.conflictStrategy(conflict)
+          : conflict.serverRow
+      // id is immutable across a resolution, mirroring update() (#98).
+      const resolvedRow: RowWithId = { ...resolved, id: conflict.id }
+
+      this.applyResolvedRow(binding, resolvedRow)
+
+      // The pending mutation was superseded by the resolution, so it must not
+      // be re-pushed as it stands.
+      settledIds.add(conflict.id)
 
       if (typeof this.conflictStrategy === 'function') {
-        resolvedRow = this.conflictStrategy(conflict)
-      } else if (this.conflictStrategy === 'client-wins') {
-        // Keep local version (already in adapter)
-        continue
-      } else {
-        // server-wins (default)
-        resolvedRow = conflict.serverRow
-      }
-
-      // Apply resolved row to local adapter (without recording mutation)
-      const existing = binding.adapter.findById(conflict.id)
-      if (existing) {
-        const allData = binding.adapter.getRawData()
-        const idx = allData.findIndex((r: RowWithId) => r.id === conflict.id)
-        if (idx >= 0) {
-          allData[idx] = resolvedRow
-          binding.adapter.replaceAll(allData)
-        }
+        // A custom resolver invents a row that exists nowhere else: without a
+        // mutation of its own it would never reach the server and the next pull
+        // would erase it (#131). Its seq is above the push boundary, so the
+        // clearForRows() in pushTable keeps it — the same mechanism that
+        // protects concurrent writes (#109).
+        const { id: _id, ...fields } = resolvedRow
+        binding.queue.push('update', conflict.id, fields)
       }
     }
+  }
+
+  private applyResolvedRow(binding: TableBinding, row: RowWithId): void {
+    const rows = binding.adapter.getRawData()
+    const idx = rows.findIndex(r => r.id === row.id)
+    if (idx >= 0) {
+      rows[idx] = row
+    } else {
+      // The row was deleted locally. Dropping the resolution here would leave
+      // the strategy's decision unapplied (#131); the resolution wins, so
+      // re-materialize the row.
+      rows.push(row)
+    }
+    binding.adapter.replaceAll(rows)
   }
 
   private async pullTable(tableName: string): Promise<void> {
     const binding = this.tables.get(tableName)
     if (!binding) return
 
-    const { rows } = await this.transport.pull(tableName)
+    const { rows } = await this.transport.pull<RowWithId>(tableName)
 
     // If there are pending local mutations, apply them on top of server data
     const merged = binding.queue.getMerged()
@@ -242,7 +520,7 @@ export class SyncEngine {
       for (const m of merged) {
         if (m.type === 'insert') {
           if (!serverMap.has(m.id)) {
-            serverMap.set(m.id, { id: m.id, ...m.data } as RowWithId)
+            serverMap.set(m.id, { id: m.id, ...m.data })
           }
         } else if (m.type === 'update') {
           const existing = serverMap.get(m.id)
@@ -254,12 +532,24 @@ export class SyncEngine {
         }
       }
 
-      binding.adapter.replaceAll(Array.from(serverMap.values()) as any[])
+      binding.adapter.replaceAll(Array.from(serverMap.values()))
     } else {
-      binding.adapter.replaceAll(rows as any[])
+      binding.adapter.replaceAll(rows)
     }
 
     this.emit({ type: 'pull-complete', table: tableName, pulledCount: rows.length })
+  }
+
+  // ── Background paths ────────────────────────────────────────────────
+
+  /**
+   * Report a failed background attempt. Nobody is awaiting these, so swallowing
+   * the rejection would leave the app with no signal at all (#132). The
+   * per-table 'error' events already fired; this one has no `table` and marks
+   * the whole attempt as failed.
+   */
+  private emitBackgroundError(err: unknown): void {
+    this.emit({ type: 'error', error: toError(err) })
   }
 
   /** Schedule a debounced push (called after local mutations) */
@@ -268,9 +558,7 @@ export class SyncEngine {
     if (this.pushDebounceTimer) clearTimeout(this.pushDebounceTimer)
     this.pushDebounceTimer = setTimeout(() => {
       this.pushDebounceTimer = null
-      this.push().catch(() => {
-        // Push failed - will retry on next sync
-      })
+      this.runPush(undefined, true).catch(err => this.emitBackgroundError(err))
     }, this.pushDebounceMs)
   }
 
@@ -278,9 +566,7 @@ export class SyncEngine {
   startAutoSync(intervalMs: number): void {
     this.stopAutoSync()
     this.autoSyncTimer = setInterval(() => {
-      this.sync().catch(() => {
-        // Sync failed - will retry on next interval
-      })
+      this.runSync(undefined, true).catch(err => this.emitBackgroundError(err))
     }, intervalMs)
   }
 
@@ -305,5 +591,6 @@ export class SyncEngine {
       this.pushDebounceTimer = null
     }
     this.listeners.length = 0
+    this.retryStates.clear()
   }
 }

--- a/packages/client/src/local/sync-transport.ts
+++ b/packages/client/src/local/sync-transport.ts
@@ -39,6 +39,28 @@ export interface ConflictItem<T extends RowWithId = RowWithId> {
 }
 
 /**
+ * Result of a transport push.
+ *
+ * `appliedIds` is the authoritative list of rows the server actually committed.
+ * It is optional for backward compatibility: when a transport omits it the
+ * engine infers the applied set from `success` —
+ * - `success: true`  → every pushed mutation was applied,
+ * - `success: false` → none of them were, so nothing may be cleared from the
+ *   local queue (including the non-conflicting rows of a conflicted batch, which
+ *   used to be dropped as if the server had taken them — #131).
+ *
+ * A server that commits part of a batch should report `appliedIds` explicitly;
+ * otherwise the client conservatively re-pushes the whole batch, which is safe
+ * because every mutation is idempotent (see the `push` contract below).
+ */
+export interface SyncPushResult<T extends RowWithId = RowWithId> {
+  success: boolean
+  conflicts?: ConflictItem<T>[]
+  /** Ids the server confirms it applied. Absent → inferred from `success`. */
+  appliedIds?: (string | number)[]
+}
+
+/**
  * Server communication interface.
  *
  * Server contract for `push`: apply each mutation idempotently —
@@ -55,10 +77,7 @@ export interface SyncTransport {
   push<T extends RowWithId>(
     tableName: string,
     mutations: MergedMutation<T>[]
-  ): Promise<{
-    success: boolean
-    conflicts?: ConflictItem<T>[]
-  }>
+  ): Promise<SyncPushResult<T>>
 }
 
 /** Sync event types */
@@ -68,18 +87,52 @@ export type SyncEventType =
   | 'pull-complete'
   | 'sync-complete'
   | 'error'
+  | 'mutation-dead'
 
 export interface SyncEvent {
   type: SyncEventType
+  /**
+   * Table the event belongs to. An `error` without a table is a whole-attempt
+   * failure reported from a background path (auto-sync tick, debounced push);
+   * the per-table `error` events were already emitted separately.
+   */
   table?: string
   error?: Error
   /** Number of mutations pushed */
   pushedCount?: number
   /** Number of rows pulled */
   pulledCount?: number
+  /** The batch the server keeps rejecting ('mutation-dead') */
+  mutations?: MergedMutation[]
+  /** Consecutive failed push attempts for the batch ('mutation-dead') */
+  attempts?: number
 }
 
 export type SyncEventListener = (event: SyncEvent) => void
+
+/** Describes a batch the server has rejected `maxRetries` times in a row. */
+export interface PoisonedMutationInfo<T extends RowWithId = RowWithId> {
+  table: string
+  /** The merged batch that keeps failing */
+  mutations: MergedMutation<T>[]
+  /** The last error the transport reported */
+  error: Error
+  /** Number of consecutive failed push attempts */
+  attempts: number
+}
+
+/**
+ * What the engine should do with a poisoned batch.
+ * - `'discard'`: drop those mutations from the queue so the table can sync again
+ *   (the local rows are left untouched — a later pull reconciles them).
+ * - `'retain'` (also the default when the handler returns nothing): keep them and
+ *   keep retrying.
+ */
+export type PoisonedMutationAction = 'discard' | 'retain'
+
+export type PoisonedMutationHandler = (
+  info: PoisonedMutationInfo
+) => PoisonedMutationAction | void
 
 /** Conflict resolution strategy */
 export type ConflictStrategy<T extends RowWithId = RowWithId> =

--- a/packages/client/src/transports/gas-api-transport.ts
+++ b/packages/client/src/transports/gas-api-transport.ts
@@ -3,7 +3,11 @@
  * Uses google.script.run in GAS environment, fetch in dev/browser environment.
  */
 import type { RowWithId } from '@gsquery/core'
-import type { SyncTransport, MergedMutation, ConflictItem } from '../local/sync-transport.js'
+import type {
+  SyncTransport,
+  MergedMutation,
+  SyncPushResult,
+} from '../local/sync-transport.js'
 
 declare const google: {
   script: {
@@ -55,10 +59,7 @@ export class GasApiTransport implements SyncTransport {
   async push<T extends RowWithId>(
     tableName: string,
     mutations: MergedMutation<T>[]
-  ): Promise<{
-    success: boolean
-    conflicts?: ConflictItem<T>[]
-  }> {
+  ): Promise<SyncPushResult<T>> {
     if (isGas()) {
       return this.gasPush<T>(tableName, mutations)
     }
@@ -79,12 +80,10 @@ export class GasApiTransport implements SyncTransport {
   private gasPush<T extends RowWithId>(
     tableName: string,
     mutations: MergedMutation<T>[]
-  ): Promise<{ success: boolean; conflicts?: ConflictItem<T>[] }> {
+  ): Promise<SyncPushResult<T>> {
     return new Promise((resolve, reject) => {
       const handler = google.script.run
-        .withSuccessHandler(
-          (result: { success: boolean; conflicts?: ConflictItem<T>[] }) => resolve(result)
-        )
+        .withSuccessHandler((result: SyncPushResult<T>) => resolve(result))
         .withFailureHandler((error: Error) => reject(error))
       ;(handler as any)[this.pushFn](tableName, mutations)
     })
@@ -111,7 +110,7 @@ export class GasApiTransport implements SyncTransport {
   private async fetchPush<T extends RowWithId>(
     tableName: string,
     mutations: MergedMutation<T>[]
-  ): Promise<{ success: boolean; conflicts?: ConflictItem<T>[] }> {
+  ): Promise<SyncPushResult<T>> {
     const url = this.baseUrl
       ? `${this.baseUrl}/sync/push`
       : `/api/sync/push`

--- a/packages/client/src/transports/mock-transport.ts
+++ b/packages/client/src/transports/mock-transport.ts
@@ -2,7 +2,12 @@
  * MockTransport - In-memory SyncTransport for testing
  */
 import type { RowWithId } from '@gsquery/core'
-import type { SyncTransport, MergedMutation, ConflictItem } from '../local/sync-transport.js'
+import type {
+  SyncTransport,
+  MergedMutation,
+  ConflictItem,
+  SyncPushResult,
+} from '../local/sync-transport.js'
 
 export class MockTransport implements SyncTransport {
   /** Server-side data per table */
@@ -24,6 +29,14 @@ export class MockTransport implements SyncTransport {
   pushShouldFail = false
   pullShouldFail = false
 
+  /**
+   * Whether a conflicting push still commits the mutations that did *not*
+   * conflict. Off by default: the whole batch is rejected, which is the
+   * conservative reading of the transport contract. When on, the applied rows
+   * are reported back via `appliedIds` so the client clears exactly those.
+   */
+  applyNonConflictedOnConflict = false
+
   /** Set server data for a table */
   setServerData<T extends RowWithId>(tableName: string, rows: T[]): void {
     this.serverData.set(tableName, [...rows])
@@ -40,10 +53,7 @@ export class MockTransport implements SyncTransport {
   async push<T extends RowWithId>(
     tableName: string,
     mutations: MergedMutation<T>[]
-  ): Promise<{
-    success: boolean
-    conflicts?: ConflictItem<T>[]
-  }> {
+  ): Promise<SyncPushResult<T>> {
     if (this.pushShouldFail) {
       throw new Error(`MockTransport: push failed for ${tableName}`)
     }
@@ -54,11 +64,26 @@ export class MockTransport implements SyncTransport {
     if (this.conflictGenerator) {
       const conflicts = this.conflictGenerator(tableName, mutations)
       if (conflicts.length > 0) {
-        return { success: false, conflicts }
+        if (!this.applyNonConflictedOnConflict) {
+          // Nothing was committed, so no appliedIds — the client keeps the
+          // whole batch queued.
+          return { success: false, conflicts }
+        }
+        const conflictIds = new Set(conflicts.map(c => c.id))
+        const applied = mutations.filter(m => !conflictIds.has(m.id))
+        this.applyMutations(tableName, applied)
+        return { success: false, conflicts, appliedIds: applied.map(m => m.id) }
       }
     }
 
-    // Apply mutations to server data
+    this.applyMutations(tableName, mutations)
+    return { success: true, appliedIds: mutations.map(m => m.id) }
+  }
+
+  private applyMutations<T extends RowWithId>(
+    tableName: string,
+    mutations: MergedMutation<T>[]
+  ): void {
     const current = [...(this.serverData.get(tableName) ?? [])] as T[]
     const byId = new Map(current.map(r => [r.id, r]))
 
@@ -76,6 +101,5 @@ export class MockTransport implements SyncTransport {
     }
 
     this.serverData.set(tableName, Array.from(byId.values()))
-    return { success: true }
   }
 }

--- a/packages/client/tests/unit/local/sync-engine.test.ts
+++ b/packages/client/tests/unit/local/sync-engine.test.ts
@@ -511,6 +511,169 @@ describe('SyncEngine', () => {
       const t1 = adapter.findById('t1')
       expect(t1?.title).toBe('Merged: Server')
     })
+
+    it("re-enqueues the custom resolver's row so it survives the next pull [#131]", async () => {
+      const customSync = new SyncEngine({
+        transport,
+        conflictStrategy: ((conflict: any) => ({
+          ...conflict.serverRow,
+          title: `Merged: ${conflict.serverRow.title}`,
+        })) as any,
+      })
+      customSync.registerTable('Todo', adapter, adapter.queue)
+
+      transport.setServerData<Todo>('Todo', [{ id: 't1', title: 'Server', done: true }])
+      adapter.insert({ id: 't1', title: 'Local', done: false })
+
+      transport.conflictGenerator = (() => [
+        {
+          id: 't1',
+          serverRow: { id: 't1', title: 'Server', done: true },
+          clientMutation: { id: 't1', type: 'insert' as const, data: { id: 't1', title: 'Local', done: false } },
+        },
+      ]) as any
+
+      await customSync.push()
+
+      // The resolution must exist as a pending mutation, not just in memory.
+      const pending = adapter.queue.getMerged().find(m => m.id === 't1')
+      expect(pending).toBeDefined()
+      expect(pending?.data).toMatchObject({ title: 'Merged: Server' })
+
+      // A pull that brings back the untouched server row must not erase it.
+      transport.conflictGenerator = undefined
+      await customSync.pull()
+      expect(adapter.findById('t1')?.title).toBe('Merged: Server')
+    })
+
+    it("pushes the custom resolver's row to the server on the next cycle [#131]", async () => {
+      const customSync = new SyncEngine({
+        transport,
+        conflictStrategy: ((conflict: any) => ({
+          ...conflict.serverRow,
+          title: `Merged: ${conflict.serverRow.title}`,
+        })) as any,
+      })
+      customSync.registerTable('Todo', adapter, adapter.queue)
+
+      transport.setServerData<Todo>('Todo', [{ id: 't1', title: 'Server', done: true }])
+      adapter.insert({ id: 't1', title: 'Local', done: false })
+
+      transport.conflictGenerator = (() => [
+        {
+          id: 't1',
+          serverRow: { id: 't1', title: 'Server', done: true },
+          clientMutation: { id: 't1', type: 'insert' as const, data: { id: 't1', title: 'Local', done: false } },
+        },
+      ]) as any
+      await customSync.push()
+
+      transport.conflictGenerator = undefined
+      await customSync.push()
+
+      const server = transport.serverData.get('Todo') as Todo[]
+      expect(server.find(t => t.id === 't1')?.title).toBe('Merged: Server')
+    })
+
+    it('applies the resolution even when the row was deleted locally [#131]', async () => {
+      const customSync = new SyncEngine({
+        transport,
+        conflictStrategy: ((conflict: any) => ({
+          ...conflict.serverRow,
+          title: `Merged: ${conflict.serverRow.title}`,
+        })) as any,
+      })
+      customSync.registerTable('Todo', adapter, adapter.queue)
+
+      transport.setServerData<Todo>('Todo', [{ id: 't1', title: 'Server', done: true }])
+      await customSync.pull()
+      adapter.delete('t1')
+
+      transport.conflictGenerator = (() => [
+        {
+          id: 't1',
+          serverRow: { id: 't1', title: 'Server', done: true },
+          clientMutation: { id: 't1', type: 'delete' as const },
+        },
+      ]) as any
+
+      await customSync.push()
+
+      // The resolver decided the row should exist — that decision must not be
+      // silently dropped just because the row is missing locally.
+      expect(adapter.findById('t1')?.title).toBe('Merged: Server')
+    })
+
+    it('keeps non-conflicted mutations of a rejected batch [#131]', async () => {
+      adapter.insert({ id: 't1', title: 'Local 1', done: false })
+      adapter.insert({ id: 't2', title: 'Local 2', done: false })
+
+      transport.conflictGenerator = ((_table: string, mutations: any[]) =>
+        mutations
+          .filter(m => m.id === 't1')
+          .map(m => ({
+            id: 't1',
+            serverRow: { id: 't1', title: 'Server 1', done: true },
+            clientMutation: m,
+          }))) as any
+
+      await sync.push()
+
+      // The server rejected the batch, so t2 was never applied and must stay
+      // queued. t1 is settled by server-wins.
+      const pending = adapter.queue.getMerged()
+      expect(pending.map(m => m.id)).toEqual(['t2'])
+    })
+
+    it('clears exactly the ids the transport reports as applied [#131]', async () => {
+      transport.applyNonConflictedOnConflict = true
+
+      adapter.insert({ id: 't1', title: 'Local 1', done: false })
+      adapter.insert({ id: 't2', title: 'Local 2', done: false })
+
+      transport.conflictGenerator = ((_table: string, mutations: any[]) =>
+        mutations
+          .filter(m => m.id === 't1')
+          .map(m => ({
+            id: 't1',
+            serverRow: { id: 't1', title: 'Server 1', done: true },
+            clientMutation: m,
+          }))) as any
+
+      await sync.push()
+
+      // t2 is in appliedIds, t1 is settled by server-wins → nothing left.
+      expect(adapter.queue.getMerged()).toHaveLength(0)
+      const server = transport.serverData.get('Todo') as Todo[]
+      expect(server.find(t => t.id === 't2')?.title).toBe('Local 2')
+    })
+
+    it('honors appliedIds on a hard push failure [#131]', async () => {
+      const partialTransport = {
+        async pull() {
+          return { rows: [] as Todo[] }
+        },
+        async push() {
+          // Server applied t1 then died before t2 — no conflicts involved.
+          return { success: false, appliedIds: ['t1'] }
+        },
+      }
+      const a = new LocalAdapter<Todo>({
+        tableName: 'Todo',
+        idMode: 'client',
+        disableIDB: true,
+        mutationStorage: createMemoryStorage(),
+      })
+      const s = new SyncEngine({ transport: partialTransport as any })
+      s.registerTable('Todo', a, a.queue)
+
+      a.insert({ id: 't1', title: 'A', done: false })
+      a.insert({ id: 't2', title: 'B', done: false })
+
+      await expect(s.push()).rejects.toThrow()
+
+      expect(a.queue.getMerged().map(m => m.id)).toEqual(['t2'])
+    })
   })
 
   // ── Auto-sync ──────────────────────────────────────────────────────

--- a/packages/client/tests/unit/local/sync-resilience.test.ts
+++ b/packages/client/tests/unit/local/sync-resilience.test.ts
@@ -1,0 +1,397 @@
+/**
+ * SyncEngine resilience tests - per-table isolation, bounded retries with
+ * backoff, and dead-lettering of permanently-rejected mutations (#132).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { RowWithId } from '@gsquery/core'
+import { LocalAdapter } from '../../../src/local/local-adapter.js'
+import { SyncEngine, SyncError } from '../../../src/local/sync-engine.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+import type {
+  MergedMutation,
+  SyncEvent,
+  SyncPushResult,
+  SyncTransport,
+  PoisonedMutationInfo,
+} from '../../../src/local/sync-transport.js'
+
+interface Todo extends RowWithId {
+  id: string
+  title: string
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+/** Transport that rejects pushes for a configurable set of tables. */
+class FlakyTransport implements SyncTransport {
+  readonly failingTables = new Set<string>()
+  readonly pushCalls: string[] = []
+  readonly pullCalls: string[] = []
+  private readonly server = new Map<string, RowWithId[]>()
+
+  async pull<T extends RowWithId>(tableName: string): Promise<{ rows: T[] }> {
+    this.pullCalls.push(tableName)
+    return { rows: [...((this.server.get(tableName) ?? []) as T[])] }
+  }
+
+  async push<T extends RowWithId>(
+    tableName: string,
+    mutations: MergedMutation<T>[]
+  ): Promise<SyncPushResult<T>> {
+    this.pushCalls.push(tableName)
+    if (this.failingTables.has(tableName)) {
+      throw new Error(`server rejected batch for ${tableName}`)
+    }
+    const rows = [...(this.server.get(tableName) ?? [])]
+    const byId = new Map(rows.map(r => [r.id, r]))
+    for (const m of mutations) {
+      if (m.type === 'delete') byId.delete(m.id)
+      else byId.set(m.id, { id: m.id, ...m.data } as RowWithId)
+    }
+    this.server.set(tableName, Array.from(byId.values()))
+    return { success: true, appliedIds: mutations.map(m => m.id) }
+  }
+
+  pushCallsFor(tableName: string): number {
+    return this.pushCalls.filter(t => t === tableName).length
+  }
+}
+
+function createAdapter(tableName: string): LocalAdapter<Todo> {
+  return new LocalAdapter<Todo>({
+    tableName,
+    idMode: 'client',
+    disableIDB: true,
+    mutationStorage: createMemoryStorage(),
+  })
+}
+
+describe('SyncEngine resilience [#132]', () => {
+  let transport: FlakyTransport
+  let tableA: LocalAdapter<Todo>
+  let tableB: LocalAdapter<Todo>
+
+  beforeEach(() => {
+    transport = new FlakyTransport()
+    tableA = createAdapter('A')
+    tableB = createAdapter('B')
+  })
+
+  function createEngine(
+    options: Partial<{
+      maxRetries: number
+      retryBaseDelayMs: number
+      onPoisonedMutation: (info: PoisonedMutationInfo) => 'discard' | 'retain' | void
+      pushDebounceMs: number
+    }> = {}
+  ): SyncEngine {
+    const engine = new SyncEngine({ transport, ...options })
+    engine.registerTable('A', tableA, tableA.queue)
+    engine.registerTable('B', tableB, tableB.queue)
+    return engine
+  }
+
+  // ── Per-table isolation ─────────────────────────────────────────────
+
+  it('a poisoned table does not stop later tables from syncing', async () => {
+    const engine = createEngine()
+    transport.failingTables.add('A')
+
+    tableA.insert({ id: 'a1', title: 'A1' })
+    tableB.insert({ id: 'b1', title: 'B1' })
+
+    await expect(engine.sync()).rejects.toThrow(SyncError)
+
+    // Table B pushed and pulled despite A's permanent failure.
+    expect(transport.pushCallsFor('B')).toBe(1)
+    expect(transport.pullCalls).toContain('B')
+    expect(tableB.queue.hasPending).toBe(false)
+
+    // A's mutation is preserved, and A never pulled (its push failed).
+    expect(tableA.queue.hasPending).toBe(true)
+    expect(transport.pullCalls).not.toContain('A')
+  })
+
+  it('emits a per-table error event and aggregates the failures', async () => {
+    const engine = createEngine()
+    const events: SyncEvent[] = []
+    engine.on(e => events.push(e))
+
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+    tableB.insert({ id: 'b1', title: 'B1' })
+
+    const error = await engine.sync().catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(SyncError)
+    expect((error as SyncError).tableErrors.map(t => t.table)).toEqual(['A'])
+
+    const errorEvents = events.filter(e => e.type === 'error')
+    expect(errorEvents).toHaveLength(1)
+    expect(errorEvents[0].table).toBe('A')
+
+    // A partial sync is not a complete sync.
+    expect(events.some(e => e.type === 'sync-complete')).toBe(false)
+  })
+
+  it('isolates per table in push() and pull() too', async () => {
+    const engine = createEngine()
+    transport.failingTables.add('A')
+
+    tableA.insert({ id: 'a1', title: 'A1' })
+    tableB.insert({ id: 'b1', title: 'B1' })
+
+    await expect(engine.push()).rejects.toThrow(SyncError)
+    expect(transport.pushCallsFor('B')).toBe(1)
+  })
+
+  // ── Dead-letter ─────────────────────────────────────────────────────
+
+  it('dead-letters a batch after maxRetries consecutive push failures', async () => {
+    const poisoned: PoisonedMutationInfo[] = []
+    const engine = createEngine({
+      maxRetries: 2,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: info => {
+        poisoned.push(info)
+      },
+    })
+    const events: SyncEvent[] = []
+    engine.on(e => events.push(e))
+
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+
+    await expect(engine.sync()).rejects.toThrow()
+    expect(poisoned).toHaveLength(0) // one failure is not poison yet
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(poisoned).toHaveLength(1)
+    expect(poisoned[0].table).toBe('A')
+    expect(poisoned[0].attempts).toBe(2)
+    expect(poisoned[0].mutations.map(m => m.id)).toEqual(['a1'])
+
+    const dead = events.filter(e => e.type === 'mutation-dead')
+    expect(dead).toHaveLength(1)
+    expect(dead[0].table).toBe('A')
+    expect(dead[0].mutations?.map(m => m.id)).toEqual(['a1'])
+  })
+
+  it('retains the batch when the handler does not discard it', async () => {
+    const engine = createEngine({ maxRetries: 1, retryBaseDelayMs: 0 })
+
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+
+    await expect(engine.sync()).rejects.toThrow()
+    expect(tableA.queue.hasPending).toBe(true)
+  })
+
+  it("discards the batch and unblocks the table when the handler returns 'discard'", async () => {
+    const engine = createEngine({
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: () => 'discard',
+    })
+
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+
+    await expect(engine.sync()).rejects.toThrow()
+    expect(tableA.queue.hasPending).toBe(false)
+
+    // With the poison gone the table syncs cleanly again, even though the
+    // transport would still reject a push (there is nothing left to push).
+    await expect(engine.sync()).resolves.toBeUndefined()
+    expect(transport.pullCalls).toContain('A')
+  })
+
+  it('keeps mutations enqueued after the failed batch when discarding', async () => {
+    let releasePush!: () => void
+    const gate = new Promise<void>(r => {
+      releasePush = r
+    })
+    const gatedTransport: SyncTransport = {
+      async pull<T extends RowWithId>(): Promise<{ rows: T[] }> {
+        return { rows: [] }
+      },
+      async push<T extends RowWithId>(): Promise<SyncPushResult<T>> {
+        tableA.update('a1', { title: 'written during push' })
+        await gate
+        throw new Error('permanent rejection')
+      },
+    }
+    const engine = new SyncEngine({
+      transport: gatedTransport,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: () => 'discard',
+    })
+    engine.registerTable('A', tableA, tableA.queue)
+
+    tableA.insert({ id: 'a1', title: 'A1' })
+    const p = engine.sync()
+    releasePush()
+    await expect(p).rejects.toThrow()
+
+    // The discard must respect the push boundary (#109): the write that landed
+    // mid-push was never part of the poisoned batch.
+    expect(tableA.queue.getMerged()).toHaveLength(1)
+    expect(tableA.queue.getMerged()[0].data).toMatchObject({ title: 'written during push' })
+  })
+
+  it('a pull failure never dead-letters pending mutations', async () => {
+    const poisoned: PoisonedMutationInfo[] = []
+    const pullFails: SyncTransport = {
+      async pull<T extends RowWithId>(): Promise<{ rows: T[] }> {
+        throw new Error('network down')
+      },
+      async push<T extends RowWithId>(
+        _table: string,
+        mutations: MergedMutation<T>[]
+      ): Promise<SyncPushResult<T>> {
+        return { success: true, appliedIds: mutations.map(m => m.id) }
+      },
+    }
+    const engine = new SyncEngine({
+      transport: pullFails,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: info => {
+        poisoned.push(info)
+      },
+    })
+    engine.registerTable('A', tableA, tableA.queue)
+
+    tableA.insert({ id: 'a1', title: 'A1' })
+    await expect(engine.sync()).rejects.toThrow()
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(poisoned).toHaveLength(0)
+  })
+
+  // ── Backoff on background attempts ──────────────────────────────────
+
+  it('backs off a failing table between auto-sync ticks', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine({ maxRetries: 0, retryBaseDelayMs: 1000 })
+      transport.failingTables.add('A')
+      tableA.insert({ id: 'a1', title: 'A1' })
+
+      engine.startAutoSync(100)
+
+      // Ticks at 100/200/300 — only the first attempt gets through, the rest
+      // fall inside the 1000ms backoff window.
+      await vi.advanceTimersByTimeAsync(350)
+      expect(transport.pushCallsFor('A')).toBe(1)
+
+      // The tick at 1100 is past the backoff deadline.
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(transport.pushCallsFor('A')).toBe(2)
+
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a backed-off table does not hold back a healthy one', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine({ maxRetries: 0, retryBaseDelayMs: 1000 })
+      transport.failingTables.add('A')
+      tableA.insert({ id: 'a1', title: 'A1' })
+
+      engine.startAutoSync(100)
+      await vi.advanceTimersByTimeAsync(350)
+
+      expect(transport.pushCallsFor('A')).toBe(1)
+      expect(transport.pullCalls.filter(t => t === 'B').length).toBeGreaterThanOrEqual(3)
+
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resetRetryState clears the backoff window', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine({ maxRetries: 0, retryBaseDelayMs: 1000 })
+      transport.failingTables.add('A')
+      tableA.insert({ id: 'a1', title: 'A1' })
+
+      engine.startAutoSync(100)
+      await vi.advanceTimersByTimeAsync(150)
+      expect(transport.pushCallsFor('A')).toBe(1)
+
+      engine.resetRetryState('A')
+      await vi.advanceTimersByTimeAsync(100)
+      expect(transport.pushCallsFor('A')).toBe(2)
+
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('an explicit sync() ignores the backoff window', async () => {
+    const engine = createEngine({ maxRetries: 0, retryBaseDelayMs: 60_000 })
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+
+    await expect(engine.sync()).rejects.toThrow()
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(transport.pushCallsFor('A')).toBe(2)
+  })
+
+  // ── Background paths surface errors ─────────────────────────────────
+
+  it('a failing debounced push emits error events instead of swallowing them', async () => {
+    const engine = createEngine({ pushDebounceMs: 20, retryBaseDelayMs: 0 })
+    const events: SyncEvent[] = []
+    engine.on(e => events.push(e))
+
+    transport.failingTables.add('A')
+    tableA.insert({ id: 'a1', title: 'A1' })
+    engine.schedulePush()
+
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(events.some(e => e.type === 'error' && e.table === 'A')).toBe(true)
+    // ...plus a table-less event marking the whole background attempt failed.
+    expect(events.some(e => e.type === 'error' && e.table === undefined)).toBe(true)
+
+    engine.dispose()
+  })
+
+  it('a failing auto-sync tick emits error events instead of swallowing them', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine({ retryBaseDelayMs: 0 })
+      const events: SyncEvent[] = []
+      engine.on(e => events.push(e))
+
+      transport.failingTables.add('A')
+      tableA.insert({ id: 'a1', title: 'A1' })
+
+      engine.startAutoSync(50)
+      await vi.advanceTimersByTimeAsync(60)
+
+      expect(events.some(e => e.type === 'error' && e.table === 'A')).toBe(true)
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Two sync-engine defects fixed on one branch (same file, interacting through the clear-with-boundary path):

**#131 — conflict durability.** A custom conflict resolver's merged row was applied locally without recording a mutation and then cleared from the queue — never pushed, reverted by the next pull. The resolver's row is now re-enqueued via `queue.push('update', ...)`, riding the existing seq-boundary mechanism; resolutions for locally-deleted rows re-materialize the row. `SyncPushResult` gains an optional `appliedIds` contract: when present it is authoritative (honored even on hard failure); when absent the engine infers everything-applied on `success:true` and **nothing** on `success:false` — so a rejected batch's non-conflicting mutations stay queued instead of being cleared as if applied.

**#132 — failure isolation.** `sync()` now wraps each table in its own try/catch: per-table `error` events, remaining tables still sync, and a `SyncError` aggregate (with `tableErrors`) is rethrown at the end so `await sync()` still rejects. Exponential backoff gates background attempts only (auto-sync/debounce) — explicit `sync()`/`push()`/`pull()` always run, with `resetRetryState()` for a "Retry" button. After N consecutive push failures a `mutation-dead` event fires and the `onPoisonedMutation` hook can return `'discard' | 'retain'`; only push failures count (a pull failure never costs pending writes), and discard respects the push boundary.

Bonus: the `any`-typed `TableBinding` is replaced with structural `SyncAdapter`/`SyncQueue` slices — the engine is now `any`-free. 20 new tests (all red before the fix); #109/#110/#104 regression tests untouched and green.

## Related Issues

Closes #131
Closes #132

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (898 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_