### PR TITLE
test: add real-GAS E2E harness with golden suite and CI workflow

### DIFF
--- a/.github/workflows/gas-e2e.yml
+++ b/.github/workflows/gas-e2e.yml
@@ -1,0 +1,74 @@
+name: GAS E2E (real Apps Script)
+
+# Runs the golden suite inside a real Apps Script deployment against a real
+# spreadsheet. Requires one-time setup (see e2e/gas/README.md):
+#   secrets.CLASPRC_JSON   — contents of ~/.clasprc.json from `clasp login`
+#                            (OAuth app must be in Production mode, or the
+#                            refresh token dies after 7 days)
+#   secrets.GAS_E2E_URL    — the deployed web app /exec URL
+#   secrets.GAS_E2E_TOKEN  — optional; must match Script Property E2E_TOKEN
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * 0' # weekly, Sunday 20:00 UTC (Monday 05:00 KST)
+
+jobs:
+  gas-e2e:
+    runs-on: ubuntu-latest
+    if: ${{ vars.GAS_E2E_ENABLED == 'true' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install and bundle harness
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @gsquery/gas-e2e-harness build
+
+      - name: Push harness to Apps Script
+        env:
+          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
+          CLASP_JSON: ${{ secrets.CLASP_JSON }}
+        run: |
+          echo "$CLASPRC_JSON" > ~/.clasprc.json
+          echo "$CLASP_JSON" > e2e/gas/.clasp.json
+          cd e2e/gas
+          npx @google/clasp push --force
+
+      - name: Run golden suite
+        env:
+          URL: ${{ secrets.GAS_E2E_URL }}
+          TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
+        run: |
+          set -euo pipefail
+          RESULT=$(curl -sSL "${URL}?action=run&token=${TOKEN}")
+          echo "$RESULT" | python3 -m json.tool
+          echo "$RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
+
+      - name: Lock contention — parallel bursts
+        env:
+          URL: ${{ secrets.GAS_E2E_URL }}
+          TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -sSL "${URL}?action=cleanup&token=${TOKEN}" > /dev/null
+          curl -sSL "${URL}?action=burst&tag=left&n=25&token=${TOKEN}" > left.json &
+          curl -sSL "${URL}?action=burst&tag=right&n=25&token=${TOKEN}" > right.json &
+          wait
+          cat left.json right.json
+          CHECK=$(curl -sSL "${URL}?action=burstCheck&expect=50&token=${TOKEN}")
+          echo "$CHECK" | python3 -m json.tool
+          echo "$CHECK" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
+
+      - name: Cleanup test sheets
+        if: always()
+        env:
+          URL: ${{ secrets.GAS_E2E_URL }}
+          TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
+        run: curl -sSL "${URL}?action=cleanup&token=${TOKEN}" || true

--- a/e2e/gas/.clasp.json.example
+++ b/e2e/gas/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "PASTE_YOUR_STANDALONE_SCRIPT_ID_HERE",
+  "rootDir": "dist"
+}

--- a/e2e/gas/.gitignore
+++ b/e2e/gas/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.clasp.json

--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -1,0 +1,68 @@
+# GAS E2E Harness
+
+Runs a golden test suite for `@gsquery/core` **inside a real Apps Script runtime against a real Google Spreadsheet** — the behaviors unit tests can only approximate with fakes:
+
+- Real `USER_ENTERED` parsing semantics (formula-injection escaping round-trips, the #130 assumption)
+- Real date/timezone cell coercion through `columnTypes`
+- Real `LockService` contention (two parallel web-app calls bursting inserts into one sheet)
+- Physical migration `addColumn` on a live sheet (header insert + single-pass backfill, #127)
+- `DuplicateIdError`, batch write correctness, stale-index safety — all against the live API
+
+The same suite also runs locally against the in-repo fakes (`local-check.test.ts`), so a red result in real GAS indicts a platform assumption, not the test code.
+
+## Test spreadsheet
+
+A dedicated spreadsheet already exists (owned by the repo owner):
+
+- **Name**: `gsquery-e2e-test (DO NOT EDIT — automated GAS integration tests)`
+- **ID**: `1q7ohGZIKdier53G87UqeS34tL1p5ldfw8-7pW8PZnLM` (the harness default; override with Script Property `GSQUERY_E2E_SPREADSHEET_ID`)
+
+The harness creates sheets named `e2e_<runId>_*`, and deletes them after each run (`?action=cleanup` removes any leftovers).
+
+## One-time setup (~10 minutes, needs your Google login)
+
+1. **Create a standalone Apps Script project** at [script.google.com](https://script.google.com) named e.g. `gsquery-e2e-harness`, and copy its Script ID (Project Settings → IDs).
+2. **Local push**:
+   ```bash
+   cd e2e/gas
+   cp .clasp.json.example .clasp.json   # paste the Script ID
+   pnpm --filter @gsquery/gas-e2e-harness build
+   npx @google/clasp login               # one-time browser OAuth
+   npx @google/clasp push --force
+   ```
+3. **First run in the editor**: open the project, run `runAllTests` once — this triggers the OAuth consent for the spreadsheet scope. Check the log for the JSON result.
+4. **Deploy as web app** (for CI): Deploy → New deployment → Web app, *Execute as: me*, *Access: anyone*. Copy the `/exec` URL.
+   Optionally set Script Properties: `E2E_TOKEN` (shared secret CI must echo), `GSQUERY_E2E_SPREADSHEET_ID` (to point at a different sheet).
+5. **Wire CI** (repo → Settings):
+   - Variable `GAS_E2E_ENABLED` = `true`
+   - Secret `CLASPRC_JSON` = contents of `~/.clasprc.json` (from step 2's login)
+   - Secret `CLASP_JSON` = contents of `e2e/gas/.clasp.json`
+   - Secret `GAS_E2E_URL` = the `/exec` URL — Secret `GAS_E2E_TOKEN` = the token (empty if unset)
+
+   > ⚠️ If the OAuth client behind `clasp login` belongs to a GCP project whose consent screen is in **Testing** mode, its refresh token dies every 7 days. Use the default clasp client (Google's, production) or move your consent screen to Production.
+
+Then: **Actions → "GAS E2E (real Apps Script)" → Run workflow.** It also runs weekly.
+
+## What CI does
+
+1. Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`) and `clasp push`es it.
+2. `GET ?action=run` — full golden suite, asserts `ok: true` from the JSON report.
+3. Fires two parallel `?action=burst&n=25` requests, then `?action=burstCheck&expect=50` — verifies the real script lock: 50 rows, 50 unique ids, no overwrites.
+4. `?action=cleanup` — removes all `e2e_*` sheets.
+
+## Local sanity check (no Google account needed)
+
+```bash
+pnpm --filter @gsquery/gas-e2e-harness test        # suite vs in-repo fakes
+pnpm --filter @gsquery/gas-e2e-harness typecheck
+pnpm --filter @gsquery/gas-e2e-harness build       # produces dist/Code.js
+```
+
+## Interpreting failures
+
+| Symptom | Likely meaning |
+|---|---|
+| `formula escape` test fails only in GAS | The `USER_ENTERED` apostrophe assumption in `escapeCellValue`/`unescapeCellValue` doesn't match real Sheets — a real finding, fix the adapter |
+| `burstCheck` reports duplicate ids | Real `LockService` isn't protecting the insert path — regression of #128 |
+| `date columnType` fails only in GAS | Timezone/serial-number coercion differs from the fakes — extend `deserializeByType` |
+| Suite green locally, HTTP error in CI | Deployment/auth issue (redeploy the web app, check token), not a library bug |

--- a/e2e/gas/appsscript.json
+++ b/e2e/gas/appsscript.json
@@ -1,0 +1,12 @@
+{
+  "timeZone": "Asia/Seoul",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets"
+  ],
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
+}

--- a/e2e/gas/build.mjs
+++ b/e2e/gas/build.mjs
@@ -1,0 +1,37 @@
+import { copyFileSync, mkdirSync, writeFileSync, appendFileSync } from 'node:fs'
+import * as esbuild from 'esbuild'
+
+// Single-file IIFE bundle: GAS has no module system. The library and the
+// harness are bundled together so the deployed project needs no dependencies.
+await esbuild.build({
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  outfile: 'dist/Code.js',
+  format: 'iife',
+  globalName: 'GasE2E',
+  platform: 'neutral',
+  target: 'es2020',
+  sourcemap: false
+})
+
+// GAS discovers entrypoints as top-level function declarations; re-export the
+// bundle's entrypoints as plain functions.
+appendFileSync(
+  'dist/Code.js',
+  [
+    '',
+    'function doGet(e) { return GasE2E.doGet(e) }',
+    'function runAllTests() { return GasE2E.runAllTests() }',
+    ''
+  ].join('\n')
+)
+
+mkdirSync('dist', { recursive: true })
+copyFileSync('appsscript.json', 'dist/appsscript.json')
+
+writeFileSync(
+  'dist/.claspignore',
+  ['**/**', '!Code.js', '!appsscript.json', ''].join('\n')
+)
+
+console.log('e2e/gas: bundled dist/Code.js + appsscript.json')

--- a/e2e/gas/local-check.test.ts
+++ b/e2e/gas/local-check.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Local sanity check: runs the exact E2E suite against the in-repo GAS fakes.
+ *
+ * This does NOT prove real-GAS behavior (that is the point of the deployed
+ * harness) — it proves the harness itself is sound, so a red run in real GAS
+ * indicts the platform assumption under test, not the test code.
+ */
+import { FakeSpreadsheet } from '@gsquery/core/testing'
+import { installGasFakes } from '@gsquery/core/testing'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runAll } from './src/main'
+
+const TEST_SPREADSHEET_ID = 'fake-e2e-spreadsheet'
+
+describe('gas e2e harness (against local fakes)', () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  it('runs the full golden suite green', async () => {
+    const handle = installGasFakes({
+      spreadsheets: { [TEST_SPREADSHEET_ID]: new FakeSpreadsheet(TEST_SPREADSHEET_ID) },
+      activeId: TEST_SPREADSHEET_ID
+    })
+    restore = () => handle.restore()
+
+    const result = await runAll(TEST_SPREADSHEET_ID, 'localcheck')
+
+    const failures = result.results.filter(r => !r.ok)
+    expect(failures, JSON.stringify(failures, null, 2)).toEqual([])
+    expect(result.total).toBeGreaterThanOrEqual(11)
+    expect(result.ok).toBe(true)
+  })
+})

--- a/e2e/gas/package.json
+++ b/e2e/gas/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@gsquery/gas-e2e-harness",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@gsquery/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/google-apps-script": "^2.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.9.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/e2e/gas/src/main.ts
+++ b/e2e/gas/src/main.ts
@@ -1,0 +1,193 @@
+/**
+ * GAS entrypoints for the E2E harness.
+ *
+ * Deployed as a web app (`clasp push` + one-time deploy), then driven by CI:
+ *   GET ?action=run                        → run the golden suite, JSON result
+ *   GET ?action=burst&tag=a&n=25           → insert n auto-id rows (call twice in parallel)
+ *   GET ?action=burstCheck&expect=50       → verify unique ids and row count after a burst pair
+ *   GET ?action=cleanup                    → delete all e2e_* sheets
+ *
+ * If a Script Property `E2E_TOKEN` is set, every request must carry the same
+ * value as `?token=`. The spreadsheet is resolved from the Script Property
+ * `GSQUERY_E2E_SPREADSHEET_ID`, falling back to the checked-in default.
+ */
+import { SheetsAdapter } from '@gsquery/core'
+import { clearTests, runSuite } from './runner'
+import { registerTests } from './tests'
+import type { SuiteResult } from './runner'
+
+/** Dedicated test spreadsheet (owned by the repo owner's account). */
+const DEFAULT_SPREADSHEET_ID = '1q7ohGZIKdier53G87UqeS34tL1p5ldfw8-7pW8PZnLM'
+
+const BURST_SHEET = 'e2e_burst'
+
+interface BurstRow {
+  id: string | number
+  tag?: string
+  [key: string]: unknown
+}
+
+function getSpreadsheetId(): string {
+  if (typeof PropertiesService !== 'undefined') {
+    const configured = PropertiesService.getScriptProperties().getProperty('GSQUERY_E2E_SPREADSHEET_ID')
+    if (configured) return configured
+  }
+  return DEFAULT_SPREADSHEET_ID
+}
+
+function newRunId(): string {
+  return new Date().getTime().toString(36)
+}
+
+export async function runAll(spreadsheetId?: string, runId?: string): Promise<SuiteResult & { runId: string }> {
+  const id = spreadsheetId ?? getSpreadsheetId()
+  const rid = runId ?? newRunId()
+
+  clearTests()
+  registerTests({ spreadsheetId: id, runId: rid })
+  const suite = await runSuite()
+
+  cleanupRunSheets(id, rid)
+  return { ...suite, runId: rid }
+}
+
+/** Deletes this run's sheets when the runtime supports it (real GAS does; fakes don't). */
+function cleanupRunSheets(spreadsheetId: string, runId: string): void {
+  try {
+    const ss = SpreadsheetApp.openById(spreadsheetId) as unknown as {
+      getSheets?: () => { getName: () => string }[]
+      deleteSheet?: (sheet: unknown) => void
+    }
+    if (typeof ss.getSheets !== 'function' || typeof ss.deleteSheet !== 'function') return
+    for (const sheet of ss.getSheets()) {
+      if (sheet.getName().indexOf(`e2e_${runId}_`) === 0) {
+        ss.deleteSheet(sheet)
+      }
+    }
+  } catch {
+    // Cleanup is best-effort; leftover sheets are removed by ?action=cleanup.
+  }
+}
+
+function deleteAllE2ESheets(spreadsheetId: string): number {
+  const ss = SpreadsheetApp.openById(spreadsheetId) as unknown as {
+    getSheets?: () => { getName: () => string }[]
+    deleteSheet?: (sheet: unknown) => void
+    insertSheet?: (name: string) => unknown
+  }
+  if (typeof ss.getSheets !== 'function' || typeof ss.deleteSheet !== 'function') return 0
+  let deleted = 0
+  const sheets = ss.getSheets()
+  // A spreadsheet must keep at least one sheet; park one if everything is e2e_*.
+  if (sheets.every(s => s.getName().indexOf('e2e_') === 0) && typeof ss.insertSheet === 'function') {
+    try {
+      ss.insertSheet('keep')
+    } catch {
+      // already exists — fine
+    }
+  }
+  for (const sheet of ss.getSheets()) {
+    if (sheet.getName().indexOf('e2e_') === 0) {
+      ss.deleteSheet(sheet)
+      deleted++
+    }
+  }
+  return deleted
+}
+
+/**
+ * Insert `n` auto-id rows tagged `tag`. CI fires two of these in parallel to
+ * exercise the real LockService: with correct locking the two bursts must not
+ * collide on ids or overwrite each other's rows.
+ */
+export function burst(tag: string, n: number): { inserted: number; tag: string } {
+  const adapter = new SheetsAdapter<BurstRow>({
+    spreadsheetId: getSpreadsheetId(),
+    sheetName: BURST_SHEET,
+    columns: ['id', 'tag']
+  })
+  for (let i = 0; i < n; i++) {
+    adapter.insert({ tag: `${tag}-${i}` })
+  }
+  return { inserted: n, tag }
+}
+
+export function burstCheck(expect: number): {
+  ok: boolean
+  rowCount: number
+  uniqueIds: number
+  uniqueTags: number
+  expected: number
+} {
+  const adapter = new SheetsAdapter<BurstRow>({
+    spreadsheetId: getSpreadsheetId(),
+    sheetName: BURST_SHEET,
+    columns: ['id', 'tag']
+  })
+  adapter.clearCache()
+  const rows = adapter.findAll()
+  const ids = new Set(rows.map(r => String(r.id)))
+  const tags = new Set(rows.map(r => String(r.tag)))
+  return {
+    ok: rows.length === expect && ids.size === expect && tags.size === expect,
+    rowCount: rows.length,
+    uniqueIds: ids.size,
+    uniqueTags: tags.size,
+    expected: expect
+  }
+}
+
+function checkToken(param: string | undefined): boolean {
+  if (typeof PropertiesService === 'undefined') return true
+  const required = PropertiesService.getScriptProperties().getProperty('E2E_TOKEN')
+  if (!required) return true
+  return param === required
+}
+
+interface DoGetEvent {
+  parameter?: Record<string, string>
+}
+
+/**
+ * Web-app entrypoint. Always returns JSON.
+ *
+ * Declared async: the V8 runtime awaits the promise returned by the invoked
+ * entry function before serializing the response, which is what lets the
+ * suite's one async step (MigrationRunner.migrate) settle. If a future
+ * runtime change breaks async doGet, `runAllTests()` from the editor remains
+ * a working fallback.
+ */
+export async function doGet(e: DoGetEvent): Promise<GoogleAppsScript.Content.TextOutput> {
+  const params = e?.parameter ?? {}
+  const respond = (body: unknown): GoogleAppsScript.Content.TextOutput =>
+    ContentService.createTextOutput(JSON.stringify(body)).setMimeType(ContentService.MimeType.JSON)
+
+  if (!checkToken(params.token)) {
+    return respond({ error: 'invalid token' })
+  }
+
+  try {
+    switch (params.action) {
+      case 'run':
+        return respond(await runAll())
+      case 'burst':
+        return respond(burst(params.tag ?? 'a', Number(params.n ?? '25')))
+      case 'burstCheck':
+        return respond(burstCheck(Number(params.expect ?? '50')))
+      case 'cleanup':
+        return respond({ deleted: deleteAllE2ESheets(getSpreadsheetId()) })
+      default:
+        return respond({ error: `unknown action: ${params.action ?? '(none)'}` })
+    }
+  } catch (err) {
+    const error = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+    return respond({ error })
+  }
+}
+
+/** Editor-friendly entrypoint: run everything and log the JSON result. */
+export async function runAllTests(): Promise<SuiteResult & { runId: string }> {
+  const result = await runAll()
+  Logger.log(JSON.stringify(result, null, 2))
+  return result
+}

--- a/e2e/gas/src/runner.ts
+++ b/e2e/gas/src/runner.ts
@@ -1,0 +1,89 @@
+/**
+ * Minimal test runner for the GAS E2E harness.
+ *
+ * Kept dependency-free and synchronous-friendly so the same suite runs both
+ * inside the Apps Script runtime (bundled, via doGet/runAllTests) and in Node
+ * against the @gsquery/core/testing fakes (local sanity check).
+ */
+
+export interface TestResult {
+  name: string
+  ok: boolean
+  error?: string
+  ms: number
+}
+
+export interface SuiteResult {
+  ok: boolean
+  total: number
+  passed: number
+  failed: number
+  durationMs: number
+  results: TestResult[]
+}
+
+type TestFn = () => void | Promise<void>
+
+const registry: { name: string; fn: TestFn }[] = []
+
+export function test(name: string, fn: TestFn): void {
+  registry.push({ name, fn })
+}
+
+export function clearTests(): void {
+  registry.length = 0
+}
+
+export async function runSuite(): Promise<SuiteResult> {
+  const results: TestResult[] = []
+  const suiteStart = Date.now()
+
+  for (const { name, fn } of registry) {
+    const start = Date.now()
+    try {
+      await fn()
+      results.push({ name, ok: true, ms: Date.now() - start })
+    } catch (err) {
+      const error = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+      results.push({ name, ok: false, error, ms: Date.now() - start })
+    }
+  }
+
+  const failed = results.filter(r => !r.ok).length
+  return {
+    ok: failed === 0,
+    total: results.length,
+    passed: results.length - failed,
+    failed,
+    durationMs: Date.now() - suiteStart,
+    results
+  }
+}
+
+// ── Assertions ──────────────────────────────────────────────────────────────
+
+export function assertOk(condition: unknown, message: string): void {
+  if (!condition) throw new Error(`assertOk failed: ${message}`)
+}
+
+/** Deep equality via JSON round-trip — sufficient for row objects and arrays. */
+export function assertEq(actual: unknown, expected: unknown, message: string): void {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a !== e) {
+    throw new Error(`assertEq failed: ${message}\n  expected: ${e}\n  actual:   ${a}`)
+  }
+}
+
+export function assertThrows(fn: () => unknown, errorNameOrCode: string, message: string): void {
+  try {
+    fn()
+  } catch (err) {
+    const e = err as { name?: string; code?: string; message?: string }
+    if (e.name === errorNameOrCode || e.code === errorNameOrCode) return
+    throw new Error(
+      `assertThrows failed: ${message} — threw ${e.name ?? 'unknown'} (${e.message ?? ''}), expected ${errorNameOrCode}`
+    )
+  }
+  throw new Error(`assertThrows failed: ${message} — did not throw`)
+}

--- a/e2e/gas/src/tests.ts
+++ b/e2e/gas/src/tests.ts
@@ -1,0 +1,263 @@
+/**
+ * Golden E2E tests for @gsquery/core against a REAL Google Spreadsheet.
+ *
+ * These exercise the exact behaviors that unit tests can only verify against
+ * fakes — most importantly the assumptions about how real Sheets parses
+ * USER_ENTERED writes (formula-injection escaping, #130) and physical column
+ * insertion (migration addColumn, #127).
+ *
+ * Every test creates its own uniquely named sheet inside the configured test
+ * spreadsheet and the harness deletes all `e2e_<runId>_*` sheets afterwards
+ * (when the runtime supports sheet deletion — the Node fakes do not).
+ */
+import type { DataStore, StoreResolver } from '@gsquery/core'
+import { MigrationRunner, SheetsAdapter } from '@gsquery/core'
+import type { ColumnType } from '@gsquery/core'
+import { assertEq, assertOk, assertThrows, test } from './runner'
+
+export interface HarnessContext {
+  spreadsheetId: string
+  runId: string
+}
+
+interface E2ERow {
+  id: string | number
+  name?: string
+  note?: string
+  labels?: string[]
+  active?: boolean
+  meta?: Record<string, unknown>
+  when?: Date | string
+  status?: string
+  [key: string]: unknown
+}
+
+export function registerTests(ctx: HarnessContext): void {
+  const createdSheets: string[] = []
+
+  const sheetName = (slug: string): string => {
+    const name = `e2e_${ctx.runId}_${slug}`
+    createdSheets.push(name)
+    return name
+  }
+
+  const makeAdapter = (
+    slug: string,
+    columns: string[],
+    opts: { idMode?: 'auto' | 'client'; columnTypes?: Record<string, ColumnType>; allowFormulas?: boolean } = {}
+  ): SheetsAdapter<E2ERow> =>
+    new SheetsAdapter<E2ERow>({
+      spreadsheetId: ctx.spreadsheetId,
+      sheetName: sheetName(slug),
+      columns,
+      idMode: opts.idMode ?? 'auto',
+      columnTypes: opts.columnTypes,
+      allowFormulas: opts.allowFormulas
+    })
+
+  // ── 1. Formula-injection escaping: the #130 USER_ENTERED assumption ──────
+  test('formula escape: dangerous strings round-trip as literals, never as formulas', () => {
+    const adapter = makeAdapter('escape', ['id', 'note'], { idMode: 'client' })
+    const dangerous = ['=1+1', '=IMPORTXML("http://example.invalid/","//x")', '+2+2', '-3-3', '@sum', "'already quoted"]
+
+    dangerous.forEach((note, i) => adapter.insert({ id: `r${i}`, note }))
+
+    const rows = adapter.findAll()
+    assertEq(rows.length, dangerous.length, 'all rows inserted')
+    dangerous.forEach((note, i) => {
+      const row = rows.find(r => r.id === `r${i}`)
+      assertOk(row, `row r${i} present`)
+      assertEq(row?.note, note, `value for ${JSON.stringify(note)} survives the round trip unchanged`)
+    })
+
+    // Real-GAS-only raw check: the cell must not have become a live formula.
+    const ss = SpreadsheetApp.openById(ctx.spreadsheetId)
+    const sheet = ss.getSheetByName(`e2e_${ctx.runId}_escape`)
+    if (sheet) {
+      const range = sheet.getRange(2, 2)
+      if (typeof (range as { getFormula?: () => string }).getFormula === 'function') {
+        assertEq(range.getFormula(), '', 'cell holds literal text, not a formula')
+        const display = range.getValue()
+        assertOk(display !== 2, 'the "=1+1" cell did not evaluate to 2')
+      }
+    }
+  })
+
+  // ── 2. Date round-trip through columnTypes ────────────────────────────────
+  test('date columnType: Date survives write + read with identical timestamp', () => {
+    const adapter = makeAdapter('dates', ['id', 'when'], { columnTypes: { when: 'date' } })
+    const when = new Date('2026-03-01T10:20:30.000Z')
+    const created = adapter.insert({ when })
+
+    const found = adapter.findById(created.id)
+    assertOk(found, 'row found')
+    assertOk(found?.when instanceof Date, `deserialized as Date (got ${typeof found?.when})`)
+    assertEq((found?.when as Date).getTime(), when.getTime(), 'timestamp identical')
+  })
+
+  // ── 3. Auto-id CRUD ───────────────────────────────────────────────────────
+  test('auto-id CRUD: create, findById, update, delete', () => {
+    const adapter = makeAdapter('crud', ['id', 'name'])
+    const a = adapter.insert({ name: 'alpha' })
+    const b = adapter.insert({ name: 'beta' })
+    assertOk(a.id !== b.id, 'auto ids are distinct')
+
+    adapter.update(b.id, { name: 'beta2' })
+    assertEq(adapter.findById(b.id)?.name, 'beta2', 'update landed on the right row')
+    assertEq(adapter.findById(a.id)?.name, 'alpha', 'other row untouched')
+
+    assertOk(adapter.delete(a.id), 'delete reports success')
+    assertEq(adapter.findById(a.id), undefined, 'deleted row gone')
+    assertEq(adapter.findAll().length, 1, 'one row remains')
+  })
+
+  // ── 4. Client-mode duplicate ID rejection (#128) ─────────────────────────
+  test('client idMode: duplicate ID insert throws DuplicateIdError', () => {
+    const adapter = makeAdapter('dup', ['id', 'name'], { idMode: 'client' })
+    adapter.insert({ id: 'u-1', name: 'first' })
+    assertThrows(() => adapter.insert({ id: 'u-1', name: 'second' }), 'DUPLICATE_ID', 'second insert of u-1')
+    assertEq(adapter.findAll().length, 1, 'no duplicate row was written')
+  })
+
+  // ── 5. batchInsert ────────────────────────────────────────────────────────
+  test('batchInsert: 50 rows land with sequential auto ids', () => {
+    const adapter = makeAdapter('binsert', ['id', 'name'])
+    const rows = adapter.batchInsert(Array.from({ length: 50 }, (_, i) => ({ name: `n${i}` })))
+    assertEq(rows.length, 50, 'returned 50 rows')
+
+    const all = adapter.findAll()
+    assertEq(all.length, 50, 'sheet holds 50 rows')
+    const ids = all.map(r => Number(r.id)).sort((x, y) => x - y)
+    assertEq(ids[49] - ids[0], 49, 'ids are a contiguous run')
+  })
+
+  // ── 6. batchUpdate correctness (contiguous + scattered, #129) ────────────
+  test('batchUpdate: contiguous and scattered updates land on the right rows', () => {
+    const adapter = makeAdapter('bupdate', ['id', 'name'])
+    const rows = adapter.batchInsert(Array.from({ length: 20 }, (_, i) => ({ name: `orig${i}` })))
+
+    const targets = [0, 1, 2, 3, 9, 15, 16, 19] // one run + scattered singles + tail run
+    adapter.batchUpdate(targets.map(i => ({ id: rows[i].id, data: { name: `upd${i}` } })))
+
+    const all = adapter.findAll()
+    for (let i = 0; i < 20; i++) {
+      const row = all.find(r => r.id === rows[i].id)
+      const expected = targets.indexOf(i) !== -1 ? `upd${i}` : `orig${i}`
+      assertEq(row?.name, expected, `row ${i}`)
+    }
+  })
+
+  // ── 7. Typed columns round-trip ───────────────────────────────────────────
+  test('columnTypes: string[], boolean, json round-trip', () => {
+    const adapter = makeAdapter('typed', ['id', 'labels', 'active', 'meta'], {
+      columnTypes: { labels: 'string[]', active: 'boolean', meta: 'json' }
+    })
+    const created = adapter.insert({ labels: ['a', 'b'], active: false, meta: { k: 1, nested: { ok: true } } })
+
+    const row = adapter.findById(created.id)
+    assertEq(row?.labels, ['a', 'b'], 'string[]')
+    assertEq(row?.active, false, 'boolean false survives (not empty/"FALSE" string)')
+    assertEq(row?.meta, { k: 1, nested: { ok: true } }, 'json object')
+  })
+
+  // ── 8. Migration addColumn: physical header + single-pass backfill (#127) ─
+  test('migration addColumn: header extended, defaults backfilled, converges on rerun', async () => {
+    const slug = 'mig'
+    const name = sheetName(slug)
+    // Seed with the OLD schema (no `status` column yet).
+    const seed = new SheetsAdapter<E2ERow>({ spreadsheetId: ctx.spreadsheetId, sheetName: name, columns: ['id', 'name'] })
+    seed.insert({ name: 'row1' })
+    seed.insert({ name: 'row2' })
+
+    // New-schema adapter declares `status`; the physical sheet is behind.
+    const store = new SheetsAdapter<E2ERow>({
+      spreadsheetId: ctx.spreadsheetId,
+      sheetName: name,
+      columns: ['id', 'name', 'status']
+    })
+    const migrationsStore = makeAdapter('migrec', ['id', 'version', 'name', 'appliedAt'])
+    const runner = new MigrationRunner({
+      migrationsStore: migrationsStore as unknown as DataStore<never>,
+      storeResolver: (() => store) as unknown as StoreResolver,
+      migrations: [
+        {
+          version: 1,
+          name: 'add status',
+          up: db => db.addColumn('t', 'status', { default: 'unknown' }),
+          down: db => db.removeColumn('t', 'status')
+        }
+      ]
+    })
+
+    const result = await runner.migrate()
+    assertEq(result.currentVersion, 1, 'version advanced')
+
+    const rows = store.findAll()
+    assertEq(rows.length, 2, 'both rows present after migration')
+    assertOk(rows.every(r => r.status === 'unknown'), 'default backfilled into every row')
+
+    // Convergence: a second migrate() must be a no-op.
+    const again = await runner.migrate()
+    assertEq(again.applied.length, 0, 'rerun applies nothing')
+  })
+
+  // ── 9. Migration addColumn for an undeclared column fails loudly (#127) ──
+  test('migration addColumn: undeclared column fails and does not advance the version', async () => {
+    const store = makeAdapter('migbad', ['id', 'name'])
+    store.insert({ name: 'x' })
+    const migrationsStore = makeAdapter('migbadrec', ['id', 'version', 'name', 'appliedAt'])
+    const runner = new MigrationRunner({
+      migrationsStore: migrationsStore as unknown as DataStore<never>,
+      storeResolver: (() => store) as unknown as StoreResolver,
+      migrations: [
+        {
+          version: 1,
+          name: 'add ghost',
+          up: db => db.addColumn('t', 'ghost', { default: 'boo' }),
+          down: db => db.removeColumn('t', 'ghost')
+        }
+      ]
+    })
+
+    let threw = false
+    try {
+      await runner.migrate()
+    } catch {
+      threw = true
+    }
+    assertOk(threw, 'migrate() rejected')
+    assertEq(runner.getCurrentVersion(), 0, 'version did not advance')
+  })
+
+  // ── 10. Stale-index guard: delete above, then update below (#128) ────────
+  test('update after a deletion above still lands on the right record', () => {
+    const adapter = makeAdapter('shift', ['id', 'name'])
+    const r1 = adapter.insert({ name: 'one' })
+    const r2 = adapter.insert({ name: 'two' })
+    const r3 = adapter.insert({ name: 'three' })
+
+    adapter.delete(r2.id)
+    adapter.update(r3.id, { name: 'three-updated' })
+
+    assertEq(adapter.findById(r3.id)?.name, 'three-updated', 'row 3 updated')
+    assertEq(adapter.findById(r1.id)?.name, 'one', 'row 1 untouched')
+    assertEq(adapter.findAll().length, 2, 'exactly two rows remain')
+  })
+
+  // ── 11. Timing probe (informational — never fails) ───────────────────────
+  test('timing: batchInsert 100 + findAll (reported in ms via test duration)', () => {
+    const adapter = makeAdapter('timing', ['id', 'name'])
+    adapter.batchInsert(Array.from({ length: 100 }, (_, i) => ({ name: `t${i}` })))
+    adapter.clearCache()
+    const all = adapter.findAll()
+    assertEq(all.length, 100, '100 rows read back')
+  })
+
+  // Expose for cleanup by the harness entrypoint.
+  registerTests.createdSheets = createdSheets
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export declare namespace registerTests {
+  let createdSheets: string[]
+}

--- a/e2e/gas/tsconfig.json
+++ b/e2e/gas/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020"],
+    "types": ["google-apps-script"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "local-check.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,25 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
 
+  e2e/gas:
+    dependencies:
+      '@gsquery/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      '@types/google-apps-script':
+        specifier: ^2.0.0
+        version: 2.0.8
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/node@25.2.1)
+
   packages/cli:
     dependencies:
       '@gsquery/core':
@@ -118,16 +137,34 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -136,16 +173,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -154,10 +209,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -166,10 +233,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -178,10 +257,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -190,10 +281,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -202,10 +305,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -214,16 +329,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -232,10 +365,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -250,11 +395,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
@@ -262,10 +419,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -455,8 +624,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.0.18':
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
@@ -469,17 +652,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
 
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
@@ -494,9 +692,21 @@ packages:
   ast-v8-to-istanbul@0.3.11:
     resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -506,8 +716,26 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -564,12 +792,18 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -581,6 +815,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -591,6 +828,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -630,12 +871,18 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -645,8 +892,20 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
@@ -663,6 +922,11 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -702,6 +966,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.0.18:
@@ -760,64 +1052,127 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -826,13 +1181,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -959,6 +1326,14 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@types/node@25.2.1)
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -967,6 +1342,14 @@ snapshots:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@3.2.7(vite@7.3.1(@types/node@25.2.1))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.1)
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.11))':
     dependencies:
@@ -984,13 +1367,29 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.1)
 
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.18':
@@ -999,7 +1398,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -1016,7 +1425,19 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1024,7 +1445,41 @@ snapshots:
 
   commander@13.1.0: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1095,6 +1550,8 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -1104,6 +1561,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  loupe@3.2.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1119,11 +1578,15 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
   obug@2.1.1: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -1178,11 +1641,17 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -1191,7 +1660,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.0.3: {}
+
+  tinyspy@4.0.4: {}
 
   typescript@5.9.3: {}
 
@@ -1200,6 +1675,27 @@ snapshots:
   undici-types@7.16.0: {}
 
   universalify@2.0.1: {}
+
+  vite-node@3.2.4(@types/node@25.2.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.2.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite@7.3.1(@types/node@22.19.11):
     dependencies:
@@ -1224,6 +1720,47 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.1
       fsevents: 2.3.3
+
+  vitest@3.2.7(@types/node@25.2.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.1(@types/node@25.2.1))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.2.1)
+      vite-node: 3.2.4(@types/node@25.2.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@types/node@22.19.11):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'packages/*'
+  - 'e2e/*'
 
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

Adds `e2e/gas/` — a harness that runs an 11-test golden suite for `@gsquery/core` **inside a real Apps Script runtime against a real spreadsheet**, covering exactly what the in-repo fakes cannot prove:

- `USER_ENTERED` formula-escape round-trips (the #130 platform assumption) with a raw `getFormula() === ''` cell check
- Date/timezone coercion through `columnTypes`
- `DuplicateIdError` on client-mode duplicates (#128), batchInsert/batchUpdate correctness (#129), stale-index safety
- Physical migration `addColumn` with header insert + single-pass backfill and rerun convergence, plus the undeclared-column loud-failure path (#127)
- A `burst`/`burstCheck` web-app endpoint pair: CI fires two parallel bursts at one sheet to exercise the **real `LockService`** (50 rows, 50 unique ids, no overwrites)

Design: library + suite bundle into one `Code.js` (esbuild IIFE) with `runAllTests` (editor) and an async `doGet` JSON reporter (CI). The identical suite runs against `@gsquery/core/testing` fakes in `local-check.test.ts` — verified green — so a red run in real GAS indicts the platform assumption under test, not the harness.

Infra: new private workspace package `@gsquery/gas-e2e-harness` (workspace glob `e2e/*` added); `gas-e2e.yml` workflow (manual + weekly) gated behind the `GAS_E2E_ENABLED` repo variable so it stays inert until secrets are configured. A dedicated test spreadsheet already exists and is referenced as the harness default. One-time setup (~10 min: create script project, `clasp login`, deploy web app, set secrets) is documented in `e2e/gas/README.md`, including the OAuth Testing-mode 7-day token caveat.

## Related Issues

Related: #143 (test coverage), #136/#127/#128/#129/#130 (behaviors pinned in real GAS)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (1,002 tests incl. the new local check)
- [x] `pnpm build` passes (harness bundle builds; output parses as script)
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_