### PR TITLE
fix(e2e): lock web app to access:MYSELF with Bearer auth; run on dev pushes

### DIFF
--- a/.github/workflows/gas-e2e.yml
+++ b/.github/workflows/gas-e2e.yml
@@ -1,33 +1,43 @@
 name: GAS E2E (real Apps Script)
 
 # Runs the golden suite inside a real Apps Script deployment against a real
-# spreadsheet. Two modes, selected by which secrets exist (see e2e/gas/README.md):
+# spreadsheet, on every dev push that touches runtime code (plus manual runs).
 #
-#   curl-only (minimum viable):
-#     secrets.GAS_E2E_URL           — deployed web app /exec URL
-#     secrets.GAS_E2E_TOKEN         — optional; must match Script Property E2E_TOKEN
-#     → runs the suite against whatever version is currently deployed.
+# The web app is locked to `access: MYSELF` — no anonymous access. CI
+# authenticates every request with a Bearer token minted from the owner's
+# clasp credentials (e2e/gas/mint-token.mjs), so CLASPRC_JSON is always
+# required. See e2e/gas/README.md.
 #
-#   full (also pushes the current checkout and redeploys before testing):
+#   always required:
 #     secrets.CLASPRC_JSON          — contents of ~/.clasprc.json from `clasp login`
+#     secrets.GAS_E2E_URL           — deployed web app /exec URL
+#   optional:
+#     secrets.GAS_E2E_TOKEN         — extra shared secret (Script Property E2E_TOKEN)
+#   full mode (push current checkout + redeploy before testing):
 #     secrets.CLASP_JSON            — contents of e2e/gas/.clasp.json
-#     secrets.GAS_E2E_DEPLOYMENT_ID — the web app deployment id (AKfycb… — from
-#                                     `clasp deployments` or the /exec URL)
-#     → `clasp push` updates HEAD, then `clasp deploy -i` re-versions the SAME
-#       deployment so the /exec URL serves the just-pushed code. Without the
-#       redeploy step the URL would keep serving the old version.
+#     secrets.GAS_E2E_DEPLOYMENT_ID — web app deployment id (AKfycb…); `clasp push`
+#                                     only moves HEAD, so `clasp deploy -i` must
+#                                     re-version the SAME deployment or the /exec
+#                                     URL keeps serving the old code.
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 20 * * 0' # weekly, Sunday 20:00 UTC (Monday 05:00 KST)
+  push:
+    branches: [dev]
+    paths:
+      - 'packages/**'
+      - 'e2e/**'
+      - '.github/workflows/gas-e2e.yml'
 
 jobs:
   gas-e2e:
     runs-on: ubuntu-latest
     if: ${{ vars.GAS_E2E_ENABLED == 'true' }}
     timeout-minutes: 20
+    concurrency:
+      group: gas-e2e
+      cancel-in-progress: false
     env:
-      HAS_CLASP: ${{ secrets.CLASPRC_JSON != '' && secrets.CLASP_JSON != '' && secrets.GAS_E2E_DEPLOYMENT_ID != '' }}
+      HAS_PUSH: ${{ secrets.CLASP_JSON != '' && secrets.GAS_E2E_DEPLOYMENT_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,14 +47,23 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Mint access token (web app is access:MYSELF)
+        env:
+          CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
+        run: |
+          set -euo pipefail
+          ACCESS_TOKEN=$(node e2e/gas/mint-token.mjs)
+          echo "::add-mask::$ACCESS_TOKEN"
+          echo "ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
+
       - name: Install and bundle harness
-        if: ${{ env.HAS_CLASP == 'true' }}
+        if: ${{ env.HAS_PUSH == 'true' }}
         run: |
           pnpm install --frozen-lockfile
           pnpm --filter @gsquery/gas-e2e-harness build
 
       - name: Push current checkout and redeploy the web app
-        if: ${{ env.HAS_CLASP == 'true' }}
+        if: ${{ env.HAS_PUSH == 'true' }}
         env:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
           CLASP_JSON: ${{ secrets.CLASP_JSON }}
@@ -63,7 +82,7 @@ jobs:
           TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
         run: |
           set -euo pipefail
-          RESULT=$(curl -sSL "${URL}?action=run&token=${TOKEN}")
+          RESULT=$(curl -sSL -H "Authorization: Bearer $ACCESS_TOKEN" "${URL}?action=run&token=${TOKEN}")
           echo "$RESULT" | python3 -m json.tool
           echo "$RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
 
@@ -73,12 +92,13 @@ jobs:
           TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
         run: |
           set -euo pipefail
-          curl -sSL "${URL}?action=cleanup&token=${TOKEN}" > /dev/null
-          curl -sSL "${URL}?action=burst&tag=left&n=25&token=${TOKEN}" > left.json &
-          curl -sSL "${URL}?action=burst&tag=right&n=25&token=${TOKEN}" > right.json &
+          AUTH="Authorization: Bearer $ACCESS_TOKEN"
+          curl -sSL -H "$AUTH" "${URL}?action=cleanup&token=${TOKEN}" > /dev/null
+          curl -sSL -H "$AUTH" "${URL}?action=burst&tag=left&n=25&token=${TOKEN}" > left.json &
+          curl -sSL -H "$AUTH" "${URL}?action=burst&tag=right&n=25&token=${TOKEN}" > right.json &
           wait
           cat left.json right.json
-          CHECK=$(curl -sSL "${URL}?action=burstCheck&expect=50&token=${TOKEN}")
+          CHECK=$(curl -sSL -H "$AUTH" "${URL}?action=burstCheck&expect=50&token=${TOKEN}")
           echo "$CHECK" | python3 -m json.tool
           echo "$CHECK" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
 
@@ -87,4 +107,5 @@ jobs:
         env:
           URL: ${{ secrets.GAS_E2E_URL }}
           TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
-        run: curl -sSL "${URL}?action=cleanup&token=${TOKEN}" || true
+        run: |
+          curl -sSL -H "Authorization: Bearer $ACCESS_TOKEN" "${URL}?action=cleanup&token=${TOKEN}" || true

--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -31,8 +31,8 @@ The harness creates sheets named `e2e_<runId>_*`, and deletes them after each ru
    npx @google/clasp push --force
    ```
 3. **First run in the editor**: open the project, run `runAllTests` once — this triggers the OAuth consent for the spreadsheet scope. Check the log for the JSON result.
-4. **Deploy as web app** (for CI): Deploy → New deployment → Web app, *Execute as: me*, *Access: anyone*. Copy the `/exec` URL.
-   Optionally set Script Properties: `E2E_TOKEN` (shared secret CI must echo), `GSQUERY_E2E_SPREADSHEET_ID` (to point at a different sheet).
+4. **Deploy as web app** (for CI): `npx @google/clasp deploy -d "e2e web app"` (the manifest already sets *Execute as: me*, ***Access: only myself***). The `/exec` URL is `https://script.google.com/macros/s/<deploymentId>/exec`.
+   Because access is locked to the owner, every non-browser call must carry `Authorization: Bearer <token>` — mint one with `node mint-token.mjs` (reads `~/.clasprc.json`). Optionally set Script Properties: `E2E_TOKEN` (defense-in-depth shared secret), `GSQUERY_E2E_SPREADSHEET_ID` (to point at a different sheet).
 5. **Wire CI** (from a machine where steps 2–4 are done; uses the `gh` CLI):
 
    ```bash
@@ -46,20 +46,30 @@ The harness creates sheets named `e2e_<runId>_*`, and deletes them after each ru
    gh secret set GAS_E2E_DEPLOYMENT_ID -b "AKfycb..." -R $REPO        # from `npx @google/clasp deployments`
    ```
 
-   Two modes, chosen automatically by which secrets exist:
-   - **curl-only** (just `GAS_E2E_URL`/`GAS_E2E_TOKEN`): tests whatever version is currently deployed. Zero token maintenance.
-   - **full** (also the three clasp secrets): CI pushes the current checkout and re-versions the SAME deployment (`clasp deploy -i`) so the `/exec` URL serves the just-pushed code — without that redeploy, `clasp push` alone would leave the URL serving the old version.
+   `CLASPRC_JSON` is always required — the web app is `access: MYSELF`, so CI mints a Bearer token from it for every request (`mint-token.mjs`). Modes:
+   - **test-only** (`CLASPRC_JSON` + `GAS_E2E_URL`): tests whatever version is currently deployed.
+   - **full** (also `CLASP_JSON` + `GAS_E2E_DEPLOYMENT_ID`): CI pushes the current checkout and re-versions the SAME deployment (`clasp deploy -i`) so the `/exec` URL serves the just-pushed code — without that redeploy, `clasp push` alone would leave the URL serving the old version.
+
+   > If authenticated curls come back as a Google login page (HTML instead of JSON), the clasp token's scopes don't satisfy the web app's access check — re-run `npx @google/clasp login` with the stock client (its `drive.file` scope satisfies the check) and refresh the `CLASPRC_JSON` secret.
 
    > ⚠️ If the OAuth client behind `clasp login` belongs to a GCP project whose consent screen is in **Testing** mode, its refresh token dies every 7 days. The stock clasp client (Google's, production) does not have this problem.
 
-Then: **Actions → "GAS E2E (real Apps Script)" → Run workflow.** It also runs weekly.
+Then: **Actions → "GAS E2E (real Apps Script)" → Run workflow.** It also runs automatically on every `dev` push that touches `packages/**` or `e2e/**`.
 
 ## What CI does
 
-1. *(full mode)* Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`), `clasp push`es it, and redeploys the web app to the new version.
-2. `GET ?action=run` — full golden suite, asserts `ok: true` from the JSON report.
-3. Fires two parallel `?action=burst&n=25` requests, then `?action=burstCheck&expect=50` — verifies the real script lock: 50 rows, 50 unique ids, no overwrites.
-4. `?action=cleanup` — removes all `e2e_*` sheets.
+1. Mints an owner Bearer token from `CLASPRC_JSON` (the app is not publicly accessible).
+2. *(full mode)* Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`), `clasp push`es it, and redeploys the web app to the new version.
+3. `GET ?action=run` — full golden suite, asserts `ok: true` from the JSON report.
+4. Fires two parallel `?action=burst&n=25` requests, then `?action=burstCheck&expect=50` — verifies the real script lock: 50 rows, 50 unique ids, no overwrites.
+5. `?action=cleanup` — removes all `e2e_*` sheets.
+
+## Calling the web app manually
+
+```bash
+ACCESS_TOKEN=$(node mint-token.mjs)
+curl -sL -H "Authorization: Bearer $ACCESS_TOKEN" "$URL?action=run&token=$E2E_TOKEN" | python3 -m json.tool
+```
 
 ## Local sanity check (no Google account needed)
 

--- a/e2e/gas/appsscript.json
+++ b/e2e/gas/appsscript.json
@@ -7,6 +7,6 @@
   ],
   "webapp": {
     "executeAs": "USER_DEPLOYING",
-    "access": "ANYONE_ANONYMOUS"
+    "access": "MYSELF"
   }
 }

--- a/e2e/gas/mint-token.mjs
+++ b/e2e/gas/mint-token.mjs
@@ -1,0 +1,62 @@
+/**
+ * Mints a Google OAuth access token from clasp's stored credentials, so the
+ * E2E web app can stay locked to `access: MYSELF` — callers authenticate with
+ * `Authorization: Bearer <token>` instead of the app being public.
+ *
+ * Credential source: $CLASPRC_JSON (CI secret) or ~/.clasprc.json (local).
+ * Handles both clasp credential layouts:
+ *   v2: { token: { refresh_token }, oauth2ClientSettings: { clientId, clientSecret } }
+ *   v3: { tokens: { default: { refresh_token, client_id, client_secret } } }
+ *
+ * Usage: node mint-token.mjs   → prints the access token to stdout.
+ */
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+function loadClasprc() {
+  if (process.env.CLASPRC_JSON) return JSON.parse(process.env.CLASPRC_JSON)
+  return JSON.parse(readFileSync(join(homedir(), '.clasprc.json'), 'utf8'))
+}
+
+/** Depth-first search for the first value under any of the given key names. */
+function findKey(node, names) {
+  if (node === null || typeof node !== 'object') return undefined
+  for (const [key, value] of Object.entries(node)) {
+    if (names.includes(key) && typeof value === 'string' && value.length > 0) return value
+    const nested = findKey(value, names)
+    if (nested !== undefined) return nested
+  }
+  return undefined
+}
+
+const rc = loadClasprc()
+const refreshToken = findKey(rc, ['refresh_token', 'refreshToken'])
+const clientId = findKey(rc, ['client_id', 'clientId'])
+const clientSecret = findKey(rc, ['client_secret', 'clientSecret'])
+
+if (!refreshToken || !clientId || !clientSecret) {
+  console.error(
+    'mint-token: could not find refresh_token/client_id/client_secret in clasp credentials. ' +
+      'Run `npx @google/clasp login` and retry.'
+  )
+  process.exit(1)
+}
+
+const res = await fetch('https://oauth2.googleapis.com/token', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  body: new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret
+  })
+})
+
+const body = await res.json()
+if (!res.ok || !body.access_token) {
+  console.error(`mint-token: token endpoint returned ${res.status}: ${JSON.stringify(body)}`)
+  process.exit(1)
+}
+process.stdout.write(body.access_token)


### PR DESCRIPTION
## Summary

Two requested changes to the GAS E2E automation:

- **No public web app.** `appsscript.json` switches from `ANYONE_ANONYMOUS` to `access: MYSELF`. CI authenticates every request with an owner Bearer token minted from the existing `CLASPRC_JSON` secret (`e2e/gas/mint-token.mjs` — dependency-free, handles both clasp v2 `{token, oauth2ClientSettings}` and v3 `{tokens.default}` credential layouts; both shapes covered by parse checks). The `E2E_TOKEN` query parameter stays as optional defense in depth. Fallback documented for the rare case where the token's scopes don't satisfy the web-app access check (re-login with the stock clasp client).
- **Trigger on dev pushes instead of weekly.** The cron is gone; the workflow now runs on pushes to `dev` touching `packages/**`, `e2e/**`, or the workflow itself, plus manual dispatch. A non-cancelling `concurrency` group queues overlapping runs so two pushes can't interleave their burst tests against the shared sheet.

README setup/runbook updated accordingly (deploy via `clasp deploy`, manual-call recipe with minted token). Workflow YAML validated; `mint-token.mjs` parse-checked against both credential layouts.

## Related Issues

Follow-up to #159–#161.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [ ] Tests added or updated (CI config; mint-token shape checks run ad hoc)
- [x] `pnpm test` passes (unaffected)
- [x] `pnpm build` passes (unaffected)
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_