### PR TITLE
fix(core): flush buffered writes before releasing the script lock

### DIFF
--- a/e2e/gas/src/main.ts
+++ b/e2e/gas/src/main.ts
@@ -100,16 +100,27 @@ function deleteAllE2ESheets(spreadsheetId: string): number {
  * exercise the real LockService: with correct locking the two bursts must not
  * collide on ids or overwrite each other's rows.
  */
-export function burst(tag: string, n: number): { inserted: number; tag: string } {
+export function burst(tag: string, n: number): { inserted: number; tag: string; errors: string[] } {
   const adapter = new SheetsAdapter<BurstRow>({
     spreadsheetId: getSpreadsheetId(),
     sheetName: BURST_SHEET,
     columns: ['id', 'tag']
   })
+  // Per-insert error capture so a failed burst is distinguishable from a
+  // silently lost row (#164): `inserted` is the count the server actually
+  // claims, and burstCheck's expectation should match the sum of the two
+  // bursts' `inserted` values.
+  const errors: string[] = []
+  let inserted = 0
   for (let i = 0; i < n; i++) {
-    adapter.insert({ tag: `${tag}-${i}` })
+    try {
+      adapter.insert({ tag: `${tag}-${i}` })
+      inserted++
+    } catch (err) {
+      errors.push(`${tag}-${i}: ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`)
+    }
   }
-  return { inserted: n, tag }
+  return { inserted, tag, errors }
 }
 
 export function burstCheck(expect: number): {

--- a/packages/core/src/core/script-lock.ts
+++ b/packages/core/src/core/script-lock.ts
@@ -31,6 +31,23 @@ function acquireLock(timeoutMs: number): GoogleAppsScript.Lock.Lock | null {
 }
 
 /**
+ * Commits buffered SpreadsheetApp writes before the lock is released.
+ *
+ * SpreadsheetApp buffers mutations: a write that is still buffered when the
+ * lock is released is invisible to the next lock holder, which then reads a
+ * stale sheet and can commit over the uncommitted row — silent data loss
+ * reproduced on the live platform by the E2E burst test (#164; two parallel
+ * runs of 25 locked inserts each produced 49 rows with both callers
+ * reporting success). This is why LockService's own documentation flushes
+ * before releasing. No-op outside GAS and under fakes without `flush`.
+ */
+function flushPendingWrites(): void {
+  if (typeof SpreadsheetApp !== 'undefined' && typeof SpreadsheetApp.flush === 'function') {
+    SpreadsheetApp.flush()
+  }
+}
+
+/**
  * Runs `fn` while holding the script lock, releasing it once `fn` returns or
  * throws. Re-entrant: a nested call runs under the lock already held.
  */
@@ -50,6 +67,7 @@ export function withScriptLock<R>(fn: () => R, timeoutMs: number = DEFAULT_LOCK_
     return fn()
   } finally {
     lockDepth--
+    flushPendingWrites()
     if (lock) {
       lock.releaseLock()
     }
@@ -80,6 +98,7 @@ export async function withScriptLockAsync<R>(
     return await fn()
   } finally {
     lockDepth--
+    flushPendingWrites()
     if (lock) {
       lock.releaseLock()
     }

--- a/packages/core/src/testing/install.ts
+++ b/packages/core/src/testing/install.ts
@@ -78,7 +78,9 @@ export function installGasFakes(options: InstallGasFakesOptions): GasFakesHandle
         )
       }
       return spreadsheets[activeId]
-    }
+    },
+    /** Fakes write synchronously, so committing buffered writes is a no-op (#164). */
+    flush(): void {}
   }
 
   const lockService = {

--- a/packages/core/tests/unit/flush-before-unlock.test.ts
+++ b/packages/core/tests/unit/flush-before-unlock.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #164 — SpreadsheetApp buffers writes, so a locked mutation must flush
+ * before releasing the script lock or the next lock holder can read a stale
+ * sheet and commit over the uncommitted row (silent data loss, reproduced on
+ * the live platform by the E2E burst test: 2×25 locked inserts → 49 rows,
+ * both callers reporting success).
+ *
+ * These tests pin the ordering contract: flush() is invoked inside the
+ * critical section boundary, strictly before releaseLock().
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { withScriptLock, withScriptLockAsync } from '../../src/core/script-lock'
+import { FakeSpreadsheet, installGasFakes } from '../../src/testing'
+
+interface Row {
+  id: number
+  name: string
+  [key: string]: unknown
+}
+
+type MutableGlobal = { SpreadsheetApp?: unknown; LockService?: unknown }
+const g = globalThis as MutableGlobal
+
+function installOrderRecorder(): { events: string[]; restore: () => void } {
+  const events: string[] = []
+  const handle = installGasFakes({
+    spreadsheets: { S: new FakeSpreadsheet('S') },
+    activeId: 'S'
+  })
+
+  // Wrap the installed fakes so every flush/lock transition is recorded.
+  const spreadsheetApp = g.SpreadsheetApp as { flush: () => void }
+  const originalFlush = spreadsheetApp.flush.bind(spreadsheetApp)
+  spreadsheetApp.flush = () => {
+    events.push('flush')
+    originalFlush()
+  }
+  g.LockService = {
+    getScriptLock: () => ({
+      waitLock: () => {
+        events.push('acquire')
+      },
+      releaseLock: () => {
+        events.push('release')
+      },
+      tryLock: () => true,
+      hasLock: () => true
+    })
+  }
+
+  return { events, restore: () => handle.restore() }
+}
+
+describe('flush before unlock (#164)', () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  it('withScriptLock flushes after the callback and before releasing', () => {
+    const recorder = installOrderRecorder()
+    restore = recorder.restore
+
+    withScriptLock(() => {
+      recorder.events.push('work')
+    })
+
+    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+  })
+
+  it('withScriptLock flushes even when the callback throws', () => {
+    const recorder = installOrderRecorder()
+    restore = recorder.restore
+
+    expect(() =>
+      withScriptLock(() => {
+        recorder.events.push('work')
+        throw new Error('boom')
+      })
+    ).toThrow('boom')
+
+    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+  })
+
+  it('withScriptLockAsync flushes before releasing', async () => {
+    const recorder = installOrderRecorder()
+    restore = recorder.restore
+
+    await withScriptLockAsync(async () => {
+      recorder.events.push('work')
+    })
+
+    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+  })
+
+  it('nested locks flush once, at the outermost release', () => {
+    const recorder = installOrderRecorder()
+    restore = recorder.restore
+
+    withScriptLock(() => {
+      withScriptLock(() => {
+        recorder.events.push('inner')
+      })
+      recorder.events.push('outer')
+    })
+
+    expect(recorder.events).toEqual(['acquire', 'inner', 'outer', 'flush', 'release'])
+  })
+
+  it('SheetsAdapter.insert commits its append before the lock is released', () => {
+    const recorder = installOrderRecorder()
+    restore = recorder.restore
+
+    const adapter = new SheetsAdapter<Row>({
+      spreadsheetId: 'S',
+      sheetName: 'users',
+      columns: ['id', 'name']
+    })
+    adapter.insert({ name: 'a' })
+
+    const flushAt = recorder.events.indexOf('flush')
+    const releaseAt = recorder.events.indexOf('release')
+    expect(flushAt).toBeGreaterThan(-1)
+    expect(releaseAt).toBeGreaterThan(flushAt)
+  })
+})


### PR DESCRIPTION
## Summary

**Live-platform data-loss bug caught by the E2E burst test (#164).** Two parallel web-app requests of 25 locked auto-id inserts each produced 49 rows — unique ids, one tag missing, both callers reporting success. Mechanism: SpreadsheetApp buffers writes, so a mutation still buffered when the lock is released is invisible to the next lock holder, which reads a stale sheet and commits over the uncommitted row. This is exactly why LockService's documented pattern flushes before releasing.

Fixes:
- `withScriptLock`/`withScriptLockAsync` now call `SpreadsheetApp.flush()` at the **outermost** release, before `releaseLock()` — covering every locked adapter mutation and the migration runner in one place. Guarded no-op outside GAS; the testing fakes gained a no-op `flush`.
- New `flush-before-unlock.test.ts` pins the ordering contract (`acquire → work → flush → release`), including the throwing and nested-lock paths, plus an adapter-level insert check.
- The harness `burst` action now captures per-insert errors (`{inserted, errors[]}`) so a thrown insert is distinguishable from a silently lost row in future diagnostics.

Full suite green (core 593, +5), typecheck clean. Real-platform confirmation pending the next burst run (2×25 → must be 50/50).

## Related Issues

Closes #164

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (1,007 tests)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_