### PR TITLE
fix(ci): redeploy the web app after clasp push, add curl-only mode

### DIFF
--- a/.github/workflows/gas-e2e.yml
+++ b/.github/workflows/gas-e2e.yml
@@ -1,12 +1,21 @@
 name: GAS E2E (real Apps Script)
 
 # Runs the golden suite inside a real Apps Script deployment against a real
-# spreadsheet. Requires one-time setup (see e2e/gas/README.md):
-#   secrets.CLASPRC_JSON   — contents of ~/.clasprc.json from `clasp login`
-#                            (OAuth app must be in Production mode, or the
-#                            refresh token dies after 7 days)
-#   secrets.GAS_E2E_URL    — the deployed web app /exec URL
-#   secrets.GAS_E2E_TOKEN  — optional; must match Script Property E2E_TOKEN
+# spreadsheet. Two modes, selected by which secrets exist (see e2e/gas/README.md):
+#
+#   curl-only (minimum viable):
+#     secrets.GAS_E2E_URL           — deployed web app /exec URL
+#     secrets.GAS_E2E_TOKEN         — optional; must match Script Property E2E_TOKEN
+#     → runs the suite against whatever version is currently deployed.
+#
+#   full (also pushes the current checkout and redeploys before testing):
+#     secrets.CLASPRC_JSON          — contents of ~/.clasprc.json from `clasp login`
+#     secrets.CLASP_JSON            — contents of e2e/gas/.clasp.json
+#     secrets.GAS_E2E_DEPLOYMENT_ID — the web app deployment id (AKfycb… — from
+#                                     `clasp deployments` or the /exec URL)
+#     → `clasp push` updates HEAD, then `clasp deploy -i` re-versions the SAME
+#       deployment so the /exec URL serves the just-pushed code. Without the
+#       redeploy step the URL would keep serving the old version.
 on:
   workflow_dispatch:
   schedule:
@@ -17,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ vars.GAS_E2E_ENABLED == 'true' }}
     timeout-minutes: 20
+    env:
+      HAS_CLASP: ${{ secrets.CLASPRC_JSON != '' && secrets.CLASP_JSON != '' && secrets.GAS_E2E_DEPLOYMENT_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -27,19 +38,24 @@ jobs:
           cache: pnpm
 
       - name: Install and bundle harness
+        if: ${{ env.HAS_CLASP == 'true' }}
         run: |
           pnpm install --frozen-lockfile
           pnpm --filter @gsquery/gas-e2e-harness build
 
-      - name: Push harness to Apps Script
+      - name: Push current checkout and redeploy the web app
+        if: ${{ env.HAS_CLASP == 'true' }}
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
           CLASP_JSON: ${{ secrets.CLASP_JSON }}
+          DEPLOYMENT_ID: ${{ secrets.GAS_E2E_DEPLOYMENT_ID }}
         run: |
+          set -euo pipefail
           echo "$CLASPRC_JSON" > ~/.clasprc.json
           echo "$CLASP_JSON" > e2e/gas/.clasp.json
           cd e2e/gas
           npx @google/clasp push --force
+          npx @google/clasp deploy -i "$DEPLOYMENT_ID" -d "ci ${GITHUB_SHA::7}"
 
       - name: Run golden suite
         env:

--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -33,19 +33,30 @@ The harness creates sheets named `e2e_<runId>_*`, and deletes them after each ru
 3. **First run in the editor**: open the project, run `runAllTests` once — this triggers the OAuth consent for the spreadsheet scope. Check the log for the JSON result.
 4. **Deploy as web app** (for CI): Deploy → New deployment → Web app, *Execute as: me*, *Access: anyone*. Copy the `/exec` URL.
    Optionally set Script Properties: `E2E_TOKEN` (shared secret CI must echo), `GSQUERY_E2E_SPREADSHEET_ID` (to point at a different sheet).
-5. **Wire CI** (repo → Settings):
-   - Variable `GAS_E2E_ENABLED` = `true`
-   - Secret `CLASPRC_JSON` = contents of `~/.clasprc.json` (from step 2's login)
-   - Secret `CLASP_JSON` = contents of `e2e/gas/.clasp.json`
-   - Secret `GAS_E2E_URL` = the `/exec` URL — Secret `GAS_E2E_TOKEN` = the token (empty if unset)
+5. **Wire CI** (from a machine where steps 2–4 are done; uses the `gh` CLI):
 
-   > ⚠️ If the OAuth client behind `clasp login` belongs to a GCP project whose consent screen is in **Testing** mode, its refresh token dies every 7 days. Use the default clasp client (Google's, production) or move your consent screen to Production.
+   ```bash
+   REPO=juhyeonni/gas-sheets-query
+   gh variable set GAS_E2E_ENABLED -b true -R $REPO
+   gh secret set GAS_E2E_URL   -b "https://script.google.com/macros/s/DEPLOYMENT_ID/exec" -R $REPO
+   gh secret set GAS_E2E_TOKEN -b "your-token-or-empty" -R $REPO
+   # Full mode (CI pushes the current checkout and redeploys before testing):
+   gh secret set CLASPRC_JSON < ~/.clasprc.json                       # -R $REPO
+   gh secret set CLASP_JSON   < e2e/gas/.clasp.json                   # -R $REPO
+   gh secret set GAS_E2E_DEPLOYMENT_ID -b "AKfycb..." -R $REPO        # from `npx @google/clasp deployments`
+   ```
+
+   Two modes, chosen automatically by which secrets exist:
+   - **curl-only** (just `GAS_E2E_URL`/`GAS_E2E_TOKEN`): tests whatever version is currently deployed. Zero token maintenance.
+   - **full** (also the three clasp secrets): CI pushes the current checkout and re-versions the SAME deployment (`clasp deploy -i`) so the `/exec` URL serves the just-pushed code — without that redeploy, `clasp push` alone would leave the URL serving the old version.
+
+   > ⚠️ If the OAuth client behind `clasp login` belongs to a GCP project whose consent screen is in **Testing** mode, its refresh token dies every 7 days. The stock clasp client (Google's, production) does not have this problem.
 
 Then: **Actions → "GAS E2E (real Apps Script)" → Run workflow.** It also runs weekly.
 
 ## What CI does
 
-1. Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`) and `clasp push`es it.
+1. *(full mode)* Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`), `clasp push`es it, and redeploys the web app to the new version.
 2. `GET ?action=run` — full golden suite, asserts `ok: true` from the JSON report.
 3. Fires two parallel `?action=burst&n=25` requests, then `?action=burstCheck&expect=50` — verifies the real script lock: 50 rows, 50 unique ids, no overwrites.
 4. `?action=cleanup` — removes all `e2e_*` sheets.


### PR DESCRIPTION
## Summary

Two fixes to the GAS E2E workflow before enabling it:

- **Stale-deployment bug**: `clasp push` only updates the script HEAD — the `/exec` web-app URL keeps serving the previously *deployed* version, so the old workflow pushed fresh code and then tested the stale deployment. Full mode now runs `clasp deploy -i <deploymentId>` after the push, re-versioning the **same** deployment (URL unchanged) so the suite always tests the just-pushed checkout. Requires the new `GAS_E2E_DEPLOYMENT_ID` secret.
- **curl-only mode**: when the three clasp secrets are absent, the push/redeploy steps skip and the workflow just drives the currently deployed harness via `GAS_E2E_URL` — a zero-token-maintenance entry point that only needs two secrets.

README updated with `gh secret set`/`gh variable set` one-liners for both modes. Workflow YAML validated.

## Related Issues

Follow-up to #159/#160.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [ ] Tests added or updated (CI config)
- [x] `pnpm test` passes (unaffected)
- [x] `pnpm build` passes (unaffected)
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_