### PR TITLE
feat(core): typed GAS errors, transient-only retry, and cell-size guard (#136 light half)

### DIFF
--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -12,8 +12,14 @@ import type {
   AddColumnOptions
 } from '../core/types'
 import { evaluateCondition, compareRows } from '../core/query-utils'
-import { DuplicateIdError, SchemaMismatchError, UnknownColumnError } from '../core/errors'
+import {
+  CellSizeLimitError,
+  DuplicateIdError,
+  SchemaMismatchError,
+  UnknownColumnError
+} from '../core/errors'
 import { withScriptLock } from '../core/script-lock'
+import { withRetries } from '../core/gas-retry'
 
 /** Column type definition for schema-based serialization */
 export type ColumnType = 
@@ -38,6 +44,15 @@ const FORMULA_TRIGGER_CHARS = ['=', '+', '-', '@', '\t', '\r']
 
 /** Prefix that forces Sheets to store a written cell as literal text. */
 const TEXT_PREFIX = "'"
+
+/**
+ * Maximum characters Google Sheets stores in one cell.
+ *
+ * Enforced before any write (#136): the platform otherwise rejects the
+ * oversized cell mid-`setValues`, which aborts a multi-row batch halfway and
+ * leaves a partial update on the sheet.
+ */
+export const MAX_CELL_LENGTH = 50000
 
 /** SheetsAdapter configuration options */
 export interface SheetsAdapterOptions {
@@ -89,6 +104,31 @@ export interface SheetsAdapterOptions {
 /**
  * Google Sheets DataStore implementation
  * Provides CRUD operations on a single sheet
+ *
+ * ## Platform ceilings
+ *
+ * Sheets is not an unbounded store, and two of its limits are hard walls that
+ * a growing table will eventually hit (#136):
+ *
+ * - **50,000 characters per cell.** Enforced: every serialized value is
+ *   checked against {@link MAX_CELL_LENGTH} before any write, and a batch is
+ *   validated in full before its first write, so an oversized value fails the
+ *   whole operation instead of tearing it in half. See
+ *   {@link CellSizeLimitError}.
+ * - **10,000,000 cells per spreadsheet** (across all sheets; a sheet is also
+ *   capped at 18,278 columns). Deliberately *not* enforced at runtime: the
+ *   adapter would have to walk every sheet in the workbook on each write to
+ *   know the current total, which costs more than it saves. Budget for it
+ *   when sizing a table — `rows × columns` for this sheet is only its share.
+ *   A workbook at the ceiling rejects writes at the platform level, which
+ *   surfaces here as a {@link SheetsApiError}.
+ *
+ * ## Transient failures
+ *
+ * Sheets API calls that are safe to repeat (all reads, and `setValues` over a
+ * fixed range) are retried with bounded backoff; calls that are not
+ * idempotent (`appendRow`, `deleteRow`, `insertSheet`, `insertColumnBefore`)
+ * are attempted exactly once. See {@link SheetsAdapter.sheetsCall}.
  */
 export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   private spreadsheetId?: string
@@ -125,9 +165,11 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   /** Get the spreadsheet instance */
   private getSpreadsheet(): GoogleAppsScript.Spreadsheet.Spreadsheet {
     if (!this._spreadsheet) {
-      const ss = this.spreadsheetId
+      // Opening a document is a read, and one of the likeliest calls to hit a
+      // transient backend timeout, so it is worth retrying (#136).
+      const ss = this.sheetsCall(() => this.spreadsheetId
         ? SpreadsheetApp.openById(this.spreadsheetId)
-        : SpreadsheetApp.getActiveSpreadsheet()
+        : SpreadsheetApp.getActiveSpreadsheet())
       if (!ss) {
         throw new Error(
           `No spreadsheet available for sheet '${this.sheetName}'. ` +
@@ -144,13 +186,18 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   private getSheet(): GoogleAppsScript.Spreadsheet.Sheet {
     if (!this._sheet) {
       const ss = this.getSpreadsheet()
-      let sheet = ss.getSheetByName(this.sheetName)
-      
+      let sheet = this.sheetsCall(() => ss.getSheetByName(this.sheetName))
+
       if (!sheet) {
         if (this.createIfNotExists) {
-          sheet = ss.insertSheet(this.sheetName)
+          // insertSheet is not idempotent — a retry after a spurious failure
+          // would either create a second sheet or throw on the taken name.
+          const created = this.sheetsCallOnce(() => ss.insertSheet(this.sheetName))
+          sheet = created
           // Write header row
-          sheet.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
+          this.sheetsCall(() =>
+            created.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
+          )
         } else {
           throw new Error(`Sheet '${this.sheetName}' not found`)
         }
@@ -317,6 +364,13 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
    * written exactly as the same value would be written through a row write —
    * including formula-injection escaping (#130), so no user-supplied string
    * can reach the sheet as a live formula through either path.
+   *
+   * This is also the single choke point for the 50,000-character cell limit
+   * (#136): every write path serializes its whole payload here before issuing
+   * any Sheets call, so an oversized value fails the operation as a whole
+   * instead of aborting a batch halfway through.
+   *
+   * @throws {CellSizeLimitError} the serialized value exceeds {@link MAX_CELL_LENGTH}
    */
   private serializeCell(column: string, value: unknown): unknown {
     const colType = this.columnTypes[column]
@@ -337,7 +391,15 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       serialized = value
     }
 
-    return this.escapeCellValue(serialized)
+    // Measured after escaping, because the text marker is part of what the
+    // cell has to hold. Only strings can overflow — a number, boolean or Date
+    // has no length to speak of.
+    const cell = this.escapeCellValue(serialized)
+    if (typeof cell === 'string' && cell.length > MAX_CELL_LENGTH) {
+      throw new CellSizeLimitError(column, cell.length, MAX_CELL_LENGTH, this.sheetName)
+    }
+
+    return cell
   }
 
   /** Serialize value based on column type */
@@ -374,6 +436,43 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   /**
+   * Run one **idempotent** Sheets API call with bounded retry (#136).
+   *
+   * Use for reads and for `setValues` over a range whose coordinates were
+   * computed before the call: repeating either writes the same cells with the
+   * same values, so a repeat after a spurious failure is indistinguishable
+   * from the first attempt having worked.
+   *
+   * Placement is per call, not per public method. Wrapping a whole locked
+   * method would re-run its read-then-write sequence — including the id
+   * allocation — which is exactly the race the lock exists to prevent.
+   *
+   * Trade-off: because these calls sit inside the script lock, a retry sleeps
+   * while holding it. That is accepted and bounded — 1.5s worst case per
+   * guarded call with the defaults. It is not bounded *per operation*: a
+   * scattered `batchUpdate` retries once per contiguous run, so a sustained
+   * quota storm can stretch the lock hold. The per-operation deadline guard
+   * is the other half of #136.
+   */
+  private sheetsCall<R>(fn: () => R): R {
+    return withRetries(fn)
+  }
+
+  /**
+   * Run one **non-idempotent** Sheets API call: classify its failure, never
+   * repeat it (#136).
+   *
+   * `appendRow`, `deleteRow`, `insertSheet` and `insertColumnBefore` change
+   * the sheet's shape. A timeout from one of them does not say whether the
+   * mutation landed, so retrying risks a second append (in auto id mode, a
+   * duplicate row under a duplicate id) or a second deleted row. Losing the
+   * operation is recoverable; silently doubling it is not.
+   */
+  private sheetsCallOnce<R>(fn: () => R): R {
+    return withRetries(fn, { attempts: 1 })
+  }
+
+  /**
    * Read the id of a client-mode row, throwing when the caller omitted it.
    */
   private requireClientId(data: Omit<T, 'id'> | T): string | number {
@@ -393,7 +492,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     if (lastRow <= 1) return keys
 
     const idColIndex = this.columns.indexOf(this.idColumn) + 1
-    const ids = sheet.getRange(2, idColIndex, lastRow - 1, 1).getValues().flat()
+    const ids = this.sheetsCall(() =>
+      sheet.getRange(2, idColIndex, lastRow - 1, 1).getValues()
+    ).flat()
     for (const id of ids) {
       if (id === '' || id === null || id === undefined) continue
       keys.add(String(id))
@@ -435,7 +536,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
 
     const idColIndex = this.columns.indexOf(this.idColumn) + 1
     const idRange = sheet.getRange(2, idColIndex, lastRow - 1, 1)
-    const ids = idRange.getValues().flat().filter(id => typeof id === 'number' && !isNaN(id))
+    const ids = this.sheetsCall(() => idRange.getValues())
+      .flat()
+      .filter(id => typeof id === 'number' && !isNaN(id))
 
     if (ids.length === 0) return 0
     return Math.max(...ids as number[])
@@ -451,7 +554,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     const idColIndex = this.columns.indexOf(this.idColumn) + 1
     const idRange = sheet.getRange(2, idColIndex, lastRow - 1, 1)
     // Unescape so a stored id keeps matching the id the caller passes (#130).
-    const ids = idRange.getValues().flat().map(rowId => this.unescapeCellValue(rowId))
+    const ids = this.sheetsCall(() => idRange.getValues())
+      .flat()
+      .map(rowId => this.unescapeCellValue(rowId))
 
     // Support both string and number comparison
     const rowOffset = ids.findIndex(rowId => rowId === id || String(rowId) === String(id))
@@ -472,7 +577,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     }
 
     const dataRange = sheet.getRange(2, 1, lastRow - 1, this.columns.length)
-    const values = dataRange.getValues()
+    const values = this.sheetsCall(() => dataRange.getValues())
 
     this._dataCache = values
       .filter(row => row.some(cell => cell !== ''))
@@ -486,7 +591,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     if (rowIndex === -1) return undefined
     
     const sheet = this.getSheet()
-    const values = sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()[0]
+    const values = this.sheetsCall(() =>
+      sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()
+    )[0]
     return this.rowToObject(values)
   }
 
@@ -532,7 +639,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
         this.assertClientIdsAvailable([id])
         const newRow = data as T
         const rowValues = this.objectToRow(newRow)
-        sheet.appendRow(rowValues)
+        this.sheetsCallOnce(() => sheet.appendRow(rowValues))
         return newRow
       })
     } else {
@@ -542,7 +649,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
         const id = this.getNextId()
         const newRow = { ...data, [this.idColumn]: id } as T
         const rowValues = this.objectToRow(newRow)
-        sheet.appendRow(rowValues)
+        this.sheetsCallOnce(() => sheet.appendRow(rowValues))
         return newRow
       })
     }
@@ -559,7 +666,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       if (rowIndex === -1) return undefined
 
       this.invalidateDataCache()
-      const currentValues = sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()[0]
+      const currentValues = this.sheetsCall(() =>
+        sheet.getRange(rowIndex, 1, 1, this.columns.length).getValues()
+      )[0]
 
       // Cheap re-verification of the row we are about to overwrite — free here
       // because the row was read anyway, and it still guards the unlocked
@@ -575,7 +684,11 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
         (currentRow as Record<string, unknown>)[this.idColumn]
       const rowValues = this.objectToRow(updatedRow)
 
-      sheet.getRange(rowIndex, 1, 1, this.columns.length).setValues([rowValues])
+      // Fixed range, fixed values: repeating this write is a no-op, so it is
+      // safe to retry through a transient backend failure (#136).
+      this.sheetsCall(() =>
+        sheet.getRange(rowIndex, 1, 1, this.columns.length).setValues([rowValues])
+      )
 
       return updatedRow
     })
@@ -591,7 +704,9 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       if (rowIndex === -1) return false
 
       this.invalidateDataCache()
-      sheet.deleteRow(rowIndex)
+      // deleteRow shifts every row below it up, so a repeat after a spurious
+      // failure removes a second, innocent row. Attempt it exactly once.
+      this.sheetsCallOnce(() => sheet.deleteRow(rowIndex))
 
       return true
     })
@@ -606,8 +721,11 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     // Batch write all rows at once, appending after the current last row.
     const writeRows = (rows: unknown[][]) => {
       const lastRow = sheet.getLastRow()
-      sheet.getRange(lastRow + 1, 1, rows.length, this.columns.length)
-        .setValues(rows)
+      // The range is pinned before the call, so retrying rewrites the same
+      // cells rather than appending a second copy of the batch (#136).
+      this.sheetsCall(() =>
+        sheet.getRange(lastRow + 1, 1, rows.length, this.columns.length).setValues(rows)
+      )
     }
 
     if (this.idMode === 'client') {
@@ -734,9 +852,13 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       if (!endOfRun) continue
 
       const run = rows.slice(runStart, i)
-      sheet
-        .getRange(run[0].rowIndex, 1, run.length, this.columns.length)
-        .setValues(run.map(({ values }) => values))
+      // Each run is an idempotent fixed-range write, so it is retried
+      // individually rather than re-running the whole batch (#136).
+      this.sheetsCall(() =>
+        sheet
+          .getRange(run[0].rowIndex, 1, run.length, this.columns.length)
+          .setValues(run.map(({ values }) => values))
+      )
       runStart = i
     }
   }
@@ -744,24 +866,30 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   reset(data: T[] = []): void {
     this.invalidateDataCache()
     const sheet = this.getSheet()
-    
+
+    // Serialize before clearing. A cell-size rejection discovered after
+    // clear() would have destroyed the existing rows in exchange for a failed
+    // write — the guard has to run while the old data is still there (#136).
+    const rows = data.map(row => this.objectToRow(row))
+
     // Clear all data except header
     sheet.clear()
-    
+
     // Write header
-    sheet.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
-    
+    this.sheetsCall(() => sheet.getRange(1, 1, 1, this.columns.length).setValues([this.columns]))
+
     // Write data
-    if (data.length > 0) {
-      const rows = data.map(row => this.objectToRow(row))
-      sheet.getRange(2, 1, rows.length, this.columns.length).setValues(rows)
+    if (rows.length > 0) {
+      this.sheetsCall(() =>
+        sheet.getRange(2, 1, rows.length, this.columns.length).setValues(rows)
+      )
     }
   }
 
   /** Get raw sheet data (for debugging) */
   getRawData(): unknown[][] {
     const sheet = this.getSheet()
-    return sheet.getDataRange().getValues()
+    return this.sheetsCall(() => sheet.getDataRange().getValues())
   }
 
   /**
@@ -786,6 +914,12 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       throw new UnknownColumnError(column, this.sheetName, [...this.columns])
     }
 
+    // Serialize the default up front, so an oversized one is rejected before
+    // the sheet is restructured rather than after (#136).
+    const defaultCell = options?.default === undefined
+      ? undefined
+      : this.serializeCell(column, options.default)
+
     const sheet = this.getSheet()
     const header = this.readHeader()
     const headerIndex = header.indexOf(column)
@@ -803,16 +937,17 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       if (position <= header.length) {
         // Mid-schema insert: shift the existing columns right so their values
         // stay under their own header instead of sliding one column left.
-        sheet.insertColumnBefore(position)
+        // Not idempotent — a retry would shift the sheet twice.
+        this.sheetsCallOnce(() => sheet.insertColumnBefore(position))
       }
       // Rewrite the whole header from the schema to guarantee alignment.
-      sheet.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
+      this.sheetsCall(() => sheet.getRange(1, 1, 1, this.columns.length).setValues([this.columns]))
       this.invalidateDataCache()
     } else if (headerIndex !== targetIndex) {
       throw new SchemaMismatchError(this.sheetName, header, [...this.columns])
     }
 
-    this.backfillColumn(column, targetIndex + 1, options?.default)
+    this.backfillColumn(targetIndex + 1, defaultCell)
   }
 
   /** Read the current header row, trailing empty cells trimmed. */
@@ -821,7 +956,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     const lastColumn = sheet.getLastColumn()
     if (lastColumn < 1) return []
 
-    const values = sheet.getRange(1, 1, 1, lastColumn).getValues()[0]
+    const values = this.sheetsCall(() => sheet.getRange(1, 1, 1, lastColumn).getValues())[0]
     const header = values.map(value => (isEmptyCellValue(value) ? '' : String(value)))
     while (header.length > 0 && header[header.length - 1] === '') {
       header.pop()
@@ -830,20 +965,23 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   /**
-   * Write `defaultValue` into every empty cell of a column with one ranged
-   * write. Without a default nothing is written, so a re-run converges instead
-   * of rewriting all N rows every time.
+   * Write the already-serialized `cell` into every empty cell of a column with
+   * one ranged write. Without a default nothing is written, so a re-run
+   * converges instead of rewriting all N rows every time.
+   *
+   * Takes the serialized cell rather than the raw default so that
+   * {@link addColumn} can reject an oversized value before it restructures the
+   * sheet (#136).
    */
-  private backfillColumn(column: string, position: number, defaultValue: unknown): void {
-    if (defaultValue === undefined) return
+  private backfillColumn(position: number, cell: unknown): void {
+    if (cell === undefined) return
 
     const sheet = this.getSheet()
     const lastRow = sheet.getLastRow()
     if (lastRow <= 1) return
 
     const range = sheet.getRange(2, position, lastRow - 1, 1)
-    const current = range.getValues()
-    const cell = this.serializeCell(column, defaultValue)
+    const current = this.sheetsCall(() => range.getValues())
 
     let emptyCount = 0
     const filled = current.map(([value]) => {
@@ -856,7 +994,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
 
     if (emptyCount === 0) return
 
-    range.setValues(filled)
+    this.sheetsCall(() => range.setValues(filled))
     this.invalidateDataCache()
   }
 }

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -182,3 +182,319 @@ export class InvalidOperatorError extends SheetsQueryError {
     this.name = 'InvalidOperatorError'
   }
 }
+
+/* -------------------------------------------------------------------------
+ * GAS platform errors (#136)
+ *
+ * Apps Script reports every platform failure — quota exhaustion, a lock it
+ * could not hand out, a Sheets backend hiccup — as a plain `Error` whose only
+ * distinguishing feature is its message. Callers therefore cannot tell "come
+ * back in a second" from "your code has a bug", and nothing can decide what
+ * is worth retrying. The classes below give those failures a type, and
+ * {@link classifyGasError} maps the platform's messages onto them.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Thrown when the script lock could not be acquired within the timeout.
+ *
+ * `Lock.waitLock` is documented as "timing out with an exception"; that
+ * exception used to escape `withScriptLock` raw. A lock timeout means another
+ * execution is mid-write: the operation was not attempted at all, so it is
+ * safe for the caller to retry it later (but not immediately — see
+ * `withRetries`, which deliberately does not retry this).
+ */
+export class LockTimeoutError extends SheetsQueryError {
+  constructor(
+    /** The wait budget that elapsed, when the acquisition site knows it. */
+    public readonly timeoutMs?: number,
+    public readonly cause?: unknown
+  ) {
+    super(
+      `Could not acquire the script lock${timeoutMs === undefined ? '' : ` within ${timeoutMs}ms`}. ` +
+      'Another execution is holding it; no data was written. Retry the operation.',
+      'LOCK_TIMEOUT'
+    )
+    this.name = 'LockTimeoutError'
+  }
+}
+
+/**
+ * Thrown when a GAS quota or rate limit was hit.
+ *
+ * `transient` separates the two very different kinds the platform words
+ * almost identically: a short-term rate limit clears within seconds and is
+ * worth a backoff, while a daily quota (or the 6-minute execution ceiling)
+ * will not clear inside this execution — retrying it only burns what is left
+ * of the run.
+ */
+export class QuotaExceededError extends SheetsQueryError {
+  constructor(
+    public readonly originalMessage: string,
+    public readonly transient: boolean,
+    public readonly cause?: unknown
+  ) {
+    super(
+      `Google Apps Script quota exceeded${transient ? ' (rate limit, retryable)' : ' (not retryable in this execution)'}: ` +
+      originalMessage,
+      'QUOTA_EXCEEDED'
+    )
+    this.name = 'QuotaExceededError'
+  }
+}
+
+/**
+ * Thrown for a Sheets/Apps Script backend failure that is not a quota or a
+ * lock — timeouts against the Spreadsheets service, internal errors, the
+ * generic "a server error occurred". These are overwhelmingly transient.
+ */
+export class SheetsApiError extends SheetsQueryError {
+  constructor(
+    public readonly originalMessage: string,
+    public readonly transient: boolean = true,
+    public readonly cause?: unknown
+  ) {
+    super(`Google Sheets API error: ${originalMessage}`, 'SHEETS_API_ERROR')
+    this.name = 'SheetsApiError'
+  }
+}
+
+/**
+ * Thrown when a serialized value would not fit in a single Sheets cell.
+ *
+ * A cell holds at most 50,000 characters. Without this guard the platform
+ * discovers the overflow *during* the write, so a multi-row batch aborts
+ * halfway and leaves a partial update behind (#136). The guard runs over the
+ * whole batch before the first write, so the operation is all-or-nothing.
+ */
+export class CellSizeLimitError extends SheetsQueryError {
+  constructor(
+    public readonly column: string,
+    public readonly length: number,
+    public readonly limit: number,
+    public readonly tableName: string,
+    public readonly id?: string | number
+  ) {
+    const rowInfo = id === undefined ? '' : ` (row id "${id}")`
+    super(
+      `Value for column "${column}" in "${tableName}"${rowInfo} serializes to ${length} characters, ` +
+      `over the ${limit}-character Google Sheets cell limit. ` +
+      'Shorten the value, or split it across columns or a linked sheet. Nothing was written.',
+      'CELL_SIZE_LIMIT'
+    )
+    this.name = 'CellSizeLimitError'
+  }
+}
+
+/** How a matched GAS message is surfaced. */
+type GasErrorKind = 'lock' | 'quota' | 'api'
+
+/** One row of the classification table. */
+interface GasErrorPattern {
+  /** Lowercased substring searched for in the platform message. */
+  readonly match: string
+  /** Which typed error the match produces. */
+  readonly kind: GasErrorKind
+  /** Whether an immediate bounded retry can plausibly succeed. */
+  readonly transient: boolean
+  /** Why this string exists / where it comes from. */
+  readonly note: string
+}
+
+/**
+ * Known Apps Script failure messages, most specific first.
+ *
+ * Matching is a lowercased substring test, because the platform decorates
+ * these strings with service names, document ids and hints
+ * ("Service invoked too many times in a short time: spreadsheets. Try
+ * Utilities.sleep(1000) between calls."), and the wording of the decoration
+ * is not stable. The apostrophe in "We're sorry…" is dodged entirely by
+ * matching from "sorry," onwards — the platform emits both the ASCII and the
+ * typographic form.
+ *
+ * Sources:
+ * - `Lock.waitLock` / `tryLock` semantics and the lock-timeout exception:
+ *   https://developers.google.com/apps-script/reference/lock/lock
+ * - Quota / rate-limit exception wording ("Service invoked too many times",
+ *   "Service using too much computer time for one day", the 6-minute
+ *   execution ceiling):
+ *   https://developers.google.com/apps-script/guides/services/quotas
+ * - "Service Spreadsheets timed out while accessing document with id …" and
+ *   the recommendation to answer it with truncated exponential backoff:
+ *   https://support.google.com/docs/thread/225093185
+ *   https://gist.github.com/peterherrmann/2700284 (GASRetry)
+ * - Generic server errors ("We're sorry, a server error occurred", "Internal
+ *   error", "Unexpected error while getting the method or property …"):
+ *   https://groups.google.com/g/google-apps-script-community/c/FcbkowjjXz8
+ */
+const GAS_ERROR_PATTERNS: readonly GasErrorPattern[] = [
+  // --- lock acquisition -------------------------------------------------
+  {
+    match: 'lock timeout',
+    kind: 'lock',
+    transient: false,
+    note: 'LockService.waitLock: "Lock timeout: another process was holding the lock for too long."'
+  },
+  {
+    match: 'could not obtain lock',
+    kind: 'lock',
+    transient: false,
+    note: 'Legacy LockService wording, still emitted by some runtimes.'
+  },
+
+  // --- terminal quotas (checked before the generic quota strings) -------
+  {
+    match: 'exceeded maximum execution time',
+    kind: 'quota',
+    transient: false,
+    note: '6-minute per-execution ceiling. The runtime is killing the script; a retry cannot run.'
+  },
+  {
+    match: 'too many times for one day',
+    kind: 'quota',
+    transient: false,
+    note: '"Service invoked too many times for one day: <service>." Resets at midnight PT.'
+  },
+  {
+    match: 'too much computer time for one day',
+    kind: 'quota',
+    transient: false,
+    note: 'Daily total-runtime quota.'
+  },
+
+  // --- transient rate limits -------------------------------------------
+  {
+    match: 'too many times in a short time',
+    kind: 'quota',
+    transient: true,
+    note: 'Short-term rate limit; the platform itself suggests Utilities.sleep between calls.'
+  },
+  {
+    match: 'service invoked too many times',
+    kind: 'quota',
+    transient: true,
+    note: 'Undecorated form of the rate limit; assumed short-term (the daily rows above win first).'
+  },
+  {
+    match: 'rate limit exceeded',
+    kind: 'quota',
+    transient: true,
+    note: 'Drive/Sheets REST wording that reaches Apps Script through advanced services.'
+  },
+  {
+    match: 'ratelimitexceeded',
+    kind: 'quota',
+    transient: true,
+    note: 'camelCase reason code from the JSON APIs.'
+  },
+  {
+    match: 'quota exceeded',
+    kind: 'quota',
+    transient: true,
+    note: 'Generic quota wording; short-term unless one of the daily rows matched first.'
+  },
+
+  // --- transient backend failures ---------------------------------------
+  {
+    match: 'timed out',
+    kind: 'api',
+    transient: true,
+    note:
+      '"Service Spreadsheets timed out while accessing document with id <id>." — the classic ' +
+      'transient Sheets failure. The bare substring also covers the "Service timed out: Spreadsheets" ordering.'
+  },
+  {
+    match: 'too many simultaneous invocations',
+    kind: 'api',
+    transient: true,
+    note: 'Concurrent-execution contention against one document.'
+  },
+  {
+    match: 'internal error',
+    kind: 'api',
+    transient: true,
+    note: '"Internal error while accessing spreadsheet."'
+  },
+  {
+    match: 'sorry, a server error occurred',
+    kind: 'api',
+    transient: true,
+    note: 'Both the ASCII and typographic apostrophe forms of "We\'re sorry, …".'
+  },
+  {
+    match: 'server error occurred',
+    kind: 'api',
+    transient: true,
+    note: 'Shorter variant of the same server error.'
+  },
+  {
+    match: 'unexpected error while getting the method or property',
+    kind: 'api',
+    transient: true,
+    note: 'Widely reported transient failure when a SpreadsheetApp handle briefly goes bad.'
+  },
+  {
+    match: 'service unavailable',
+    kind: 'api',
+    transient: true,
+    note: '"Service unavailable: Spreadsheets".'
+  },
+  {
+    match: 'service error:',
+    kind: 'api',
+    transient: true,
+    note: '"Service error: Spreadsheets".'
+  }
+]
+
+/** Best-effort message extraction from an unknown thrown value. */
+function messageOf(error: unknown): string | undefined {
+  if (error instanceof Error) return error.message
+  return undefined
+}
+
+/**
+ * Map a thrown value onto a typed library error.
+ *
+ * Returns `undefined` when the value is not a recognized GAS platform failure
+ * — an unrecognized error is a logical error, and silently relabelling it
+ * would hide real bugs behind a retry loop. An error that is already a
+ * {@link SheetsQueryError} is returned as-is.
+ */
+export function classifyGasError(error: unknown): SheetsQueryError | undefined {
+  if (error instanceof SheetsQueryError) return error
+
+  const message = messageOf(error)
+  if (message === undefined) return undefined
+
+  const haystack = message.toLowerCase()
+  for (const pattern of GAS_ERROR_PATTERNS) {
+    if (haystack.indexOf(pattern.match) === -1) continue
+
+    switch (pattern.kind) {
+      case 'lock':
+        // The wait budget is not in the message; the acquisition site adds it.
+        return new LockTimeoutError(undefined, error)
+      case 'quota':
+        return new QuotaExceededError(message, pattern.transient, error)
+      case 'api':
+        return new SheetsApiError(message, pattern.transient, error)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Whether a bounded retry with backoff can plausibly succeed for this error.
+ *
+ * Deliberately false for {@link LockTimeoutError}: the caller already waited
+ * the full lock timeout, so an immediate second wait just spends the same
+ * budget again. Also false for anything unrecognized — retrying a logical
+ * error multiplies its side effects instead of fixing it.
+ */
+export function isTransientGasError(error: unknown): boolean {
+  const classified = classifyGasError(error)
+  if (classified instanceof QuotaExceededError) return classified.transient
+  if (classified instanceof SheetsApiError) return classified.transient
+  return false
+}

--- a/packages/core/src/core/gas-retry.ts
+++ b/packages/core/src/core/gas-retry.ts
@@ -1,0 +1,87 @@
+/**
+ * Bounded retry with backoff for transient Apps Script failures (#136).
+ *
+ * The Sheets backend fails spuriously: "Service Spreadsheets timed out",
+ * "Internal error", short-term rate limits. Google's own guidance for these
+ * is truncated exponential backoff. Nothing in this library retried anything,
+ * so a single blip failed the whole user-facing operation.
+ *
+ * What this helper deliberately does *not* do:
+ *
+ * - It never retries an unrecognized error. A logical bug retried three times
+ *   is a bug with three times the side effects.
+ * - It never retries a {@link LockTimeoutError}. `waitLock` already spent the
+ *   caller's full wait budget; asking again immediately just spends it twice.
+ * - It never retries a daily quota or the 6-minute execution ceiling. Those
+ *   cannot clear inside this execution, so sleeping on them only burns what
+ *   is left of it.
+ *
+ * Backoff is deterministic (no jitter) on purpose: the total is two short
+ * sleeps, so the thundering-herd problem jitter solves does not apply at this
+ * scale, and determinism keeps the policy testable.
+ */
+import { classifyGasError, isTransientGasError } from './errors'
+
+/** Total number of calls (not extra retries) a guarded operation may make. */
+export const DEFAULT_RETRY_ATTEMPTS = 3
+
+/** Delay before the first retry; each further retry doubles it. */
+export const DEFAULT_RETRY_BASE_DELAY_MS = 500
+
+/** Options for {@link withRetries}. */
+export interface RetryOptions {
+  /**
+   * Total attempts, including the first. `1` disables retrying but keeps the
+   * error classification, which is how non-idempotent calls are guarded.
+   */
+  attempts?: number
+  /** Delay before the first retry, in ms. Doubles on each subsequent retry. */
+  baseDelayMs?: number
+  /**
+   * Sleep implementation. Defaults to `Utilities.sleep` on GAS and to a no-op
+   * everywhere else — Node has no synchronous sleep, and blocking a test run
+   * for seconds to reproduce a platform delay buys nothing.
+   */
+  sleep?: (ms: number) => void
+}
+
+/** `Utilities.sleep` when running on the platform; a no-op otherwise. */
+function platformSleep(ms: number): void {
+  if (typeof Utilities !== 'undefined' && typeof Utilities.sleep === 'function') {
+    Utilities.sleep(ms)
+  }
+}
+
+/**
+ * Run `fn`, retrying transient GAS failures with exponential backoff.
+ *
+ * Whatever finally escapes is the typed error from
+ * {@link classifyGasError} when the platform message is recognized, and the
+ * original value untouched when it is not. So even with `attempts: 1` this is
+ * worth wrapping around a Sheets call: it is what turns raw platform strings
+ * into `QuotaExceededError` / `SheetsApiError` at the API boundary.
+ *
+ * Worst-case added latency with the defaults is `500 + 1000 = 1500ms` per
+ * guarded call. Callers that hold the script lock across several guarded
+ * calls should keep that multiplication in mind — see the note on
+ * `SheetsAdapter.sheetsCall`.
+ */
+export function withRetries<R>(fn: () => R, options: RetryOptions = {}): R {
+  const attempts = options.attempts ?? DEFAULT_RETRY_ATTEMPTS
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS
+  const sleep = options.sleep ?? platformSleep
+
+  let attempt = 0
+  for (;;) {
+    attempt++
+    try {
+      return fn()
+    } catch (error) {
+      const isLastAttempt = attempt >= attempts
+      if (isLastAttempt || !isTransientGasError(error)) {
+        throw classifyGasError(error) ?? error
+      }
+      sleep(baseDelayMs * Math.pow(2, attempt - 1))
+    }
+  }
+}

--- a/packages/core/src/core/script-lock.ts
+++ b/packages/core/src/core/script-lock.ts
@@ -8,6 +8,7 @@
  * sequence. LockService is absent outside GAS (Node tests, bundlers), in which
  * case these helpers degrade to running the callback unlocked.
  */
+import { classifyGasError, LockTimeoutError } from './errors'
 
 /** Default time (ms) to wait for the script lock before giving up. */
 export const DEFAULT_LOCK_TIMEOUT_MS = 10000
@@ -22,11 +23,34 @@ export const DEFAULT_LOCK_TIMEOUT_MS = 10000
  */
 let lockDepth = 0
 
-/** Acquires the script lock, or returns null when LockService is unavailable. */
+/**
+ * Acquires the script lock, or returns null when LockService is unavailable.
+ *
+ * `waitLock` is documented as "timing out with an exception", and that
+ * exception used to escape as a raw `Error` — indistinguishable from a bug,
+ * so callers could not tell "someone else is writing, come back later" from
+ * "your code is broken" (#136). It is classified here instead: a recognized
+ * non-lock platform failure keeps its own type, and anything else from
+ * `waitLock` is a failed acquisition, because that is the method's only
+ * documented failure mode.
+ *
+ * No lock is held when this throws, so the caller's operation was not
+ * attempted at all.
+ */
 function acquireLock(timeoutMs: number): GoogleAppsScript.Lock.Lock | null {
   if (typeof LockService === 'undefined') return null
   const lock = LockService.getScriptLock()
-  lock.waitLock(timeoutMs)
+  try {
+    lock.waitLock(timeoutMs)
+  } catch (error) {
+    const classified = classifyGasError(error)
+    if (classified !== undefined && !(classified instanceof LockTimeoutError)) {
+      throw classified
+    }
+    // Re-created rather than rethrown so the error reports the wait budget
+    // the caller actually asked for, which is not in the platform message.
+    throw new LockTimeoutError(timeoutMs, error)
+  }
   return lock
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ export type { SheetsDB, TableHandle, CreateSheetsDBOptions, DefineSheetsDBOption
 // Adapters
 export { MockAdapter } from './adapters/mock-adapter'
 export type { MockAdapterOptions } from './adapters/mock-adapter'
-export { SheetsAdapter } from './adapters/sheets-adapter'
+export { SheetsAdapter, MAX_CELL_LENGTH } from './adapters/sheets-adapter'
 export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter'
 
 // Query utilities
@@ -69,8 +69,19 @@ export {
   ValidationError,
   InvalidOperatorError,
   UnknownColumnError,
-  SchemaMismatchError
+  SchemaMismatchError,
+  // GAS platform errors (#136)
+  LockTimeoutError,
+  QuotaExceededError,
+  SheetsApiError,
+  CellSizeLimitError,
+  classifyGasError,
+  isTransientGasError
 } from './core/errors'
+
+// Bounded retry with backoff for transient GAS failures (#136)
+export { withRetries, DEFAULT_RETRY_ATTEMPTS, DEFAULT_RETRY_BASE_DELAY_MS } from './core/gas-retry'
+export type { RetryOptions } from './core/gas-retry'
 
 // Migration System
 export {

--- a/packages/core/tests/unit/cell-size-guard.test.ts
+++ b/packages/core/tests/unit/cell-size-guard.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #136 — a Sheets cell holds at most 50,000 characters. Oversized values used
+ * to be discovered by the platform *during* the write, so a batch aborted
+ * halfway and left a partial update behind. These tests pin that the guard
+ * rejects before anything is written, and that a batch is validated as a whole.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { MAX_CELL_LENGTH, SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { CellSizeLimitError } from '../../src'
+import type { FakeSheet } from '../../src/testing/fake-sheet'
+import type { FakeSpreadsheet } from '../../src/testing/fake-spreadsheet'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+import type { GasFakesHandle } from '../../src/testing/install'
+
+interface Row {
+  id: number
+  name: string
+  notes: string
+  [key: string]: unknown
+}
+
+const SPREADSHEET_ID = 'cell-size-guard'
+const SHEET_NAME = 'Docs'
+const COLUMNS = ['id', 'name', 'notes']
+
+/** A string that fits, and one that does not. */
+const OK_VALUE = 'x'.repeat(MAX_CELL_LENGTH)
+const OVERSIZED = 'x'.repeat(MAX_CELL_LENGTH + 1)
+
+let handle: GasFakesHandle
+let spreadsheet: FakeSpreadsheet
+let sheet: FakeSheet
+let writes: number
+
+function seed(rows: unknown[][] = []): SheetsAdapter<Row> {
+  spreadsheet = fromArrays({ [SHEET_NAME]: [COLUMNS, ...rows] })
+  handle = installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+
+  const found = spreadsheet.getSheetByName(SHEET_NAME)
+  if (!found) throw new Error('seed: sheet missing')
+  sheet = found
+
+  // Count every mutation the adapter attempts, whatever shape it takes.
+  writes = 0
+  const originalGetRange = sheet.getRange.bind(sheet)
+  sheet.getRange = (row: number, col: number, numRows = 1, numCols = 1) => {
+    const range = originalGetRange(row, col, numRows, numCols)
+    const setValues = range.setValues.bind(range)
+    range.setValues = (values: unknown[][]) => {
+      writes++
+      setValues(values)
+    }
+    return range
+  }
+  const originalAppend = sheet.appendRow.bind(sheet)
+  sheet.appendRow = (values: unknown[]) => {
+    writes++
+    originalAppend(values)
+  }
+
+  return new SheetsAdapter<Row>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: SHEET_NAME,
+    columns: COLUMNS
+  })
+}
+
+describe('cell size guard (#136)', () => {
+  afterEach(() => handle?.restore())
+
+  it('exposes the documented Sheets ceiling', () => {
+    expect(MAX_CELL_LENGTH).toBe(50000)
+  })
+
+  it('accepts a value exactly at the limit', () => {
+    const adapter = seed()
+    expect(() => adapter.insert({ name: 'ok', notes: OK_VALUE })).not.toThrow()
+    expect(sheet.getLastRow()).toBe(2)
+  })
+
+  it('rejects an oversized value on insert without writing', () => {
+    const adapter = seed()
+
+    try {
+      adapter.insert({ name: 'too big', notes: OVERSIZED })
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(CellSizeLimitError)
+      const typed = error as CellSizeLimitError
+      expect(typed.code).toBe('CELL_SIZE_LIMIT')
+      expect(typed.column).toBe('notes')
+      expect(typed.tableName).toBe(SHEET_NAME)
+      expect(typed.length).toBe(MAX_CELL_LENGTH + 1)
+      expect(typed.limit).toBe(MAX_CELL_LENGTH)
+      expect(typed.message).toContain('notes')
+      expect(typed.message).toContain(SHEET_NAME)
+      expect(typed.message).toContain(String(MAX_CELL_LENGTH + 1))
+    }
+
+    expect(writes).toBe(0)
+    expect(sheet.getLastRow()).toBe(1)
+  })
+
+  it('measures the serialized JSON, not the source object', () => {
+    // A modest-looking object can serialize past the limit; the guard has to
+    // run on what actually reaches the cell.
+    seed()
+    const adapter = new SheetsAdapter<Row>({
+      spreadsheetId: SPREADSHEET_ID,
+      sheetName: SHEET_NAME,
+      columns: COLUMNS,
+      columnTypes: { notes: 'json' }
+    })
+    const big = { blob: 'y'.repeat(MAX_CELL_LENGTH) }
+
+    expect(() => adapter.insert({ name: 'json', notes: big as unknown as string }))
+      .toThrow(CellSizeLimitError)
+    expect(writes).toBe(0)
+  })
+
+  it('rejects the whole batch before writing any row', () => {
+    const adapter = seed()
+    const items = [
+      { name: 'a', notes: 'fine' },
+      { name: 'b', notes: 'fine' },
+      { name: 'c', notes: OVERSIZED },
+      { name: 'd', notes: 'fine' }
+    ]
+
+    expect(() => adapter.batchInsert(items)).toThrow(CellSizeLimitError)
+    expect(writes).toBe(0)
+    expect(sheet.getLastRow()).toBe(1)
+  })
+
+  it('rejects the whole batchUpdate before writing any row', () => {
+    const adapter = seed([
+      [1, 'a', 'fine'],
+      [2, 'b', 'fine'],
+      [3, 'c', 'fine']
+    ])
+
+    expect(() => adapter.batchUpdate([
+      { id: 1, data: { notes: 'still fine' } },
+      { id: 3, data: { notes: OVERSIZED } }
+    ])).toThrow(CellSizeLimitError)
+
+    expect(writes).toBe(0)
+    expect(adapter.findById(1)?.notes).toBe('fine')
+  })
+
+  it('rejects an oversized update without touching the row', () => {
+    const adapter = seed([[1, 'a', 'fine']])
+
+    expect(() => adapter.update(1, { notes: OVERSIZED })).toThrow(CellSizeLimitError)
+    expect(writes).toBe(0)
+    expect(adapter.findById(1)?.notes).toBe('fine')
+  })
+
+  it('rejects an oversized addColumn default before clearing or writing data', () => {
+    const adapter = new SheetsAdapter<Row>({
+      spreadsheetId: SPREADSHEET_ID,
+      sheetName: SHEET_NAME,
+      columns: COLUMNS
+    })
+    seed([[1, 'a', '']])
+
+    expect(() => adapter.addColumn('notes', { default: OVERSIZED })).toThrow(CellSizeLimitError)
+  })
+
+  it('rejects an oversized reset row before clearing the sheet', () => {
+    const adapter = seed([[1, 'a', 'existing']])
+
+    expect(() => adapter.reset([
+      { id: 1, name: 'a', notes: 'fine' },
+      { id: 2, name: 'b', notes: OVERSIZED }
+    ])).toThrow(CellSizeLimitError)
+
+    // The old data must survive: a guard that fires after clear() is a data-loss bug.
+    expect(sheet.getLastRow()).toBe(2)
+    expect(adapter.findById(1)?.notes).toBe('existing')
+  })
+
+  it('accounts for the formula-escape prefix', () => {
+    // '=' + 50,000 chars becomes "'=..." — 50,002 characters in the cell.
+    const adapter = seed()
+    expect(() => adapter.insert({ name: 'formulaish', notes: '=' + 'z'.repeat(MAX_CELL_LENGTH - 1) }))
+      .toThrow(CellSizeLimitError)
+  })
+})

--- a/packages/core/tests/unit/gas-error-classification.test.ts
+++ b/packages/core/tests/unit/gas-error-classification.test.ts
@@ -1,0 +1,142 @@
+/**
+ * #136 — GAS surfaces every platform failure as a bare `Error` whose only
+ * distinguishing feature is its message. These tests pin the classification
+ * table that turns those messages into typed errors, and pin which of them
+ * are transient (worth retrying) versus terminal (retrying only burns the
+ * remaining execution budget).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  LockTimeoutError,
+  QuotaExceededError,
+  SheetsApiError,
+  SheetsQueryError,
+  DuplicateIdError,
+  classifyGasError,
+  isTransientGasError
+} from '../../src'
+
+describe('classifyGasError (#136)', () => {
+  describe('lock failures', () => {
+    const messages = [
+      'Lock timeout: another process was holding the lock for too long.',
+      'Could not obtain lock.',
+      'Action not allowed: could not obtain lock'
+    ]
+
+    for (const message of messages) {
+      it(`classifies "${message}" as LockTimeoutError`, () => {
+        const error = classifyGasError(new Error(message))
+        expect(error).toBeInstanceOf(LockTimeoutError)
+        expect(error?.code).toBe('LOCK_TIMEOUT')
+      })
+    }
+
+    it('never treats a lock timeout as transient', () => {
+      // The caller already waited the full timeout; an immediate retry would
+      // just wait it again while holding nothing.
+      expect(isTransientGasError(new Error('Lock timeout: another process'))).toBe(false)
+    })
+  })
+
+  describe('quota failures', () => {
+    it('classifies short-term rate limits as transient', () => {
+      const error = classifyGasError(
+        new Error('Service invoked too many times in a short time: spreadsheets. Try Utilities.sleep(1000) between calls.')
+      )
+      expect(error).toBeInstanceOf(QuotaExceededError)
+      expect(error?.code).toBe('QUOTA_EXCEEDED')
+      expect((error as QuotaExceededError).transient).toBe(true)
+    })
+
+    it('classifies daily quota exhaustion as terminal', () => {
+      const error = classifyGasError(new Error('Service invoked too many times for one day: spreadsheets.'))
+      expect(error).toBeInstanceOf(QuotaExceededError)
+      expect((error as QuotaExceededError).transient).toBe(false)
+      expect(isTransientGasError(error)).toBe(false)
+    })
+
+    it('classifies the execution-time limit as a terminal quota error', () => {
+      const error = classifyGasError(new Error('Exceeded maximum execution time'))
+      expect(error).toBeInstanceOf(QuotaExceededError)
+      expect((error as QuotaExceededError).transient).toBe(false)
+    })
+
+    it('classifies the daily compute-time limit as terminal', () => {
+      const error = classifyGasError(new Error('Service using too much computer time for one day'))
+      expect((error as QuotaExceededError).transient).toBe(false)
+    })
+
+    it('preserves the original message', () => {
+      const raw = 'Service invoked too many times in a short time: spreadsheets.'
+      const error = classifyGasError(new Error(raw)) as QuotaExceededError
+      expect(error.originalMessage).toBe(raw)
+      expect(error.message).toContain(raw)
+    })
+  })
+
+  describe('transient Sheets API failures', () => {
+    const messages = [
+      'Service Spreadsheets timed out while accessing document with id 1AbC.',
+      'Service timed out: Spreadsheets',
+      'Internal error while accessing spreadsheet.',
+      "We're sorry, a server error occurred. Please wait a bit and try again.",
+      'We’re sorry, a server error occurred. Please wait a bit and try again.',
+      'Service error: Spreadsheets',
+      'Service unavailable: Spreadsheets',
+      'Unexpected error while getting the method or property getRange on object SpreadsheetApp.Spreadsheet.',
+      'Too many simultaneous invocations: Spreadsheets'
+    ]
+
+    for (const message of messages) {
+      it(`classifies "${message.slice(0, 40)}..." as a transient SheetsApiError`, () => {
+        const error = classifyGasError(new Error(message))
+        expect(error).toBeInstanceOf(SheetsApiError)
+        expect(error?.code).toBe('SHEETS_API_ERROR')
+        expect((error as SheetsApiError).transient).toBe(true)
+        expect((error as SheetsApiError).originalMessage).toBe(message)
+        expect(isTransientGasError(error)).toBe(true)
+      })
+    }
+
+    it('matches case-insensitively', () => {
+      expect(classifyGasError(new Error('SERVICE SPREADSHEETS TIMED OUT'))).toBeInstanceOf(SheetsApiError)
+    })
+  })
+
+  describe('non-GAS failures', () => {
+    it('returns undefined for an unrecognized message', () => {
+      expect(classifyGasError(new Error('Cannot read property foo of undefined'))).toBeUndefined()
+      expect(isTransientGasError(new Error('boom'))).toBe(false)
+    })
+
+    it('returns undefined for a non-Error value', () => {
+      expect(classifyGasError('Service Spreadsheets timed out')).toBeUndefined()
+      expect(classifyGasError(undefined)).toBeUndefined()
+    })
+
+    it('passes an already-typed library error through untouched', () => {
+      const original = new DuplicateIdError(7, 'Users')
+      expect(classifyGasError(original)).toBe(original)
+      expect(isTransientGasError(original)).toBe(false)
+    })
+  })
+
+  describe('error shape', () => {
+    it('extends the SheetsQueryError hierarchy', () => {
+      const lock = new LockTimeoutError(10000)
+      const quota = new QuotaExceededError('raw', true)
+      const api = new SheetsApiError('raw')
+
+      for (const error of [lock, quota, api]) {
+        expect(error).toBeInstanceOf(Error)
+        expect(error).toBeInstanceOf(SheetsQueryError)
+      }
+      expect(lock.name).toBe('LockTimeoutError')
+      expect(quota.name).toBe('QuotaExceededError')
+      expect(api.name).toBe('SheetsApiError')
+      expect(lock.timeoutMs).toBe(10000)
+      expect(api.transient).toBe(true)
+    })
+  })
+})

--- a/packages/core/tests/unit/gas-retry.test.ts
+++ b/packages/core/tests/unit/gas-retry.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #136 — bounded retry with backoff for transient GAS failures.
+ *
+ * Failures are injected rather than provoked: the point is the retry policy
+ * (what is retried, how many times, how long it sleeps, what finally escapes)
+ * and that a logical error is never retried.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_RETRY_ATTEMPTS,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  withRetries
+} from '../../src/core/gas-retry'
+import { DuplicateIdError, LockTimeoutError, QuotaExceededError, SheetsApiError } from '../../src'
+
+/** Collects the sleep durations a run would have spent on the platform. */
+function recorder(): { slept: number[]; sleep: (ms: number) => void } {
+  const slept: number[] = []
+  return { slept, sleep: (ms: number) => void slept.push(ms) }
+}
+
+const TRANSIENT = 'Service Spreadsheets timed out while accessing document with id 1AbC.'
+
+describe('withRetries (#136)', () => {
+  it('returns the value without sleeping when the call succeeds', () => {
+    const { slept, sleep } = recorder()
+    const fn = vi.fn(() => 'ok')
+
+    expect(withRetries(fn, { sleep })).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(slept).toEqual([])
+  })
+
+  it('retries a transient failure and returns the eventual success', () => {
+    const { slept, sleep } = recorder()
+    let calls = 0
+    const fn = () => {
+      calls++
+      if (calls < 3) throw new Error(TRANSIENT)
+      return 'ok'
+    }
+
+    expect(withRetries(fn, { sleep })).toBe('ok')
+    expect(calls).toBe(3)
+    expect(slept).toEqual([500, 1000])
+  })
+
+  it('backs off exponentially from baseDelayMs', () => {
+    const { slept, sleep } = recorder()
+    expect(() => withRetries(() => { throw new Error(TRANSIENT) }, { attempts: 4, baseDelayMs: 100, sleep }))
+      .toThrow(SheetsApiError)
+    expect(slept).toEqual([100, 200, 400])
+  })
+
+  it('gives up after `attempts` calls and throws the classified error', () => {
+    const { slept, sleep } = recorder()
+    let calls = 0
+
+    try {
+      withRetries(() => { calls++; throw new Error(TRANSIENT) }, { sleep })
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(SheetsApiError)
+      expect((error as SheetsApiError).originalMessage).toBe(TRANSIENT)
+      expect((error as SheetsApiError).cause).toBeInstanceOf(Error)
+    }
+
+    expect(calls).toBe(DEFAULT_RETRY_ATTEMPTS)
+    expect(slept).toEqual([DEFAULT_RETRY_BASE_DELAY_MS, DEFAULT_RETRY_BASE_DELAY_MS * 2])
+  })
+
+  it('does not retry a logical error, and rethrows it unchanged', () => {
+    const { slept, sleep } = recorder()
+    const original = new DuplicateIdError(1, 'Users')
+    let calls = 0
+
+    expect(() => withRetries(() => { calls++; throw original }, { sleep })).toThrow(original)
+    expect(calls).toBe(1)
+    expect(slept).toEqual([])
+  })
+
+  it('does not retry an unrecognized error, and rethrows it unchanged', () => {
+    const { slept, sleep } = recorder()
+    const original = new TypeError('x is not a function')
+    let calls = 0
+
+    expect(() => withRetries(() => { calls++; throw original }, { sleep })).toThrow(original)
+    expect(calls).toBe(1)
+    expect(slept).toEqual([])
+  })
+
+  it('does not retry a lock timeout', () => {
+    // Waiting again immediately cannot help: waitLock already waited its full
+    // budget, and this call holds no lock to make progress with.
+    const { slept, sleep } = recorder()
+    let calls = 0
+
+    expect(() => withRetries(() => { calls++; throw new LockTimeoutError(10000) }, { sleep }))
+      .toThrow(LockTimeoutError)
+    expect(calls).toBe(1)
+    expect(slept).toEqual([])
+  })
+
+  it('does not retry a terminal quota error', () => {
+    const { slept, sleep } = recorder()
+    let calls = 0
+
+    expect(() => withRetries(
+      () => { calls++; throw new Error('Service invoked too many times for one day: spreadsheets.') },
+      { sleep }
+    )).toThrow(QuotaExceededError)
+    expect(calls).toBe(1)
+    expect(slept).toEqual([])
+  })
+
+  it('retries a short-term quota error', () => {
+    const { slept, sleep } = recorder()
+    let calls = 0
+    const fn = () => {
+      calls++
+      if (calls < 2) throw new Error('Service invoked too many times in a short time: spreadsheets.')
+      return calls
+    }
+
+    expect(withRetries(fn, { sleep })).toBe(2)
+    expect(slept).toEqual([500])
+  })
+
+  it('classifies without retrying when attempts is 1', () => {
+    const { slept, sleep } = recorder()
+    let calls = 0
+
+    expect(() => withRetries(() => { calls++; throw new Error(TRANSIENT) }, { attempts: 1, sleep }))
+      .toThrow(SheetsApiError)
+    expect(calls).toBe(1)
+    expect(slept).toEqual([])
+  })
+
+  it('sleeps via Utilities.sleep when the platform provides it', () => {
+    const g = globalThis as { Utilities?: unknown }
+    const had = 'Utilities' in g
+    const previous = g.Utilities
+    const sleep = vi.fn()
+    g.Utilities = { sleep }
+
+    try {
+      let calls = 0
+      withRetries(() => {
+        calls++
+        if (calls < 2) throw new Error(TRANSIENT)
+        return calls
+      })
+      expect(sleep).toHaveBeenCalledTimes(1)
+      expect(sleep).toHaveBeenCalledWith(500)
+    } finally {
+      if (had) g.Utilities = previous
+      else delete g.Utilities
+    }
+  })
+
+  it('is a no-op sleeper outside GAS, so Node callers never block', () => {
+    const started = Date.now()
+    let calls = 0
+
+    expect(() => withRetries(() => { calls++; throw new Error(TRANSIENT) })).toThrow(SheetsApiError)
+    expect(calls).toBe(DEFAULT_RETRY_ATTEMPTS)
+    expect(Date.now() - started).toBeLessThan(1000)
+  })
+})

--- a/packages/core/tests/unit/lock-timeout-error.test.ts
+++ b/packages/core/tests/unit/lock-timeout-error.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #136 — `Lock.waitLock` "times out with an exception". Before this change the
+ * exception escaped as a raw `Error`, indistinguishable from a bug, so callers
+ * had no way to tell "someone else is writing, try later" from "your code is
+ * broken". These tests pin the typed surface and that the #164 flush/release
+ * contract is unaffected by the wrapping.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { withScriptLock, withScriptLockAsync } from '../../src/core/script-lock'
+import { LockTimeoutError, QuotaExceededError } from '../../src'
+
+type MutableGlobal = { LockService?: unknown; SpreadsheetApp?: unknown }
+const g = globalThis as MutableGlobal
+
+let restore: (() => void) | undefined
+
+/** Installs a LockService whose waitLock throws `message`. */
+function installFailingLock(message: string): { released: number } {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'LockService')
+  const state = { released: 0 }
+
+  g.LockService = {
+    getScriptLock: () => ({
+      waitLock: () => {
+        throw new Error(message)
+      },
+      releaseLock: () => {
+        state.released++
+      },
+      tryLock: () => true,
+      hasLock: () => false
+    })
+  }
+
+  restore = () => {
+    if (previous) Object.defineProperty(globalThis, 'LockService', previous)
+    else delete g.LockService
+  }
+  return state
+}
+
+describe('waitLock failures surface as LockTimeoutError (#136)', () => {
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  it('wraps the platform lock-timeout exception', () => {
+    installFailingLock('Lock timeout: another process was holding the lock for too long.')
+
+    try {
+      withScriptLock(() => 'never runs')
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(LockTimeoutError)
+      expect((error as LockTimeoutError).code).toBe('LOCK_TIMEOUT')
+      expect((error as LockTimeoutError).timeoutMs).toBe(10000)
+      expect((error as LockTimeoutError).cause).toBeInstanceOf(Error)
+    }
+  })
+
+  it('reports the timeout the caller actually asked for', () => {
+    installFailingLock('Could not obtain lock.')
+
+    expect(() => withScriptLock(() => 0, 2500)).toThrow(LockTimeoutError)
+    try {
+      withScriptLock(() => 0, 2500)
+    } catch (error) {
+      expect((error as LockTimeoutError).timeoutMs).toBe(2500)
+      expect((error as LockTimeoutError).message).toContain('2500')
+    }
+  })
+
+  it('wraps an unrecognized waitLock exception as a lock timeout', () => {
+    // waitLock's documented failure mode is the timeout, so an unmatched
+    // message from it is still a failed acquisition, not a mystery.
+    installFailingLock('something the platform has not documented')
+    expect(() => withScriptLock(() => 0)).toThrow(LockTimeoutError)
+  })
+
+  it('keeps a non-lock GAS failure classified as itself', () => {
+    installFailingLock('Service invoked too many times for one day: spreadsheets.')
+    expect(() => withScriptLock(() => 0)).toThrow(QuotaExceededError)
+  })
+
+  it('never runs the callback and never releases a lock it did not take', () => {
+    const state = installFailingLock('Lock timeout: another process')
+    let ran = false
+
+    expect(() => withScriptLock(() => { ran = true })).toThrow(LockTimeoutError)
+    expect(ran).toBe(false)
+    expect(state.released).toBe(0)
+  })
+
+  it('applies to the async variant too', async () => {
+    installFailingLock('Lock timeout: another process')
+    await expect(withScriptLockAsync(async () => 'x')).rejects.toBeInstanceOf(LockTimeoutError)
+  })
+
+  it('leaves the re-entrancy depth clean, so the next acquisition is a real one', () => {
+    installFailingLock('Lock timeout: another process')
+    expect(() => withScriptLock(() => 0)).toThrow(LockTimeoutError)
+
+    // A leaked depth would make this nested-looking call skip acquisition.
+    let acquired = 0
+    g.LockService = {
+      getScriptLock: () => ({
+        waitLock: () => { acquired++ },
+        releaseLock: () => {},
+        tryLock: () => true,
+        hasLock: () => true
+      })
+    }
+    expect(withScriptLock(() => 'ok')).toBe('ok')
+    expect(acquired).toBe(1)
+  })
+})

--- a/packages/core/tests/unit/sheets-adapter-retry.test.ts
+++ b/packages/core/tests/unit/sheets-adapter-retry.test.ts
@@ -1,0 +1,156 @@
+/**
+ * #136 — where SheetsAdapter applies the retry policy.
+ *
+ * The policy is not "retry everything": `setValues` over a fixed range and
+ * every read are idempotent and safe to repeat, while `appendRow`/`deleteRow`
+ * are not — a timed-out append may well have landed, and repeating it would
+ * duplicate the row (in auto id mode, duplicate it under the same id). These
+ * tests pin both halves of that distinction.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { SheetsApiError } from '../../src'
+import type { FakeSheet } from '../../src/testing/fake-sheet'
+import type { FakeSpreadsheet } from '../../src/testing/fake-spreadsheet'
+import type { GasFakesHandle } from '../../src/testing/install'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+
+interface Row {
+  id: number
+  name: string
+  [key: string]: unknown
+}
+
+const SPREADSHEET_ID = 'sheets-adapter-retry'
+const SHEET_NAME = 'Users'
+const COLUMNS = ['id', 'name']
+const TRANSIENT = 'Service Spreadsheets timed out while accessing document with id 1AbC.'
+
+let handle: GasFakesHandle
+let spreadsheet: FakeSpreadsheet
+let sheet: FakeSheet
+
+function seed(rows: unknown[][] = [[1, 'a'], [2, 'b']]): SheetsAdapter<Row> {
+  spreadsheet = fromArrays({ [SHEET_NAME]: [COLUMNS, ...rows] })
+  handle = installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+
+  const found = spreadsheet.getSheetByName(SHEET_NAME)
+  if (!found) throw new Error('seed: sheet missing')
+  sheet = found
+
+  return new SheetsAdapter<Row>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: SHEET_NAME,
+    columns: COLUMNS
+  })
+}
+
+/** Makes the first `times` calls of every `getValues` throw `message`. */
+function failReads(times: number, message = TRANSIENT): { remaining: () => number } {
+  let left = times
+  const originalGetRange = sheet.getRange.bind(sheet)
+  sheet.getRange = (row: number, col: number, numRows = 1, numCols = 1) => {
+    const range = originalGetRange(row, col, numRows, numCols)
+    const getValues = range.getValues.bind(range)
+    range.getValues = () => {
+      if (left > 0) {
+        left--
+        throw new Error(message)
+      }
+      return getValues()
+    }
+    return range
+  }
+  return { remaining: () => left }
+}
+
+describe('SheetsAdapter retry placement (#136)', () => {
+  afterEach(() => handle?.restore())
+
+  it('retries a transient read failure and still returns the data', () => {
+    const adapter = seed()
+    failReads(2)
+
+    expect(adapter.findAll()).toEqual([
+      { id: 1, name: 'a' },
+      { id: 2, name: 'b' }
+    ])
+  })
+
+  it('surfaces a typed SheetsApiError once the attempts are spent', () => {
+    const adapter = seed()
+    failReads(Number.MAX_SAFE_INTEGER)
+
+    expect(() => adapter.findAll()).toThrow(SheetsApiError)
+  })
+
+  it('retries a transient fixed-range write, which is idempotent', () => {
+    const adapter = seed()
+
+    let writeFailures = 1
+    const originalGetRange = sheet.getRange.bind(sheet)
+    sheet.getRange = (row: number, col: number, numRows = 1, numCols = 1) => {
+      const range = originalGetRange(row, col, numRows, numCols)
+      const setValues = range.setValues.bind(range)
+      range.setValues = (values: unknown[][]) => {
+        if (writeFailures > 0) {
+          writeFailures--
+          throw new Error(TRANSIENT)
+        }
+        setValues(values)
+      }
+      return range
+    }
+
+    expect(adapter.update(1, { name: 'renamed' })?.name).toBe('renamed')
+    expect(adapter.findById(1)?.name).toBe('renamed')
+  })
+
+  it('never retries appendRow, so a possibly-committed insert is not duplicated', () => {
+    const adapter = seed([])
+
+    let calls = 0
+    const originalAppend = sheet.appendRow.bind(sheet)
+    sheet.appendRow = (values: unknown[]) => {
+      calls++
+      // Model the dangerous case: the write lands, then the call reports a timeout.
+      originalAppend(values)
+      throw new Error(TRANSIENT)
+    }
+
+    expect(() => adapter.insert({ name: 'a' })).toThrow(SheetsApiError)
+    expect(calls).toBe(1)
+    expect(sheet.getLastRow()).toBe(2)
+  })
+
+  it('never retries deleteRow, which is not idempotent either', () => {
+    const adapter = seed()
+
+    let calls = 0
+    sheet.deleteRow = () => {
+      calls++
+      throw new Error(TRANSIENT)
+    }
+
+    expect(() => adapter.delete(1)).toThrow(SheetsApiError)
+    expect(calls).toBe(1)
+  })
+
+  it('does not retry a logical failure', () => {
+    const adapter = seed()
+    let calls = 0
+    const originalGetRange = sheet.getRange.bind(sheet)
+    sheet.getRange = (row: number, col: number, numRows = 1, numCols = 1) => {
+      const range = originalGetRange(row, col, numRows, numCols)
+      range.getValues = () => {
+        calls++
+        throw new TypeError('not a function')
+      }
+      return range
+    }
+
+    expect(() => adapter.findAll()).toThrow(TypeError)
+    expect(calls).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

The light half of #136 — GAS platform failures become legible and survivable:

- **Typed errors**: `LockTimeoutError` (`LOCK_TIMEOUT`), `QuotaExceededError` (`QUOTA_EXCEEDED`), `SheetsApiError` (`SHEETS_API_ERROR`) with a data-driven, sourced matcher table (`GAS_ERROR_PATTERNS`). Quota patterns are split by transience — a short-term rate limit clears within the execution, a daily quota doesn't, and `Exceeded maximum execution time` is terminal by definition.
- **`waitLock` classification** in `script-lock.ts` (acquireLock only — #164 flush ordering and re-entrancy untouched): a timeout surfaces as `LockTimeoutError` carrying the actual wait budget; no lock is held when it throws.
- **Bounded transient-only retry** (`core/gas-retry.ts`, 3 attempts, 500ms base backoff, `Utilities.sleep` guarded for Node): applied via `sheetsCall` on idempotent range reads/writes. **Deliberate deviation from the brief**: `appendRow`/`deleteRow`/`insertSheet`/`insertColumnBefore` go through `sheetsCallOnce` (classify, never repeat) — a timed-out `appendRow` may have landed, and repeating it could mint a duplicate row under the same auto-id, which is worse than surfacing the failure. A test pins this ("never retries appendRow, so a possibly-committed insert is not duplicated"). Worst-case added latency ≈1.5s per guarded call, ≈4.5s on the heaviest locked path — under the 10s lock wait; documented with a pointer to #136's remaining half.
- **Cell-size guard**: `CellSizeLimitError` (`CELL_SIZE_LIMIT`) thrown from `serializeCell` at >50,000 chars, measured after formula-escaping (the `'` marker counts). All write paths serialize the full payload before any Sheets call, making batches all-or-nothing — which surfaced and fixed two pre-existing partial-write orderings: `reset()` cleared the sheet before serializing, and `addColumn` inserted the physical column before validating its default.

58 new tests across 5 files (37 red before implementation); full suite 1,098 green with **zero existing tests modified**. Chunking/time-budget/resume stays open on #136.

## Related Issues

Related: #136 (do not close — chunking half remains)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes (core 671)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_