### PR TITLE
docs: slim down README and defer details to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,63 +4,34 @@
 
 Abstracts the repetitive Sheets CRUD + query logic when developing GAS (Google Apps Script) applications.
 
-## ✨ Core Values
+**📖 Full documentation lives in the [wiki](https://juhyeonni.github.io/gas-sheets-query/) — this README is just the tour.**
 
-- 🔌 **Plug & Play** - Minimal configuration, ready to use
-- 🛡️ **Type-safe** - Schema definition → automatic type inference
-- ⚡ **Performance** - Fetch only needed data (indexing, partial reads)
-- 🔄 **Portability** - Supports both GAS + local development environments
-- 🧩 **Extensibility** - JOIN, Aggregation, Migration support
+## ✨ Highlights
 
-## 📦 Package Structure
+- 🔌 **Plug & Play** — minimal configuration, works bound to a Sheet or with an explicit spreadsheet ID
+- 🛡️ **Type-safe** — schema definition → generated types and a typed client (strict TS, no `any`)
+- ⚡ **Sheets-aware I/O** — one bulk read per query with per-execution caching, batched range writes, script-locked mutations
+- 🔄 **Portability** — the same code runs on GAS (`SheetsAdapter`), in tests (`MockAdapter` + `@gsquery/core/testing` fakes), and in the browser (`@gsquery/client` local-first adapter)
+- 🧩 **Extensibility** — query builder, JOIN, aggregation, schema migrations, code-gen CLI
 
-```
-gas-sheets-query/
-├── packages/
-│   ├── core/       # Core library (SheetsDB, QueryBuilder)
-│   ├── cli/        # CLI tools (gsquery)
-│   ├── client/     # Generated typed client runtime
-│   └── skills/     # AI coding assistant context files (@gsquery/skills)
-```
+## 📦 Packages
+
+| Package | Purpose |
+|---|---|
+| `@gsquery/core` | SheetsDB, query builder, adapters, migrations |
+| `@gsquery/cli` | `gsquery` — codegen, migration scaffolding |
+| `@gsquery/client` | Browser runtime: typed client + local-first sync |
+| `@gsquery/skills` | Context files for AI coding assistants |
 
 ## 🚀 Quick Start
 
-### 1. Installation
-
 ```bash
-# npm
-npm install @gsquery/core
-
-# pnpm (recommended)
-pnpm add @gsquery/core
+pnpm add @gsquery/core   # or: npm install @gsquery/core
 ```
-
-### 2. Define Schema
-
-```yaml
-# schema.gsq.yaml
-tables:
-  User:
-    fields:
-      id: number @id @default(autoincrement)
-      email: string @unique
-      name: string
-      role: string @default("USER")
-      createdAt: datetime @default(now)
-```
-
-### 3. Generate Types
-
-```bash
-npx gsquery generate
-```
-
-### 4. Usage
 
 ```typescript
-import { defineSheetsDB, MockAdapter } from '@gsquery/core'
+import { defineSheetsDB } from '@gsquery/core'
 
-// Create DB instance (mock: true for testing)
 const db = defineSheetsDB({
   tables: {
     users: {
@@ -68,17 +39,11 @@ const db = defineSheetsDB({
       types: { id: 0, name: '', email: '', role: '' }
     }
   },
-  mock: true  // Auto-creates MockAdapter for all tables
-  // For production, use stores: { users: new SheetsAdapter({...}) }
+  mock: true  // in-memory for tests; use stores: { users: new SheetsAdapter({...}) } on GAS
 })
 
-// CRUD
 const user = db.from('users').create({ name: 'John', email: 'john@example.com', role: 'USER' })
-const found = db.from('users').findById(user.id)
-db.from('users').update(user.id, { role: 'ADMIN' })
-db.from('users').delete(user.id)
 
-// Query
 const admins = db.from('users')
   .query()
   .where('role', '=', 'ADMIN')
@@ -87,110 +52,38 @@ const admins = db.from('users')
   .exec()
 ```
 
-## 🛠 CLI Commands
+Schema-first instead? Define `schema.gsq.yaml` and run `npx gsquery generate` — see [Quick Start](https://juhyeonni.github.io/gas-sheets-query/quick-start) and [Schema Definition](https://juhyeonni.github.io/gas-sheets-query/schema-definition).
+
+## 🛠 CLI
 
 | Command | Description |
 |---------|-------------|
-| `gsquery init` | Initialize project (creates gsq.config.json) |
+| `gsquery init` | Initialize project (creates `gsquery.config.json`) |
 | `gsquery generate` | Generate types/client code from schema |
-| `gsquery migration:create <name>` | Create new migration file |
-| `gsquery migrate` | Run migrations |
-| `gsquery rollback` | Rollback last migration |
+| `gsquery generate --client` | Also generate the typed client into your project |
+| `gsquery migration:create <name>` | Create a migration file |
+| `gsquery migrate` / `gsquery rollback` | **Preview** migrations/rollbacks — execution happens in the GAS runtime via `MigrationRunner` |
 
-```bash
-# Initialize
-npx gsquery init --spreadsheet-id YOUR_SPREADSHEET_ID
-
-# Generate types
-npx gsquery generate
-
-# Migration
-npx gsquery migration:create add_users_table
-npx gsquery migrate
-npx gsquery rollback
-```
+Details: [CLI Reference](https://juhyeonni.github.io/gas-sheets-query/cli-reference) · [Migration System](https://juhyeonni.github.io/gas-sheets-query/migration-system)
 
 ## 📚 Documentation
 
-- [Getting Started](./docs/getting-started.md) - Step-by-step guide
-- [API Reference](./docs/api-reference.md) - Detailed API documentation
-- [Examples](./docs/examples.md) - Practical examples
-- [Schema Syntax](./docs/schema-syntax.md) - Schema syntax guide
+- [Installation](https://juhyeonni.github.io/gas-sheets-query/installation) · [Quick Start](https://juhyeonni.github.io/gas-sheets-query/quick-start)
+- [Query Builder](https://juhyeonni.github.io/gas-sheets-query/query-builder) · [JOIN](https://juhyeonni.github.io/gas-sheets-query/join-queries) · [Aggregation](https://juhyeonni.github.io/gas-sheets-query/aggregation)
+- [Adapters](https://juhyeonni.github.io/gas-sheets-query/adapters) · [ID Modes](https://juhyeonni.github.io/gas-sheets-query/id-modes) · [Error Handling](https://juhyeonni.github.io/gas-sheets-query/error-handling)
+- [Typed Client](https://juhyeonni.github.io/gas-sheets-query/typed-client) · [Indexing & Performance](https://juhyeonni.github.io/gas-sheets-query/indexing-and-performance)
+- [API Reference](https://juhyeonni.github.io/gas-sheets-query/api-reference)
 
-## 🎯 Key Features
+## ⚠️ Limitations
 
-### Query Builder
+Google Sheets is not a database engine — know what you're trading:
 
-```typescript
-// Basic query
-const users = db.from('users')
-  .query()
-  .where('active', '=', true)
-  .where('age', '>', 18)
-  .orderBy('name', 'asc')
-  .limit(10)
-  .exec()
-
-// Convenience methods
-db.from('users').query().whereEq('role', 'ADMIN')
-db.from('users').query().whereIn('status', ['ACTIVE', 'PENDING'])
-db.from('users').query().whereLike('name', 'John%')
-```
-
-### Aggregation
-
-```typescript
-// Single aggregation
-const count = db.from('orders').query().count()
-const total = db.from('orders').query().sum('amount')
-
-// Group by aggregation
-const stats = db.from('orders')
-  .query()
-  .groupBy('status')
-  .agg({
-    count: 'count',
-    totalAmount: 'sum:amount',
-    avgAmount: 'avg:amount'
-  })
-// [{ status: 'PAID', count: 10, totalAmount: 5000, avgAmount: 500 }, ...]
-```
-
-### JOIN
-
-```typescript
-const postsWithAuthors = db.from('posts')
-  .joinQuery()
-  .join('users', 'authorId', 'id', { as: 'author' })
-  .where('status', '=', 'PUBLISHED')
-  .exec()
-
-// Result: [{ id, title, author: { id, name, email } }, ...]
-```
-
-### Migration
-
-```typescript
-// migrations/001_add_users.ts
-export const migration = {
-  version: 1,
-  name: 'add_users_table',
-  up: (db) => {
-    db.addColumn('users', 'nickname', { default: '' })
-  },
-  down: (db) => {
-    db.removeColumn('users', 'nickname')
-  }
-}
-```
-
-## 🗺 Roadmap
-
-- [x] v0.1 - Core (MVP): Basic CRUD + Query Builder
-- [x] v0.2 - Performance: Optimization, Batch, Indexing
-- [x] v0.3 - Advanced Query: JOIN, Aggregation
-- [x] v0.4 - DX: Migration, Schema Generator, CLI
-- [ ] v1.0 - Production: npm publish, integration testing, release
+- **No transactions** — mutations are script-locked but not atomic across multiple operations; there is no rollback of applied writes.
+- **Full-table reads** — queries read the data block once per execution and filter in memory; fine for thousands of rows, not for hundreds of thousands. Sheets caps at 10M cells.
+- **Per-execution cache** — an adapter instance snapshots the sheet on first read; writes from other executions are invisible until `clearCache()` or a new execution.
+- **Schema `@unique` / `@@index` are declarative only** — parsed and emitted, but not enforced at runtime; indexes accelerate the mock/local adapters, not `SheetsAdapter`.
+- **Local-first client is single-tab** — two tabs sharing the same namespace can clobber each other's queued mutations.
+- **Formula escaping is on by default** — user-supplied strings are stored as literal text (never executed as formulas); opt out per adapter with `allowFormulas: true` if you intentionally store formulas.
 
 ## 🤖 AI Coding Assistants
 
@@ -202,11 +95,7 @@ npx openskills install @gsquery/skills
 
 ## 🤝 Contributing
 
-Issues and PRs are welcome! Please read:
-
-- [Contributing Guide](./CONTRIBUTING.md)
-- [Code of Conduct](./CODE_OF_CONDUCT.md)
-- [Security Policy](./SECURITY.md)
+Issues and PRs are welcome! Please read the [Contributing Guide](./CONTRIBUTING.md), [Code of Conduct](./CODE_OF_CONDUCT.md), and [Security Policy](./SECURITY.md).
 
 ## 📝 License
 


### PR DESCRIPTION
## Summary

Rewrites the root README as a concise tour (213 → ~110 lines) that defers deep-dive content to the wiki, now that the Docusaurus site covers installation, query building, adapters, migrations, CLI, and the typed client.

Accuracy fixes baked in:
- `gsquery migrate`/`rollback` are labeled **preview-only** (execution happens in the GAS runtime) — the old README claimed they run migrations.
- Config filename corrected to `gsquery.config.json` (was `gsq.config.json`).
- The "fetch only needed data (indexing, partial reads)" performance claim is replaced with what the library actually does (bulk read + per-execution cache, batched range writes, script-locked mutations); indexing is honestly scoped to mock/local adapters.
- New **Limitations** section: no transactions, full-table reads, cache staleness, declarative-only `@unique`/`@@index`, single-tab local client, formula escaping default.
- Mentions the previously undocumented `@gsquery/client` local-first runtime and `@gsquery/core/testing` fakes; drops the stale roadmap.

The quick-start snippet was extracted and type-checked against core source as written (zero snippet errors). Wiki links use the site's `routeBasePath: '/'` URLs.

## Related Issues

Closes #145
Related: #141 (wiki-side drift tracked there)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [ ] Tests added or updated (docs-only)
- [x] `pnpm test` passes (unaffected)
- [x] `pnpm build` passes (unaffected)
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_