### PR TITLE
fix: enforce client-mode ID uniqueness in MockAdapter and LocalAdapter (parity with SheetsAdapter)

### DIFF
--- a/packages/client/src/local/local-adapter.ts
+++ b/packages/client/src/local/local-adapter.ts
@@ -18,7 +18,13 @@ import type {
   IdMode,
   UpdateData,
 } from '@gsquery/core'
-import { IndexStore, evaluateCondition, compareRows, deserializeRow } from '@gsquery/core'
+import {
+  IndexStore,
+  evaluateCondition,
+  compareRows,
+  deserializeRow,
+  DuplicateIdError,
+} from '@gsquery/core'
 import type { IndexDefinition, ColumnType } from '@gsquery/core'
 import { MutationQueue } from './mutation-queue.js'
 import type { MutationStorage } from './mutation-queue.js'
@@ -265,13 +271,50 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
     return this.data[index]
   }
 
+  /** Read the id of a client-mode row, throwing when the caller omitted it. */
+  private requireClientId(data: Omit<T, 'id'> | T): string | number {
+    if (!('id' in data)) {
+      throw new Error(`ID is required in client mode (idMode: 'client')`)
+    }
+    return (data as T).id
+  }
+
+  /** Every id currently held, keyed as strings so 1 and '1' collide. */
+  private readExistingIdKeys(): Set<string> {
+    const keys = new Set<string>()
+    for (const row of this.data) {
+      keys.add(String(row.id))
+    }
+    return keys
+  }
+
+  /**
+   * Reject client-supplied ids that already exist locally, or that repeat
+   * within the same batch — the same contract SheetsAdapter enforces on the
+   * server (#128/#154). Called before any mutation, so a rejected write leaves
+   * the rows, the MutationQueue and IndexedDB untouched: the duplicate fails
+   * at the call site instead of being pushed and dead-lettered (#132).
+   *
+   * Rows arriving through replaceAll()/reset() are seeded verbatim and are not
+   * checked, mirroring rows that were already on the sheet.
+   */
+  private assertClientIdsAvailable(ids: (string | number)[]): void {
+    const existing = this.readExistingIdKeys()
+    for (const id of ids) {
+      const key = String(id)
+      if (existing.has(key)) {
+        throw new DuplicateIdError(id, this.tableName)
+      }
+      existing.add(key)
+    }
+  }
+
   insert(data: Omit<T, 'id'> | T): T {
     let newRow: T
 
     if (this.idMode === 'client') {
-      if (!('id' in data)) {
-        throw new Error(`ID is required in client mode (idMode: 'client')`)
-      }
+      const id = this.requireClientId(data)
+      this.assertClientIdsAvailable([id])
       newRow = data as T
     } else {
       const id = this.nextId++
@@ -331,33 +374,36 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   batchInsert(items: (Omit<T, 'id'> | T)[]): T[] {
-    const results: T[] = []
-    const startIndex = this.data.length
+    // Resolve and validate every row up front: a rejected batch must leave the
+    // rows, the queue and IndexedDB untouched, matching SheetsAdapter (#154).
+    const newRows: T[] = []
 
-    for (let i = 0; i < items.length; i++) {
-      let newRow: T
-
-      if (this.idMode === 'client') {
-        if (!('id' in items[i])) {
-          throw new Error(`ID is required in client mode (idMode: 'client')`)
-        }
-        newRow = items[i] as T
-      } else {
-        const id = this.nextId++
-        newRow = { ...items[i], id } as T
+    if (this.idMode === 'client') {
+      const ids: (string | number)[] = []
+      for (const item of items) {
+        ids.push(this.requireClientId(item))
+        newRows.push(item as T)
       }
+      this.assertClientIdsAvailable(ids)
+    } else {
+      for (const item of items) {
+        newRows.push({ ...item, id: this.nextId++ } as T)
+      }
+    }
 
+    const startIndex = this.data.length
+    for (let i = 0; i < newRows.length; i++) {
+      const newRow = newRows[i]
       const rowIndex = startIndex + i
       this.data.push(newRow)
       this.idIndex.set(newRow.id, rowIndex)
       this.indexStore.addToIndex(rowIndex, newRow)
 
       this.queue.push('insert', newRow.id, undefined, newRow)
-      results.push(newRow)
     }
 
     this.schedulePersist()
-    return results
+    return newRows
   }
 
   batchUpdate(items: BatchUpdateItem<T>[]): T[] {

--- a/packages/client/tests/unit/local/id-uniqueness.test.ts
+++ b/packages/client/tests/unit/local/id-uniqueness.test.ts
@@ -1,0 +1,265 @@
+/**
+ * LocalAdapter side of the client-mode id uniqueness parity suite (#154).
+ *
+ * The scenario list mirrors `packages/core/tests/unit/id-uniqueness-parity.test.ts`,
+ * which pins MockAdapter and SheetsAdapter to the same contract. LocalAdapter
+ * adds two obligations of its own: a rejected insert must not enqueue a
+ * mutation (it would be pushed to the server and bounce into the dead-letter
+ * flow) and must not write to IndexedDB.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { LocalAdapter } from '../../../src/local/local-adapter.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+import { DuplicateIdError } from '@gsquery/core'
+import type { RowWithId } from '@gsquery/core'
+
+interface Counter extends RowWithId {
+  id: string | number
+  value: number
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+function createAdapter(
+  seed: Counter[] = [],
+  idMode: 'client' | 'auto' = 'client'
+): LocalAdapter<Counter> {
+  return new LocalAdapter<Counter>({
+    tableName: 'Counter',
+    idMode,
+    initialData: seed,
+    disableIDB: true,
+    mutationStorage: createMemoryStorage(),
+  })
+}
+
+const ids = (adapter: LocalAdapter<Counter>): string[] =>
+  adapter.findAll().map(row => String(row.id))
+
+describe('LocalAdapter client-mode id uniqueness [#154]', () => {
+  it('insert() rejects an id that already exists', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+
+    expect(() => adapter.insert({ id: 'a', value: 2 })).toThrow(DuplicateIdError)
+    expect(ids(adapter)).toEqual(['a'])
+  })
+
+  it('insert() matches ids across string/number representations', () => {
+    const adapter = createAdapter([{ id: 7, value: 1 }])
+
+    expect(() => adapter.insert({ id: '7', value: 2 })).toThrow(DuplicateIdError)
+    expect(ids(adapter)).toEqual(['7'])
+  })
+
+  it('carries the offending id, the table name and a stable error code', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+
+    try {
+      adapter.insert({ id: 'a', value: 2 })
+      expect.unreachable('insert should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateIdError)
+      expect((error as DuplicateIdError).id).toBe('a')
+      expect((error as DuplicateIdError).code).toBe('DUPLICATE_ID')
+      expect((error as DuplicateIdError).tableName).toBe('Counter')
+    }
+  })
+
+  it('batchInsert() writes nothing when one id already exists', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'b', value: 2 },
+        { id: 'a', value: 3 },
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(ids(adapter)).toEqual(['a'])
+  })
+
+  it('batchInsert() rejects ids duplicated within the same batch', () => {
+    const adapter = createAdapter()
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'a', value: 1 },
+        { id: 'a', value: 2 },
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(ids(adapter)).toEqual([])
+  })
+
+  it('batchInsert() writes nothing when a later item omits its id', () => {
+    const adapter = createAdapter()
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'a', value: 1 },
+        { value: 2 } as Omit<Counter, 'id'>,
+      ])
+    ).toThrow(/ID is required/)
+    expect(ids(adapter)).toEqual([])
+  })
+
+  it('still accepts distinct ids', () => {
+    const adapter = createAdapter()
+
+    adapter.insert({ id: 'a', value: 1 })
+    adapter.batchInsert([
+      { id: 'b', value: 2 },
+      { id: 'c', value: 3 },
+    ])
+
+    expect(ids(adapter)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('frees an id again after the row is deleted', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+
+    expect(adapter.delete('a')).toBe(true)
+    expect(() => adapter.insert({ id: 'a', value: 2 })).not.toThrow()
+    expect(adapter.findById('a')?.value).toBe(2)
+  })
+
+  it('leaves auto mode unaffected: caller ids are ignored, not rejected', () => {
+    const adapter = createAdapter([], 'auto')
+
+    adapter.insert({ id: 1, value: 1 })
+    adapter.insert({ id: 1, value: 2 })
+    adapter.batchInsert([{ id: 1, value: 3 }])
+
+    expect(ids(adapter)).toEqual(['1', '2', '3'])
+  })
+
+  // ── MutationQueue ───────────────────────────────────────────────────
+
+  it('does not enqueue a mutation for a rejected insert', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+    const before = adapter.queue.length
+
+    expect(() => adapter.insert({ id: 'a', value: 2 })).toThrow(DuplicateIdError)
+    expect(adapter.queue.length).toBe(before)
+  })
+
+  it('does not enqueue any mutation for a rejected batch', () => {
+    const adapter = createAdapter([{ id: 'a', value: 1 }])
+    const before = adapter.queue.length
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'b', value: 2 },
+        { id: 'a', value: 3 },
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(adapter.queue.length).toBe(before)
+    expect(adapter.queue.getMerged()).toEqual([])
+  })
+})
+
+// ── IndexedDB persistence ─────────────────────────────────────────────
+
+/** Minimal IndexedDB stand-in that counts the readwrite transactions it serves. */
+function installFakeIndexedDB(storeNames: string[]) {
+  const rows = new Map<string, Map<string, unknown>>()
+  for (const name of storeNames) rows.set(name, new Map())
+  const stats = { readwriteTransactions: 0 }
+
+  const db = {
+    version: 1,
+    objectStoreNames: { contains: (name: string) => rows.has(name) },
+    createObjectStore: () => {},
+    close: () => {},
+    transaction(storeName: string, mode: 'readonly' | 'readwrite' = 'readonly') {
+      const store = rows.get(storeName)!
+      const tx: Record<string, unknown> = { error: null }
+
+      if (mode === 'readonly') {
+        const snapshot = [...store.values()]
+        tx.objectStore = () => ({
+          getAll: () => {
+            const request: Record<string, unknown> = { result: snapshot, error: null }
+            queueMicrotask(() => (request.onsuccess as (() => void) | undefined)?.())
+            return request
+          },
+        })
+        return tx
+      }
+
+      stats.readwriteTransactions++
+      tx.objectStore = () => ({
+        clear: () => store.clear(),
+        put: (row: { id: string | number }) => store.set(String(row.id), row),
+      })
+      queueMicrotask(() => (tx.oncomplete as (() => void) | undefined)?.())
+      return tx
+    },
+  }
+
+  ;(globalThis as Record<string, unknown>).indexedDB = {
+    open() {
+      const request: Record<string, unknown> = { result: db }
+      queueMicrotask(() => (request.onsuccess as (() => void) | undefined)?.())
+      return request
+    },
+  }
+
+  return { rows, stats }
+}
+
+describe('LocalAdapter rejected insert leaves IndexedDB untouched [#154]', () => {
+  let fake: ReturnType<typeof installFakeIndexedDB>
+
+  beforeEach(() => {
+    fake = installFakeIndexedDB(['Counter', '_meta'])
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).indexedDB
+  })
+
+  async function createPersistedAdapter(): Promise<LocalAdapter<Counter>> {
+    const adapter = new LocalAdapter<Counter>({
+      tableName: 'Counter',
+      idMode: 'client',
+      mutationStorage: createMemoryStorage(),
+    })
+    await adapter.init()
+    adapter.insert({ id: 'a', value: 1 })
+    await adapter.flush()
+    return adapter
+  }
+
+  it('schedules no persist when the id is a duplicate', async () => {
+    const adapter = await createPersistedAdapter()
+    const writesBefore = fake.stats.readwriteTransactions
+
+    expect(() => adapter.insert({ id: 'a', value: 2 })).toThrow(DuplicateIdError)
+    await adapter.flush()
+
+    expect(fake.stats.readwriteTransactions).toBe(writesBefore)
+    expect([...fake.rows.get('Counter')!.values()]).toEqual([{ id: 'a', value: 1 }])
+  })
+
+  it('schedules no persist when a batch is rejected', async () => {
+    const adapter = await createPersistedAdapter()
+    const writesBefore = fake.stats.readwriteTransactions
+
+    expect(() =>
+      adapter.batchInsert([
+        { id: 'b', value: 2 },
+        { id: 'a', value: 3 },
+      ])
+    ).toThrow(DuplicateIdError)
+    await adapter.flush()
+
+    expect(fake.stats.readwriteTransactions).toBe(writesBefore)
+    expect([...fake.rows.get('Counter')!.values()]).toEqual([{ id: 'a', value: 1 }])
+  })
+})

--- a/packages/core/src/adapters/mock-adapter.ts
+++ b/packages/core/src/adapters/mock-adapter.ts
@@ -5,10 +5,18 @@ import type { RowWithId, DataStore, QueryOptions, WhereCondition, BatchUpdateIte
 import { IndexStore } from '../core/index-store'
 import type { IndexDefinition } from '../core/index-store'
 import { evaluateCondition, compareRows } from '../core/query-utils'
+import { DuplicateIdError } from '../core/errors'
 
 /** MockAdapter configuration options */
 export interface MockAdapterOptions<T extends RowWithId = RowWithId> {
-  /** Initial data */
+  /**
+   * Initial data.
+   *
+   * Seeded verbatim: unlike insert()/batchInsert() it is not checked for
+   * duplicate ids, so a caller can still seed a store with colliding ids
+   * (same for `reset()`). That mirrors SheetsAdapter, which likewise cannot
+   * vouch for rows that were already on the sheet (#154).
+   */
   initialData?: T[]
   /** Index definitions (schema-based) */
   indexes?: IndexDefinition[]
@@ -218,21 +226,57 @@ export class MockAdapter<T extends RowWithId> implements DataStore<T> {
     return this.data[index]
   }
 
+  /**
+   * Read the id of a client-mode row, throwing when the caller omitted it.
+   */
+  private requireClientId(data: Omit<T, 'id'> | T): string | number {
+    if (!('id' in data)) {
+      throw new Error(`ID is required in client mode (idMode: 'client')`)
+    }
+    return (data as T).id
+  }
+
+  /** Every id currently held, keyed as strings so 1 and '1' collide. */
+  private readExistingIdKeys(): Set<string> {
+    const keys = new Set<string>()
+    for (const row of this.data) {
+      keys.add(String(row.id))
+    }
+    return keys
+  }
+
+  /**
+   * Reject client-supplied ids that already exist, or that repeat within the
+   * same batch. Called before any mutation so a rejected write leaves the
+   * store untouched — same contract as SheetsAdapter, which the mock stands in
+   * for during tests (#128/#154).
+   */
+  private assertClientIdsAvailable(ids: (string | number)[]): void {
+    const existing = this.readExistingIdKeys()
+    for (const id of ids) {
+      const key = String(id)
+      if (existing.has(key)) {
+        throw new DuplicateIdError(id)
+      }
+      existing.add(key)
+    }
+  }
+
   insert(data: Omit<T, 'id'> | T): T {
     let newRow: T
-    
+
     if (this.idMode === 'client') {
-      // Client mode: use client-provided ID
-      if (!('id' in data)) {
-        throw new Error(`ID is required in client mode (idMode: 'client')`)
-      }
+      // Client mode: use client-provided ID, rejecting one that is taken
+      // before anything is written.
+      const id = this.requireClientId(data)
+      this.assertClientIdsAvailable([id])
       newRow = data as T
     } else {
       // Auto mode: server generates numeric ID (default, backward compatible)
       const id = this.nextId++
       newRow = { ...data, id } as T
     }
-    
+
     const index = this.data.length
     this.data.push(newRow)
     this.idIndex.set(newRow.id, index)
@@ -288,33 +332,36 @@ export class MockAdapter<T extends RowWithId> implements DataStore<T> {
    * More efficient than calling insert() in a loop
    */
   batchInsert(items: (Omit<T, 'id'> | T)[]): T[] {
-    const results: T[] = []
-    const startIndex = this.data.length
-    
-    for (let i = 0; i < items.length; i++) {
-      let newRow: T
-      
-      if (this.idMode === 'client') {
-        // Client mode: use client-provided ID
-        if (!('id' in items[i])) {
-          throw new Error(`ID is required in client mode (idMode: 'client')`)
-        }
-        newRow = items[i] as T
-      } else {
-        // Auto mode: server generates numeric ID
-        const id = this.nextId++
-        newRow = { ...items[i], id } as T
+    // Resolve and validate every row before touching the store: a rejected
+    // batch must mutate nothing, matching SheetsAdapter (#128/#154).
+    const newRows: T[] = []
+
+    if (this.idMode === 'client') {
+      // Client mode: use client-provided IDs
+      const ids: (string | number)[] = []
+      for (const item of items) {
+        ids.push(this.requireClientId(item))
+        newRows.push(item as T)
       }
-      
+      this.assertClientIdsAvailable(ids)
+    } else {
+      // Auto mode: server generates numeric IDs
+      for (const item of items) {
+        newRows.push({ ...item, id: this.nextId++ } as T)
+      }
+    }
+
+    const startIndex = this.data.length
+    for (let i = 0; i < newRows.length; i++) {
+      const newRow = newRows[i]
       const rowIndex = startIndex + i
       this.data.push(newRow)
       this.idIndex.set(newRow.id, rowIndex)
       // Update column indexes
       this.indexStore.addToIndex(rowIndex, newRow)
-      results.push(newRow)
     }
-    
-    return results
+
+    return newRows
   }
 
   /**
@@ -344,7 +391,7 @@ export class MockAdapter<T extends RowWithId> implements DataStore<T> {
     return results
   }
 
-  /** Test helper: reset all data */
+  /** Test helper: reset all data (seeded verbatim, see {@link MockAdapterOptions.initialData}) */
   reset(data: T[] = []): void {
     this.data = [...data]
     this.rebuildIndex()

--- a/packages/core/tests/unit/id-uniqueness-parity.test.ts
+++ b/packages/core/tests/unit/id-uniqueness-parity.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Client-mode id uniqueness must behave identically on every adapter (#154).
+ *
+ * SheetsAdapter rejects a client-supplied id that already exists — or repeats
+ * inside one batch — with DuplicateIdError (#128). MockAdapter is the
+ * documented test double, so code that passes against it must not throw in
+ * production: the same scenarios run here against both stores and the results
+ * are asserted to agree. LocalAdapter is pinned to the same list in
+ * `packages/client/tests/unit/local/id-uniqueness.test.ts` (it lives in another
+ * package and pulls in IndexedDB/MutationQueue plumbing).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { DuplicateIdError } from '../../src/core/errors'
+import { installGasFakes } from '../../src/testing/install'
+import type { GasFakesHandle } from '../../src/testing/install'
+import { fromArrays } from '../../src/testing/loaders'
+import type { DataStore, IdMode, RowWithId } from '../../src/core/types'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+const SHEET_NAME = 'Users'
+const COLUMNS = ['id', 'name']
+
+interface TestRow extends RowWithId {
+  id: string | number
+  name: string
+}
+
+/** DataStore leaves batchInsert optional; every adapter under test implements it. */
+type BatchingStore<T extends RowWithId> = DataStore<T> & {
+  batchInsert(data: (T | Omit<T, 'id'>)[]): T[]
+}
+
+/** One adapter under test, plus a way to read back what it actually stored. */
+interface Harness {
+  store: BatchingStore<TestRow>
+  /** Ids currently stored, normalized to strings so adapters compare equal. */
+  ids(): string[]
+}
+
+type HarnessFactory = (idMode: IdMode, seed: TestRow[]) => Harness
+
+let gasFakes: GasFakesHandle | undefined
+
+afterEach(() => {
+  gasFakes?.restore()
+  gasFakes = undefined
+})
+
+const mockHarness: HarnessFactory = (idMode, seed) => {
+  const store = new MockAdapter<TestRow>({ initialData: seed, idMode })
+  return { store, ids: () => store.findAll().map(row => String(row.id)) }
+}
+
+const sheetsHarness: HarnessFactory = (idMode, seed) => {
+  const grid: unknown[][] = [COLUMNS, ...seed.map(row => [row.id, row.name])]
+  gasFakes = installGasFakes({
+    spreadsheets: { [SPREADSHEET_ID]: fromArrays({ [SHEET_NAME]: grid }) },
+    activeId: SPREADSHEET_ID,
+  })
+  const store = new SheetsAdapter<TestRow>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: SHEET_NAME,
+    columns: COLUMNS,
+    idMode,
+  })
+  return { store, ids: () => store.findAll().map(row => String(row.id)) }
+}
+
+const ADAPTERS: [name: string, factory: HarnessFactory][] = [
+  ['MockAdapter', mockHarness],
+  ['SheetsAdapter', sheetsHarness],
+]
+
+describe.each(ADAPTERS)('%s client-mode id uniqueness [#154]', (_name, createHarness) => {
+  const client = (seed: TestRow[] = []) => createHarness('client', seed)
+
+  it('insert() rejects an id that already exists', () => {
+    const { store, ids } = client([{ id: 'a', name: 'Alice' }])
+
+    expect(() => store.insert({ id: 'a', name: 'Clone' })).toThrow(DuplicateIdError)
+    expect(ids()).toEqual(['a'])
+  })
+
+  it('insert() matches ids across string/number representations', () => {
+    const { store, ids } = client([{ id: 7, name: 'Alice' }])
+
+    expect(() => store.insert({ id: '7', name: 'Clone' })).toThrow(DuplicateIdError)
+    expect(ids()).toEqual(['7'])
+  })
+
+  it('carries the offending id and a stable error code', () => {
+    const { store } = client([{ id: 'a', name: 'Alice' }])
+
+    try {
+      store.insert({ id: 'a', name: 'Clone' })
+      expect.unreachable('insert should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateIdError)
+      expect((error as DuplicateIdError).id).toBe('a')
+      expect((error as DuplicateIdError).code).toBe('DUPLICATE_ID')
+    }
+  })
+
+  it('batchInsert() writes nothing when one id already exists', () => {
+    const { store, ids } = client([{ id: 'a', name: 'Alice' }])
+
+    expect(() =>
+      store.batchInsert([
+        { id: 'b', name: 'Bob' },
+        { id: 'a', name: 'Clone' },
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(ids()).toEqual(['a'])
+  })
+
+  it('batchInsert() rejects ids duplicated within the same batch', () => {
+    const { store, ids } = client()
+
+    expect(() =>
+      store.batchInsert([
+        { id: 'a', name: 'Alice' },
+        { id: 'a', name: 'Clone' },
+      ])
+    ).toThrow(DuplicateIdError)
+    expect(ids()).toEqual([])
+  })
+
+  it('batchInsert() writes nothing when a later item omits its id', () => {
+    const { store, ids } = client()
+
+    expect(() =>
+      store.batchInsert([
+        { id: 'a', name: 'Alice' },
+        { name: 'No id' } as Omit<TestRow, 'id'>,
+      ])
+    ).toThrow(/ID is required/)
+    expect(ids()).toEqual([])
+  })
+
+  it('still accepts distinct ids', () => {
+    const { store, ids } = client()
+
+    store.insert({ id: 'a', name: 'Alice' })
+    store.batchInsert([
+      { id: 'b', name: 'Bob' },
+      { id: 'c', name: 'Carol' },
+    ])
+
+    expect(ids()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('frees an id again after the row is deleted', () => {
+    const { store, ids } = client([{ id: 'a', name: 'Alice' }])
+
+    expect(store.delete('a')).toBe(true)
+    expect(() => store.insert({ id: 'a', name: 'Reused' })).not.toThrow()
+    expect(ids()).toEqual(['a'])
+    expect(store.findById('a')?.name).toBe('Reused')
+  })
+
+  it('leaves auto mode unaffected: caller ids are ignored, not rejected', () => {
+    const { store, ids } = createHarness('auto', [])
+
+    store.insert({ id: 1, name: 'Alice' })
+    store.insert({ id: 1, name: 'Bob' })
+    store.batchInsert([{ id: 1, name: 'Carol' }])
+
+    expect(ids()).toEqual(['1', '2', '3'])
+  })
+})

--- a/website/docs/error-handling.md
+++ b/website/docs/error-handling.md
@@ -66,10 +66,10 @@ try {
 ### DuplicateIdError
 
 Thrown by `insert()`/`batchInsert()` on a `idMode: 'client'` store when the
-supplied id already exists (including a duplicate inside the same batch). The
-check runs under the write lock, so a concurrent execution that inserts the
-same id first wins and this one throws instead of writing a row that no id
-lookup could ever reach.
+supplied id already exists (including a duplicate inside the same batch). On
+`SheetsAdapter` the check runs under the write lock, so a concurrent execution
+that inserts the same id first wins and this one throws instead of writing a
+row that no id lookup could ever reach.
 
 ```ts
 try {
@@ -82,6 +82,16 @@ try {
   }
 }
 ```
+
+Every adapter enforces the same rule, so code that passes against the test
+double behaves the same in production: `MockAdapter` and the client-side
+`LocalAdapter` reject duplicates too, and a rejected write mutates nothing —
+no row, and on `LocalAdapter` no queued mutation and no IndexedDB write, so the
+duplicate fails at the call site instead of being pushed and dead-lettered.
+Ids are compared as strings, so `1` collides with `'1'`. `MockAdapter` has no
+table name and leaves `e.tableName` undefined. Rows seeded outside the insert
+path — `initialData`, `reset()`, `LocalAdapter.replaceAll()` (a sync pull), or
+rows already on the sheet — are taken verbatim and are not checked.
 
 ### NoResultsError
 


### PR DESCRIPTION
## Summary

`SheetsAdapter` (since #128) rejects client-mode inserts with a colliding ID via `DuplicateIdError`; MockAdapter and LocalAdapter silently accepted duplicates — so code tested green against the mock threw in production, and a LocalAdapter duplicate got pushed, rejected server-side, and dead-lettered (#132) instead of failing at the call site.

Both adapters now mirror SheetsAdapter's exact contract: existing-ID and duplicate-within-batch collisions throw `DuplicateIdError` **before any mutation** (string-compared ids, so `1` collides with `'1'`); a failed batch mutates nothing — which also fixes a pre-existing partial-write bug where a mid-batch item missing its `id` threw after earlier rows were already written/enqueued. On LocalAdapter a rejected insert enqueues no mutation and opens no IndexedDB transaction (verified by a transaction-counting fake).

New parity suites pin all three adapters to one scenario list: core `id-uniqueness-parity.test.ts` (9 scenarios × Mock/Sheets — SheetsAdapter passed unchanged, proving the tests encode its existing contract) and client `id-uniqueness.test.ts` (13 tests). Out of scope, documented: `initialData`/`reset()`/`replaceAll()` seed rows verbatim. Auto mode unchanged.

**Changelog note (breaking)**: Mock/LocalAdapter client-mode duplicate inserts now throw instead of silently appending.

## Related Issues

Closes #154

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (core 611, client 157)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_