### PR TITLE
fix(e2e): bundle @gsquery/core from source, not a possibly-stale dist

### DIFF
--- a/e2e/gas/build.mjs
+++ b/e2e/gas/build.mjs
@@ -1,8 +1,18 @@
 import { copyFileSync, mkdirSync, writeFileSync, appendFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import * as esbuild from 'esbuild'
+
+const here = dirname(fileURLToPath(import.meta.url))
 
 // Single-file IIFE bundle: GAS has no module system. The library and the
 // harness are bundled together so the deployed project needs no dependencies.
+//
+// IMPORTANT: '@gsquery/core' is aliased to the workspace SOURCE, not the
+// package entry. The package entry resolves to packages/core/dist, and a
+// stale local dist would silently deploy an old library to GAS — which is
+// exactly what happened on the first real run (three "missing fix" failures
+// that were really a stale bundle).
 await esbuild.build({
   entryPoints: ['src/main.ts'],
   bundle: true,
@@ -11,7 +21,10 @@ await esbuild.build({
   globalName: 'GasE2E',
   platform: 'neutral',
   target: 'es2020',
-  sourcemap: false
+  sourcemap: false,
+  alias: {
+    '@gsquery/core': resolve(here, '../../packages/core/src/index.ts')
+  }
 })
 
 // GAS discovers entrypoints as top-level function declarations; re-export the

--- a/e2e/gas/src/tests.ts
+++ b/e2e/gas/src/tests.ts
@@ -196,6 +196,15 @@ export function registerTests(ctx: HarnessContext): void {
     assertEq(rows.length, 2, 'both rows present after migration')
     assertOk(rows.every(r => r.status === 'unknown'), 'default backfilled into every row')
 
+    // The physical header row must actually contain the new column — this is
+    // what separates the real #127 fix (header insert + backfill) from the
+    // old value-backfill that left the sheet header untouched.
+    const ss = SpreadsheetApp.openById(ctx.spreadsheetId)
+    const sheet = ss.getSheetByName(name)
+    assertOk(sheet, 'migrated sheet exists')
+    const header = sheet ? (sheet.getRange(1, 1, 1, 3).getValues()[0] as string[]) : []
+    assertEq(header, ['id', 'name', 'status'], 'physical header row extended')
+
     // Convergence: a second migrate() must be a no-op.
     const again = await runner.migrate()
     assertEq(again.applied.length, 0, 'rerun applies nothing')

--- a/e2e/gas/vitest.config.ts
+++ b/e2e/gas/vitest.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+// Match build.mjs: resolve @gsquery/core to workspace SOURCE so the local
+// check exercises the same code the GAS bundle ships, independent of any
+// stale packages/core/dist on the machine.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@gsquery/core/testing': resolve(__dirname, '../../packages/core/src/testing/index.ts'),
+      '@gsquery/core': resolve(__dirname, '../../packages/core/src/index.ts')
+    }
+  },
+  test: {
+    include: ['local-check.test.ts']
+  }
+})


### PR DESCRIPTION
## Summary

The first real-GAS run of the E2E harness failed 3/11 tests — formula escaping, `DuplicateIdError`, and the undeclared-column migration failure — which are exactly the code paths added by the recent fix batch (#130/#128/#127). Diagnosis: the harness bundled the `@gsquery/core` **package entry**, which resolves to `packages/core/dist`, and a stale local dist silently shipped an old library to Apps Script. The 8 passing tests were all pre-batch behaviors, consistent with that.

Fixes:
- `build.mjs` and a new `vitest.config.ts` alias `@gsquery/core` (and `/testing`) to the **workspace source**, so the deployed bundle and the local check always match the checkout regardless of dist state. Verified: the rebuilt bundle now contains `escapeCellValue`/`DUPLICATE_ID`/`UNKNOWN_COLUMN`.
- The `addColumn` golden test now asserts the **physical header row** (`['id','name','status']`) — the diagnosis revealed the old value-backfill behavior passed the test unnoticed because it only checked deserialized rows.

## Related Issues

Follow-up to #159.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated (header assertion)
- [x] `pnpm test` passes (local check green against source alias)
- [x] `pnpm build` passes (bundle rebuilt and content-verified)
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_