### PR TITLE
chore: npm publish readiness — per-package README/LICENSE, version alignment, ESM contract, workspace-range guards

### DIFF
--- a/.claude/npm-publish-strategy.md
+++ b/.claude/npm-publish-strategy.md
@@ -186,6 +186,30 @@ npm dist-tag rm @gsquery/core beta
 
 ---
 
+## Publish with pnpm — never `npm publish`
+
+> The examples above are the intent; `.github/workflows/release.yml` (release-please
+> + `pnpm -r publish`) is what actually runs. Keep both on pnpm.
+
+`@gsquery/cli` declares `peerDependencies: { "@gsquery/core": "workspace:*" }` and
+`@gsquery/client` depends on `@gsquery/core: workspace:*`. `pnpm publish` rewrites those
+to the concrete version at pack time; `npm publish` ships `workspace:*` verbatim, which
+no installer can resolve — and a published version cannot be replaced.
+
+Two guards enforce this:
+
+| Guard | Where | Fails when |
+|---|---|---|
+| `scripts/check-publish-manifest.mjs` | `prepublishOnly` in every package | a `workspace:` / `catalog:` / `link:` range is in the manifest and the publisher is not pnpm |
+| `scripts/verify-publish-artifacts.mjs` (`pnpm verify:pack`) | release workflow, after build+test | a packed tarball is missing README/LICENSE/`dist`, leaks `src/`/`tests/`, or still contains a pnpm-only protocol |
+
+Run the artifact check locally before any release:
+
+```bash
+pnpm build && pnpm verify:pack          # add --list for full file listings
+node scripts/verify-publish-artifacts.mjs --list
+```
+
 ## Monorepo Publishing
 
 ### 전체 패키지 배포

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
 
       - run: pnpm test
 
+      # Guard (#142): packs every package and inspects the real tarball — README
+      # and LICENSE present, dist/ shipped, no src/test leakage, and no
+      # `workspace:*` range left in the manifest. All four are unfixable once a
+      # version is on npm.
+      - run: pnpm verify:pack
+
       - name: Publish to npm
         # Prereleases (rc/alpha/beta) go under the "rc" dist-tag so they never
         # clobber the "latest" tag that a plain `npm install` resolves to.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-sheets-query-monorepo",
-  "version": "0.9.0",
+  "version": "1.0.0-rc3",
   "private": true,
   "description": "Monorepo for gas-sheets-query",
   "scripts": {
@@ -10,6 +10,7 @@
     "test:coverage": "pnpm -r exec vitest run --coverage",
     "typecheck": "pnpm -r typecheck",
     "clean": "pnpm -r clean",
+    "verify:pack": "node scripts/verify-publish-artifacts.mjs",
     "dev": "pnpm --filter gsquery dev",
     "release": "pnpm build && pnpm -r publish --access public"
   },

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juhyeon Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,52 @@
+# @gsquery/cli
+
+> `gsquery` — schema codegen and migration scaffolding for [gas-sheets-query](https://github.com/juhyeonni/gas-sheets-query)
+
+Turns a `schema.gsq.yaml` file into typed tables, an optional typed client, and migration files.
+
+**📖 Full documentation lives in the [wiki](https://juhyeonni.github.io/gas-sheets-query/) — this README is just the tour.**
+
+## Install
+
+```bash
+pnpm add -D @gsquery/cli   # or: npm install --save-dev @gsquery/cli
+```
+
+## Quick Start
+
+```bash
+npx gsquery init                       # creates gsquery.config.json
+npx gsquery generate --client          # schema.gsq.yaml -> generated types + typed client
+```
+
+```yaml
+# schema.gsq.yaml
+tables:
+  User:
+    fields:
+      id:     number   @id
+      name:   string
+      email:  string   @unique
+      active: boolean  @default(true)
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `gsquery init` | Initialize project (creates `gsquery.config.json`) |
+| `gsquery generate` | Generate types/client code from schema (`--watch` to regenerate on change) |
+| `gsquery generate --client` | Also generate the typed client into your project |
+| `gsquery migration:create <name>` | Create a migration file |
+| `gsquery migrate` / `gsquery rollback` | **Preview** migrations/rollbacks — execution happens in the GAS runtime via `MigrationRunner` |
+
+## Documentation
+
+- [CLI Reference](https://juhyeonni.github.io/gas-sheets-query/cli-reference) · [Schema Definition](https://juhyeonni.github.io/gas-sheets-query/schema-definition)
+- [Migration System](https://juhyeonni.github.io/gas-sheets-query/migration-system) · [Typed Client](https://juhyeonni.github.io/gas-sheets-query/typed-client)
+
+The generated code imports from [`@gsquery/core`](https://www.npmjs.com/package/@gsquery/core) (peer dependency) and, with `--client`, from [`@gsquery/client`](https://www.npmjs.com/package/@gsquery/client).
+
+## License
+
+[MIT](./LICENSE) © Juhyeon Lee

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,10 +10,12 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm clean && pnpm build",
+    "prepublishOnly": "node ../../scripts/check-publish-manifest.mjs && pnpm clean && pnpm build",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
@@ -51,5 +53,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/client/LICENSE
+++ b/packages/client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juhyeon Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,48 @@
+# @gsquery/client
+
+> Browser runtime for [gas-sheets-query](https://github.com/juhyeonni/gas-sheets-query) — typed client + local-first sync
+
+Gives the browser the same `SheetsDB` API you use on GAS, backed by IndexedDB instead of a spreadsheet: local reads, queued offline mutations, and sync to a GAS web app.
+
+**📖 Full documentation lives in the [wiki](https://juhyeonni.github.io/gas-sheets-query/) — this README is just the tour.**
+
+## Install
+
+```bash
+pnpm add @gsquery/core @gsquery/client   # or: npm install @gsquery/core @gsquery/client
+```
+
+## Quick Start
+
+```typescript
+import { createClientDB, GasApiTransport } from '@gsquery/client'
+import { schema, type Tables } from './generated/client'  // from `gsquery generate --client`
+
+const { db, sync, close } = await createClientDB<Tables>({
+  schema,
+  transport: new GasApiTransport(),  // google.script.run inside GAS web apps
+})
+
+// Works offline immediately — mutations are queued locally
+db.from('users').create({ id: crypto.randomUUID(), name: 'John' })
+
+// Push queued mutations, then pull server state
+await sync.sync()
+```
+
+Prefer a thin typed wrapper over a remote GAS backend instead of a local copy? Use `createClientFactory` — see [Typed Client](https://juhyeonni.github.io/gas-sheets-query/typed-client).
+
+## ESM only
+
+This package is published as ESM only (`"type": "module"`, `exports` with an `import` condition). It targets browsers and bundlers, where every consumer resolves the `import` condition; unlike `@gsquery/core` — which additionally ships CJS and a GAS IIFE bundle — there is no `require()` consumer for an IndexedDB-backed runtime. Import it with `import`, not `require()`.
+
+## Documentation
+
+- [Local-First Client](https://juhyeonni.github.io/gas-sheets-query/local-first-client) · [Typed Client](https://juhyeonni.github.io/gas-sheets-query/typed-client)
+- [Installation](https://juhyeonni.github.io/gas-sheets-query/installation) · [API Reference](https://juhyeonni.github.io/gas-sheets-query/api-reference)
+
+The local-first client is single-tab: two tabs sharing a namespace can clobber each other's queued mutations. See the wiki for the full trade-off list.
+
+## License
+
+[MIT](./LICENSE) © Juhyeon Lee

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,19 +3,21 @@
   "version": "1.0.0-rc3",
   "description": "Typed client for gas-sheets-query",
   "type": "module",
-  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm clean && pnpm build",
+    "prepublishOnly": "node ../../scripts/check-publish-manifest.mjs && pnpm clean && pnpm build",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
@@ -48,5 +50,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juhyeon Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,60 @@
+# @gsquery/core
+
+> Use Google Sheets like a database — the runtime core of [gas-sheets-query](https://github.com/juhyeonni/gas-sheets-query)
+
+`SheetsDB`, the query builder, the adapters (GAS / in-memory), migrations, and the testing fakes.
+
+**📖 Full documentation lives in the [wiki](https://juhyeonni.github.io/gas-sheets-query/) — this README is just the tour.**
+
+## Install
+
+```bash
+pnpm add @gsquery/core   # or: npm install @gsquery/core
+```
+
+## Quick Start
+
+```typescript
+import { defineSheetsDB } from '@gsquery/core'
+
+const db = defineSheetsDB({
+  tables: {
+    users: {
+      columns: ['id', 'name', 'email', 'role'] as const,
+      types: { id: 0, name: '', email: '', role: '' }
+    }
+  },
+  mock: true  // in-memory for tests; use stores: { users: new SheetsAdapter({...}) } on GAS
+})
+
+const user = db.from('users').create({ name: 'John', email: 'john@example.com', role: 'USER' })
+
+const admins = db.from('users')
+  .query()
+  .where('role', '=', 'ADMIN')
+  .orderBy('name', 'asc')
+  .limit(10)
+  .exec()
+```
+
+## Entry Points
+
+| Import | Contents |
+|---|---|
+| `@gsquery/core` | `defineSheetsDB`, query/JOIN builders, `SheetsAdapter`, `MockAdapter`, migrations, errors |
+| `@gsquery/core/testing` | GAS fakes (`FakeSheet`, …) and CSV/JSON fixture loaders for unit tests |
+
+Ships ESM (`dist/index.mjs`), CJS (`dist/index.cjs`), and a standalone GAS bundle (`dist/gas/bundle.js`) for `clasp push`.
+
+## Documentation
+
+- [Installation](https://juhyeonni.github.io/gas-sheets-query/installation) · [Quick Start](https://juhyeonni.github.io/gas-sheets-query/quick-start)
+- [Query Builder](https://juhyeonni.github.io/gas-sheets-query/query-builder) · [JOIN](https://juhyeonni.github.io/gas-sheets-query/join-queries) · [Aggregation](https://juhyeonni.github.io/gas-sheets-query/aggregation)
+- [Adapters](https://juhyeonni.github.io/gas-sheets-query/adapters) · [Indexing & Performance](https://juhyeonni.github.io/gas-sheets-query/indexing-and-performance)
+- [API Reference](https://juhyeonni.github.io/gas-sheets-query/api-reference)
+
+Google Sheets is not a database engine — no transactions, full-table reads, per-execution caching. Read the Limitations section of the [project README](https://github.com/juhyeonni/gas-sheets-query) before you commit to it.
+
+## License
+
+[MIT](./LICENSE) © Juhyeon Lee

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,13 +16,16 @@
       "types": "./dist/types/testing/index.d.ts",
       "import": "./dist/testing.mjs",
       "require": "./dist/testing.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm clean && pnpm build",
+    "prepublishOnly": "node ../../scripts/check-publish-manifest.mjs && pnpm clean && pnpm build",
     "build": "node build.mjs && tsc --emitDeclarationOnly",
     "build:gas": "node build.mjs",
     "dev": "vitest",
@@ -54,5 +57,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/skills/LICENSE
+++ b/packages/skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juhyeon Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -14,15 +14,19 @@
       "import": "./dist/index.js"
     },
     "./skills": "./skills",
-    "./cheatsheet": "./skills/generic/gsquery-cheatsheet.md"
+    "./skills/*": "./skills/*",
+    "./cheatsheet": "./skills/generic/gsquery-cheatsheet.md",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",
     "bin",
-    "skills"
+    "skills",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm clean && pnpm build",
+    "prepublishOnly": "node ../../scripts/check-publish-manifest.mjs && pnpm clean && pnpm build",
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",

--- a/scripts/check-publish-manifest.mjs
+++ b/scripts/check-publish-manifest.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * prepublishOnly guard: refuse to publish a manifest that still carries
+ * pnpm-only dependency protocols unless pnpm itself is doing the packing.
+ *
+ * Why: `@gsquery/cli` declares `peerDependencies: { "@gsquery/core": "workspace:*" }`
+ * (and `@gsquery/client` a `workspace:*` dependency). `pnpm publish` rewrites those
+ * to the real version range at pack time; `npm publish` does not — it would ship a
+ * manifest that no installer can resolve, and the broken version cannot be replaced.
+ *
+ * Run from a package directory (that is what prepublishOnly does). Fail-closed:
+ * if we cannot prove pnpm is packing, we refuse.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const PNPM_ONLY_PROTOCOLS = ['workspace:', 'catalog:', 'link:']
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies'
+]
+
+const manifestPath = resolve(process.cwd(), 'package.json')
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+
+const offenders = []
+for (const field of DEPENDENCY_FIELDS) {
+  for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+    if (typeof range === 'string' && PNPM_ONLY_PROTOCOLS.some((p) => range.startsWith(p))) {
+      offenders.push(`${field}.${name}: "${range}"`)
+    }
+  }
+}
+
+if (offenders.length === 0) {
+  process.exit(0)
+}
+
+// pnpm sets npm_config_user_agent to "pnpm/<version> ..." for lifecycle scripts;
+// npm sets "npm/<version> ...". npm_execpath is the cross-check.
+const userAgent = process.env.npm_config_user_agent ?? ''
+const execPath = process.env.npm_execpath ?? ''
+const packedByPnpm = userAgent.startsWith('pnpm/') || /pnpm/.test(execPath)
+
+if (packedByPnpm) {
+  process.exit(0)
+}
+
+console.error(
+  [
+    '',
+    `✖ ${manifest.name}: refusing to publish — pnpm-only dependency protocols in package.json:`,
+    ...offenders.map((o) => `    ${o}`),
+    '',
+    '  These are rewritten to real version ranges only by `pnpm publish`.',
+    `  Detected publisher: ${userAgent || execPath || 'unknown (not a package-manager lifecycle)'}`,
+    '',
+    '  Publish with pnpm instead:',
+    '    pnpm -r publish --access public',
+    '    pnpm --filter <package> publish --access public',
+    ''
+  ].join('\n')
+)
+process.exit(1)

--- a/scripts/verify-publish-artifacts.mjs
+++ b/scripts/verify-publish-artifacts.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Pack every publishable workspace package and assert the tarball is fit to publish:
+ *
+ *   - README.md and LICENSE at the package root (npm renders the first, npm/legal
+ *     tooling reads the second — a `files: ["dist"]` list silently omits both unless
+ *     npm's implicit inclusion kicks in, so we verify the real artifact)
+ *   - dist/ present (the package actually ships code)
+ *   - no src/ or tests/ leakage
+ *   - no pnpm-only dependency protocols (workspace:/catalog:/link:) left in the
+ *     packed manifest — see scripts/check-publish-manifest.mjs
+ *
+ * Requires a prior `pnpm build`: pack does not run prepublishOnly.
+ *
+ * Usage: node scripts/verify-publish-artifacts.mjs [--list]
+ */
+import { execFileSync } from 'node:child_process'
+import { gunzipSync } from 'node:zlib'
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const showList = process.argv.includes('--list')
+
+const PNPM_ONLY_PROTOCOLS = ['workspace:', 'catalog:', 'link:']
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies'
+]
+
+/** Minimal tar reader: returns [{ name, content }] for regular files. */
+function readTar(buffer) {
+  const entries = []
+  let offset = 0
+  let longName = null
+
+  while (offset + 512 <= buffer.length) {
+    const header = buffer.subarray(offset, offset + 512)
+    if (header.every((byte) => byte === 0)) break
+
+    const readString = (start, length) => {
+      const raw = header.subarray(start, start + length)
+      const end = raw.indexOf(0)
+      return raw.subarray(0, end === -1 ? raw.length : end).toString('utf8')
+    }
+
+    const size = parseInt(readString(124, 12).trim() || '0', 8)
+    const typeFlag = String.fromCharCode(header[156])
+    const prefix = readString(345, 155)
+    const rawName = readString(0, 100)
+    const name = longName ?? (prefix ? `${prefix}/${rawName}` : rawName)
+    longName = null
+
+    const dataStart = offset + 512
+    const data = buffer.subarray(dataStart, dataStart + size)
+    offset = dataStart + Math.ceil(size / 512) * 512
+
+    if (typeFlag === 'L') {
+      // GNU long name: the payload is the next entry's path.
+      longName = data.toString('utf8').replace(/\0+$/, '')
+    } else if (typeFlag === 'x' || typeFlag === 'X') {
+      // pax extended header: "<len> path=<value>\n"
+      const match = data.toString('utf8').match(/\d+ path=(.*)\n/)
+      if (match) longName = match[1]
+    } else if (typeFlag === '0' || typeFlag === '\0') {
+      entries.push({ name, content: data })
+    }
+  }
+
+  return entries
+}
+
+const packagesDir = join(repoRoot, 'packages')
+const publishable = readdirSync(packagesDir)
+  .map((name) => join(packagesDir, name))
+  .filter((dir) => {
+    try {
+      return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')).private !== true
+    } catch {
+      return false
+    }
+  })
+  .sort()
+
+let failed = false
+const outDir = mkdtempSync(join(tmpdir(), 'gsquery-pack-'))
+
+try {
+  for (const packageDir of publishable) {
+    const manifest = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
+    console.log(`\n=== ${manifest.name}@${manifest.version} ===`)
+
+    execFileSync('pnpm', ['pack', '--pack-destination', outDir], {
+      cwd: packageDir,
+      stdio: ['ignore', 'ignore', 'inherit']
+    })
+
+    const tarballs = readdirSync(outDir).filter((f) => f.endsWith('.tgz'))
+    const tarball = join(outDir, tarballs[tarballs.length - 1])
+    const entries = readTar(gunzipSync(readFileSync(tarball)))
+    const files = entries.map((e) => e.name.replace(/^package\//, '')).sort()
+
+    const problems = []
+    const require = (predicate, message) => {
+      if (!predicate) problems.push(message)
+    }
+
+    require(files.includes('README.md'), 'missing README.md at package root')
+    require(files.includes('LICENSE'), 'missing LICENSE at package root')
+    require(files.includes('package.json'), 'missing package.json')
+    require(
+      files.some((f) => f.startsWith('dist/')),
+      'no dist/ output — run `pnpm build` first'
+    )
+
+    const leaked = files.filter((f) => f.startsWith('src/') || f.startsWith('tests/'))
+    require(leaked.length === 0, `source/test leakage: ${leaked.slice(0, 5).join(', ')}`)
+
+    const packedManifest = JSON.parse(
+      entries.find((e) => e.name === 'package/package.json').content.toString('utf8')
+    )
+    for (const field of DEPENDENCY_FIELDS) {
+      for (const [dep, range] of Object.entries(packedManifest[field] ?? {})) {
+        require(
+          !(typeof range === 'string' && PNPM_ONLY_PROTOCOLS.some((p) => range.startsWith(p))),
+          `unresolved pnpm protocol in packed manifest: ${field}.${dep} = "${range}"`
+        )
+      }
+    }
+
+    const summary = new Map()
+    for (const file of files) {
+      const top = file.includes('/') ? `${file.split('/')[0]}/` : file
+      summary.set(top, (summary.get(top) ?? 0) + 1)
+    }
+    for (const [top, count] of [...summary].sort()) {
+      console.log(count === 1 && !top.endsWith('/') ? `  ${top}` : `  ${top} (${count} files)`)
+    }
+    if (showList) for (const file of files) console.log(`    ${file}`)
+
+    if (problems.length > 0) {
+      failed = true
+      for (const problem of problems) console.error(`  ✖ ${problem}`)
+    } else {
+      console.log(`  ✔ ${files.length} files, publish-ready`)
+    }
+
+    rmSync(tarball)
+  }
+} finally {
+  rmSync(outDir, { recursive: true, force: true })
+}
+
+if (failed) {
+  console.error('\n✖ publish artifact verification failed')
+  process.exit(1)
+}
+console.log('\n✔ all packages publish-ready')


### PR DESCRIPTION
## Summary

Makes all four `@gsquery/*` packages safe to publish:

- **Per-package README.md + LICENSE** for core/cli/client (skills already had a README; all four get LICENSE), added to `files` — verified present in every tarball.
- **Version alignment**: private root `0.9.0` → `1.0.0-rc3`.
- **`@gsquery/client` stays ESM-only, `main` removed** — Node ignores `main` when `exports` exists, so the field promised a `require()` entry that never existed. CJS was deliberately not added: browser/bundler runtime, all docs and codegen emit `import`, `src` uses explicit `.js` specifiers so the output is Node-ESM resolvable. Trade-off documented in the client README.
- **`workspace:*` publish hazard, two-layer guard** — empirically confirmed `npm pack` ships `"workspace:*"` verbatim while `pnpm pack` rewrites it. (1) `prepublishOnly` runs `scripts/check-publish-manifest.mjs`, which discriminates npm vs pnpm via `npm_config_user_agent` (+`npm_execpath` cross-check, fails closed) — a naive grep would break legitimate pnpm publishes since `prepublishOnly` fires before the rewrite. (2) `release.yml` gains `pnpm verify:pack` (`scripts/verify-publish-artifacts.mjs`, dependency-free tar reader): asserts README/LICENSE/dist present, no src/tests leakage, no unresolved `workspace:` range in the packed manifest. All three guard paths verified, including a real `pnpm publish --dry-run`.
- `publishConfig.access: "public"` on core/cli/client; `"./package.json"` export added; skills gains `"./skills/*"` subpath.

Reported-not-fixed items (peer range `workspace:*` vs `workspace:^` semantics, skills folder-mapping export, stale root `dev` script, release-please naming, publish-strategy doc staleness) are listed in the review notes for a deliberate call.

## Related Issues

Closes #142

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated (verify:pack artifact checks)
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_