### PR TITLE
fix(core): hold the script lock across batchUpdate's read-write cycle

### DIFF
--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -652,48 +652,58 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     if (items.length === 0) return []
 
     this.invalidateDataCache()
-    const results: T[] = []
     const sheet = this.getSheet()
-    
+
     // Build a map of id -> data for batch processing
     const updateMap = new Map<string | number, Partial<Omit<T, 'id'>>>()
     for (const { id, data } of items) {
       updateMap.set(id, data)
     }
 
-    // Get all data to find rows to update
-    const lastRow = sheet.getLastRow()
-    if (lastRow <= 1) return results
+    // Read, resolve row indices and write inside one lock. The row numbers
+    // below are positions within the block read at the top, so a concurrent
+    // deleteRow or insert landing in between shifts them and the ranged writes
+    // hit the wrong rows — the stale-index race of #128, amplified because
+    // writeRowRuns rewrites a whole contiguous span at once (#155).
+    // withScriptLock is re-entrant, so callers already holding the lock (a
+    // migration delegating to batchUpdate) reuse their acquisition.
+    return this.withLock(() => {
+      const results: T[] = []
 
-    const allData = sheet.getRange(2, 1, lastRow - 1, this.columns.length).getValues()
-    const idColIndex = this.columns.indexOf(this.idColumn)
+      // Get all data to find rows to update
+      const lastRow = sheet.getLastRow()
+      if (lastRow <= 1) return results
 
-    const updatedRows: { rowIndex: number; values: unknown[] }[] = []
+      const allData = sheet.getRange(2, 1, lastRow - 1, this.columns.length).getValues()
+      const idColIndex = this.columns.indexOf(this.idColumn)
 
-    for (let i = 0; i < allData.length; i++) {
-      // Unescape so an escaped id still matches the caller's id (#130).
-      const rowId = this.unescapeCellValue(allData[i][idColIndex]) as string | number
-      const updateData = updateMap.get(rowId) ?? updateMap.get(String(rowId))
-      
-      if (updateData) {
-        const currentRow = this.rowToObject(allData[i])
-        const updatedRow = { ...currentRow, ...updateData } as T
-        // id is immutable via batchUpdate too — mirrors the guard update()
-        // already has (#98/#113). Without this, `data` carrying an id rewrites
-        // the key cell and the row becomes reachable only at its new id.
-        ;(updatedRow as Record<string, unknown>)[this.idColumn] =
-          (currentRow as Record<string, unknown>)[this.idColumn]
-        results.push(updatedRow)
-        updatedRows.push({
-          rowIndex: i + 2, // +2 for header and 1-indexing
-          values: this.objectToRow(updatedRow)
-        })
+      const updatedRows: { rowIndex: number; values: unknown[] }[] = []
+
+      for (let i = 0; i < allData.length; i++) {
+        // Unescape so an escaped id still matches the caller's id (#130).
+        const rowId = this.unescapeCellValue(allData[i][idColIndex]) as string | number
+        const updateData = updateMap.get(rowId) ?? updateMap.get(String(rowId))
+
+        if (updateData) {
+          const currentRow = this.rowToObject(allData[i])
+          const updatedRow = { ...currentRow, ...updateData } as T
+          // id is immutable via batchUpdate too — mirrors the guard update()
+          // already has (#98/#113). Without this, `data` carrying an id rewrites
+          // the key cell and the row becomes reachable only at its new id.
+          ;(updatedRow as Record<string, unknown>)[this.idColumn] =
+            (currentRow as Record<string, unknown>)[this.idColumn]
+          results.push(updatedRow)
+          updatedRows.push({
+            rowIndex: i + 2, // +2 for header and 1-indexing
+            values: this.objectToRow(updatedRow)
+          })
+        }
       }
-    }
-    
-    this.writeRowRuns(sheet, updatedRows)
 
-    return results
+      this.writeRowRuns(sheet, updatedRows)
+
+      return results
+    })
   }
 
   /**

--- a/packages/core/tests/unit/concurrent-write-locking.test.ts
+++ b/packages/core/tests/unit/concurrent-write-locking.test.ts
@@ -136,6 +136,31 @@ function interruptAfterIdScan(sheet: FakeSheet, run: () => void): void {
   )
 }
 
+/**
+ * Fires `run` once, right after the first full-width data-block read returns —
+ * i.e. between batchUpdate's "read every row" and its ranged writes, where a
+ * concurrent deleteRow shifts every computed row index up by one.
+ */
+function interruptAfterDataScan(sheet: FakeSheet, run: () => void): void {
+  let armed = true
+  const original = sheet.getRange.bind(sheet)
+  vi.spyOn(sheet, 'getRange').mockImplementation(
+    (row: number, col: number, numRows = 1, numCols = 1) => {
+      const range = original(row, col, numRows, numCols)
+      if (armed && row === 2 && col === 1 && numCols === COLUMNS.length) {
+        armed = false
+        const getValues = range.getValues.bind(range)
+        range.getValues = () => {
+          const values = getValues()
+          run()
+          return values
+        }
+      }
+      return range
+    }
+  )
+}
+
 /** Fires `run` once, right after the first `getLastRow()` reads its value. */
 function interruptAfterLastRow(sheet: FakeSheet, run: () => void): void {
   let armed = true
@@ -256,6 +281,41 @@ describe('SheetsAdapter concurrency (#128)', () => {
       other.drain()
 
       expect(idsOnSheet(sheet).sort()).toEqual(['a', 'b', 'c', 'd'])
+    })
+  })
+
+  describe('batchUpdate()', () => {
+    it('does not overwrite an unrelated row when another execution deletes a row above (#155)', () => {
+      const sheet = setupSharedSheet([
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30],
+        [2, 'Bob', 25],
+        [3, 'Carol', 35],
+        [4, 'Dave', 40]
+      ])
+      const lockState = installExclusiveLock()
+
+      const writer = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+      const deleter = new SheetsAdapter<TestRow>(BASE_OPTIONS)
+
+      const other = concurrentExecution(lockState, () => {
+        deleter.delete(1)
+      })
+      // The delete lands between the data-block read and writeRowRuns, so an
+      // unlocked batchUpdate writes Carol's values into row 4 — which by then
+      // holds Dave.
+      interruptAfterDataScan(sheet, () => other.run())
+
+      const results = writer.batchUpdate([{ id: 3, data: { name: 'Carol Updated' } }])
+      other.drain()
+
+      expect(results).toEqual([{ id: 3, name: 'Carol Updated', age: 35 }])
+      expect(idsOnSheet(sheet)).toEqual([2, 3, 4])
+      expect(dataRows(sheet)).toEqual([
+        [2, 'Bob', 25],
+        [3, 'Carol Updated', 35],
+        [4, 'Dave', 40]
+      ])
     })
   })
 
@@ -389,6 +449,24 @@ describe('SheetsAdapter lock coverage (#128)', () => {
     expect(order(lock.releaseLock)).toBeGreaterThan(order(write!))
   })
 
+  it('batchUpdate() holds the lock across the data read and the write (#155)', () => {
+    const sheet = fromArrays({
+      [SHEET_NAME]: [
+        ['id', 'name', 'age'],
+        [1, 'Alice', 30]
+      ]
+    }).getSheetByName(SHEET_NAME)!
+    const lock = setupCapturedLock(sheet)
+    const { getRange, lastWrite } = captureWrites(sheet)
+
+    new SheetsAdapter<TestRow>(BASE_OPTIONS).batchUpdate([{ id: 1, data: { name: 'Updated' } }])
+
+    const write = lastWrite()
+    expect(write).toBeDefined()
+    expect(order(lock.waitLock)).toBeLessThan(order(getRange))
+    expect(order(lock.releaseLock)).toBeGreaterThan(order(write!))
+  })
+
   it('keeps working when LockService is unavailable (Node)', () => {
     const sheet = setupSharedSheet([
       ['id', 'name', 'age'],
@@ -398,6 +476,9 @@ describe('SheetsAdapter lock coverage (#128)', () => {
 
     const adapter = new SheetsAdapter<TestRow>(BASE_OPTIONS)
     expect(adapter.update(1, { name: 'Updated' })?.name).toBe('Updated')
+    expect(adapter.batchUpdate([{ id: 1, data: { name: 'Batched' } }])).toEqual([
+      { id: 1, name: 'Batched', age: 30 }
+    ])
     expect(adapter.delete(1)).toBe(true)
 
     const clientAdapter = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, idMode: 'client' })


### PR DESCRIPTION
## Summary

`batchUpdate` read the full data block, computed row indices, and wrote coalesced ranges with no lock — a concurrent `deleteRow`/insert between the read and the writes shifted indices so a whole run could land one row off (the stale-index corruption class #128 fixed for update/delete, amplified by ranged writes). The read → compute → `writeRowRuns` sequence now runs inside `withLock` (re-entrant, flushes before release per #164); the pure `updateMap` build stays outside.

New interleaved test reproduces the corruption on pre-fix code (adapter B deletes id 1 between A's read and write → `[2,3,3]`: Carol's values destroy Dave's row) and passes after; lock-coverage and LockService-unavailable cases added. Existing batchUpdate tests pass unmodified; migration re-entrancy still green.

## Related Issues

Closes #155

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_