### PR TITLE
test(e2e): add four real-GAS production scenarios (mixed workload, human edits, volume, migration chain)

### DIFF
--- a/.github/workflows/gas-e2e.yml
+++ b/.github/workflows/gas-e2e.yml
@@ -102,6 +102,22 @@ jobs:
           echo "$CHECK" | python3 -m json.tool
           echo "$CHECK" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
 
+      - name: Mixed concurrent workload — parallel insert/update/delete/batch
+        env:
+          URL: ${{ secrets.GAS_E2E_URL }}
+          TOKEN: ${{ secrets.GAS_E2E_TOKEN }}
+        run: |
+          set -euo pipefail
+          AUTH="Authorization: Bearer $ACCESS_TOKEN"
+          curl -sSL -H "$AUTH" "${URL}?action=cleanup&token=${TOKEN}" > /dev/null
+          curl -sSL -H "$AUTH" "${URL}?action=mixedBurst&tag=left&seed=11&token=${TOKEN}" > mixed-left.json &
+          curl -sSL -H "$AUTH" "${URL}?action=mixedBurst&tag=right&seed=29&token=${TOKEN}" > mixed-right.json &
+          wait
+          cat mixed-left.json mixed-right.json
+          CHECK=$(curl -sSL -H "$AUTH" "${URL}?action=mixedCheck&tags=left,right&token=${TOKEN}")
+          echo "$CHECK" | python3 -m json.tool
+          echo "$CHECK" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('ok') else 1)"
+
       - name: Cleanup test sheets
         if: always()
         env:

--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -8,6 +8,19 @@ Runs a golden test suite for `@gsquery/core` **inside a real Apps Script runtime
 - Physical migration `addColumn` on a live sheet (header insert + single-pass backfill, #127)
 - `DuplicateIdError`, batch write correctness, stale-index safety — all against the live API
 
+### Production scenarios
+
+On top of the golden suite, four scenarios model what a real deployment does to a sheet:
+
+| # | Scenario | Where | What it proves |
+|---|---|---|---|
+| S1 | **Mixed concurrent workload** | `?action=mixedBurst&tag=&seed=` ×2 in parallel, then `?action=mixedCheck` | Two callers each run 10 inserts + 5 updates + 3 deletes + 1 batchUpdate against one sheet. Each touches only its own rows and its op sets are disjoint, so the per-tag end state is fixed *whatever the interleaving*: 7 survivors, slots 0–1 `u`, slots 2–6 `b`, slots 7–9 gone. The check asserts that, plus no duplicate ids/keys and no **cross-tag contamination** (a row whose `key` no longer reconstructs from its own `tag`+`slot` was partially overwritten). `seed` shuffles op order to explore different interleavings without changing the end state. |
+| S2 | **Human interference** | `?action=run` (3 tests) | People edit production sheets. Sorting the data range by a non-id column and inserting a blank row mid-table are both survivable (the adapter resolves rows by scanning the id column, and all-empty rows are filtered out). Inserting a **foreign column** mid-table is not — it is tagged `[documents #TBD]` and asserts the *current* failure mode rather than fixing it. |
+| S3 | **Volume budget** | `?action=run` (1 test, one shared 2,000-row sheet) | batchInsert / findAll / filtered query / 200-row scattered batchUpdate / single update stay correct at 2k rows, within loose ceilings that only trip on an egregious blowup. Per-operation timings are reported in the result's `info` field. This test dominates the suite's wall clock. |
+| S4 | **Live migration chain** | `?action=run` (1 test) | v1 `addColumn` → v2 `renameColumn` → v3 `removeColumn` driven synchronously in the order a chain would issue them, asserting the physical header and grid alignment after every step. Also `[documents #TBD]`: only `addColumn` is a physical schema op. |
+
+`Range.sort` and `Sheet.insertRowBefore` are not implemented by the fakes, so S2's first two probes feature-detect them and record a skip note in `info`; every other assertion in those tests still runs locally.
+
 The same suite also runs locally against the in-repo fakes (`local-check.test.ts`), so a red result in real GAS indicts a platform assumption, not the test code.
 
 ## Test spreadsheet
@@ -62,7 +75,8 @@ Then: **Actions → "GAS E2E (real Apps Script)" → Run workflow.** It also run
 2. *(full mode)* Bundles the harness (`esbuild` IIFE — library + tests in one `Code.js`), `clasp push`es it, and redeploys the web app to the new version.
 3. `GET ?action=run` — full golden suite, asserts `ok: true` from the JSON report.
 4. Fires two parallel `?action=burst&n=25` requests, then `?action=burstCheck&expect=50` — verifies the real script lock: 50 rows, 50 unique ids, no overwrites.
-5. `?action=cleanup` — removes all `e2e_*` sheets.
+5. Fires two parallel `?action=mixedBurst` requests (S1), then `?action=mixedCheck` — verifies the mixed-workload invariants.
+6. `?action=cleanup` — removes all `e2e_*` sheets.
 
 ## Calling the web app manually
 
@@ -86,4 +100,8 @@ pnpm --filter @gsquery/gas-e2e-harness build       # produces dist/Code.js
 | `formula escape` test fails only in GAS | The `USER_ENTERED` apostrophe assumption in `escapeCellValue`/`unescapeCellValue` doesn't match real Sheets — a real finding, fix the adapter |
 | `burstCheck` reports duplicate ids | Real `LockService` isn't protecting the insert path — regression of #128 |
 | `date columnType` fails only in GAS | Timezone/serial-number coercion differs from the fakes — extend `deserializeByType` |
+| `mixedCheck` reports `contaminated` rows | A write landed on a row number resolved before a concurrent delete shifted it — the stale-index race of #128/#155 |
+| `mixedCheck` reports `wrongStates`/`missingSlots` | An update, delete or batchUpdate was silently lost under contention |
+| A `[documents #TBD]` test fails | The characterized behavior *changed* — re-read the assertion, then update it (or the issue) rather than "fixing" the test |
+| `volume` trips a time ceiling | A per-row write path crept back into a batch operation — the ceilings are ~10x the expected cost, not tight benchmarks |
 | Suite green locally, HTTP error in CI | Deployment/auth issue (redeploy the web app, check token), not a library bug |

--- a/e2e/gas/local-check.test.ts
+++ b/e2e/gas/local-check.test.ts
@@ -8,7 +8,7 @@
 import { FakeSpreadsheet } from '@gsquery/core/testing'
 import { installGasFakes } from '@gsquery/core/testing'
 import { afterEach, describe, expect, it } from 'vitest'
-import { runAll } from './src/main'
+import { mixedBurst, mixedCheck, runAll } from './src/main'
 
 const TEST_SPREADSHEET_ID = 'fake-e2e-spreadsheet'
 
@@ -31,7 +31,68 @@ describe('gas e2e harness (against local fakes)', () => {
 
     const failures = result.results.filter(r => !r.ok)
     expect(failures, JSON.stringify(failures, null, 2)).toEqual([])
-    expect(result.total).toBeGreaterThanOrEqual(11)
+    expect(result.total).toBeGreaterThanOrEqual(15)
     expect(result.ok).toBe(true)
+  })
+
+  /**
+   * The mixed workload's *invariants* checked against fakes.
+   *
+   * Run sequentially here — Node has no second Apps Script execution to race
+   * against, so this proves the workload's end state is what `mixedCheck`
+   * expects (i.e. the check is not vacuous and not self-contradicting). Real
+   * concurrency is what the parallel CI step adds on top.
+   */
+  it('mixedBurst pairs satisfy mixedCheck (sequential, against fakes)', () => {
+    const handle = installGasFakes({
+      spreadsheets: { [TEST_SPREADSHEET_ID]: new FakeSpreadsheet(TEST_SPREADSHEET_ID) },
+      activeId: TEST_SPREADSHEET_ID
+    })
+    restore = () => handle.restore()
+
+    const left = mixedBurst('left', 11, TEST_SPREADSHEET_ID)
+    const right = mixedBurst('right', 29, TEST_SPREADSHEET_ID)
+
+    for (const run of [left, right]) {
+      expect(run.errors, JSON.stringify(run, null, 2)).toEqual([])
+      expect(run.inserted).toBe(10)
+      expect(run.updated).toBe(5)
+      expect(run.deleted).toBe(3)
+      expect(run.batchUpdated).toBe(5)
+    }
+
+    const check = mixedCheck(['left', 'right'], TEST_SPREADSHEET_ID)
+    expect(check, JSON.stringify(check, null, 2)).toMatchObject({
+      ok: true,
+      rowCount: 14,
+      expectedRowCount: 14,
+      duplicateIds: [],
+      duplicateKeys: [],
+      contaminated: [],
+      unknownTags: []
+    })
+    for (const report of check.tags) {
+      expect(report.survivors).toBe(7)
+      expect(report.missingSlots).toEqual([])
+      expect(report.unexpectedSlots).toEqual([])
+      expect(report.wrongStates).toEqual([])
+    }
+  })
+
+  /** The check must actually fail on a broken end state, or it proves nothing. */
+  it('mixedCheck rejects a run whose end state is incomplete', () => {
+    const handle = installGasFakes({
+      spreadsheets: { [TEST_SPREADSHEET_ID]: new FakeSpreadsheet(TEST_SPREADSHEET_ID) },
+      activeId: TEST_SPREADSHEET_ID
+    })
+    restore = () => handle.restore()
+
+    mixedBurst('left', 3, TEST_SPREADSHEET_ID)
+
+    const check = mixedCheck(['left', 'right'], TEST_SPREADSHEET_ID)
+    expect(check.ok).toBe(false)
+    expect(check.rowCount).toBe(7)
+    expect(check.expectedRowCount).toBe(14)
+    expect(check.tags.find(report => report.tag === 'right')?.missingSlots).toEqual([0, 1, 2, 3, 4, 5, 6])
   })
 })

--- a/e2e/gas/src/main.ts
+++ b/e2e/gas/src/main.ts
@@ -5,6 +5,8 @@
  *   GET ?action=run                        → run the golden suite, JSON result
  *   GET ?action=burst&tag=a&n=25           → insert n auto-id rows (call twice in parallel)
  *   GET ?action=burstCheck&expect=50       → verify unique ids and row count after a burst pair
+ *   GET ?action=mixedBurst&tag=a&seed=1    → mixed insert/update/delete/batchUpdate workload
+ *   GET ?action=mixedCheck&tags=left,right → verify the mixed workload's invariants
  *   GET ?action=cleanup                    → delete all e2e_* sheets
  *
  * If a Script Property `E2E_TOKEN` is set, every request must carry the same
@@ -148,6 +150,293 @@ export function burstCheck(expect: number): {
   }
 }
 
+// ── Mixed concurrent workload (S1) ──────────────────────────────────────────
+//
+// `burst` proves one thing: parallel *inserts* don't collide on ids. Production
+// traffic is not one operation type — it is inserts, updates, deletes and batch
+// writes arriving at the same sheet at the same time, and the dangerous races
+// live in the read-then-write ops (a concurrent deleteRow shifts every row
+// number the other caller just resolved, #128/#155).
+//
+// Invariant design: each caller only ever touches ROWS IT INSERTED ITSELF, and
+// its operations are chosen so the per-tag end state is a pure function of the
+// tag — no matter how the two callers interleave. That is what makes the check
+// order-independent, which is the only kind of assertion that is meaningful
+// under real concurrency.
+
+const MIXED_SHEET = 'e2e_mixed'
+const MIXED_COLUMNS = ['id', 'tag', 'slot', 'state', 'key']
+
+/** Slots each caller inserts. Slot is caller-local, so the two tags never overlap. */
+const MIXED_INSERT_COUNT = 10
+/** Slots re-written with `update()` — after the inserts. */
+const MIXED_UPDATE_SLOTS = [0, 1, 2, 3, 4]
+/** Slots removed with `delete()` — disjoint from every slot written afterwards. */
+const MIXED_DELETE_SLOTS = [7, 8, 9]
+/** Slots re-written with a single `batchUpdate()` — the last write to touch them. */
+const MIXED_BATCH_SLOTS = [2, 3, 4, 5, 6]
+
+const MIXED_EXPECTED_SURVIVORS = MIXED_INSERT_COUNT - MIXED_DELETE_SLOTS.length
+
+interface MixedRow {
+  id: string | number
+  tag?: unknown
+  slot?: unknown
+  state?: unknown
+  key?: unknown
+  [column: string]: unknown
+}
+
+/**
+ * The end state of one slot, independent of interleaving.
+ *
+ * Deletes are disjoint from the later writes, and batchUpdate always runs last,
+ * so the final state of a slot depends only on which sets it belongs to.
+ * `undefined` means the row must not exist any more.
+ */
+function expectedMixedState(slot: number): string | undefined {
+  if (MIXED_DELETE_SLOTS.indexOf(slot) !== -1) return undefined
+  if (MIXED_BATCH_SLOTS.indexOf(slot) !== -1) return 'b'
+  if (MIXED_UPDATE_SLOTS.indexOf(slot) !== -1) return 'u'
+  return 'i'
+}
+
+/**
+ * Deterministic Fisher-Yates shuffle (LCG) — `seed` varies the ORDER in which a
+ * caller issues its operations without changing the end state, so two runs of
+ * the same workload explore different interleavings against the other caller.
+ */
+function shuffled(items: number[], seed: number): number[] {
+  const out = items.slice()
+  let state = (seed >>> 0) || 1
+  for (let i = out.length - 1; i > 0; i--) {
+    state = (state * 1664525 + 1013904223) >>> 0
+    const j = state % (i + 1)
+    const swap = out[i]
+    out[i] = out[j]
+    out[j] = swap
+  }
+  return out
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+}
+
+export interface MixedBurstResult {
+  tag: string
+  seed: number
+  inserted: number
+  updated: number
+  deleted: number
+  batchUpdated: number
+  errors: string[]
+}
+
+/**
+ * Run one caller's share of the mixed workload against the shared sheet.
+ *
+ * CI fires two of these in parallel with different tags and seeds; the end
+ * state each one is responsible for is fixed, so `mixedCheck` can assert it
+ * exactly without knowing anything about how the two runs interleaved.
+ */
+export function mixedBurst(tag: string, seed: number, spreadsheetId?: string): MixedBurstResult {
+  const adapter = new SheetsAdapter<MixedRow>({
+    spreadsheetId: spreadsheetId ?? getSpreadsheetId(),
+    sheetName: MIXED_SHEET,
+    columns: MIXED_COLUMNS
+  })
+
+  const errors: string[] = []
+  const idBySlot: Record<number, string | number> = {}
+  const allSlots = Array.from({ length: MIXED_INSERT_COUNT }, (_, i) => i)
+
+  let inserted = 0
+  for (const slot of shuffled(allSlots, seed)) {
+    try {
+      const row = adapter.insert({ tag, slot, state: 'i', key: `${tag}:${slot}` })
+      idBySlot[slot] = row.id
+      inserted++
+    } catch (err) {
+      errors.push(`insert ${tag}:${slot}: ${describeError(err)}`)
+    }
+  }
+
+  let updated = 0
+  for (const slot of shuffled(MIXED_UPDATE_SLOTS, seed + 1)) {
+    const id = idBySlot[slot]
+    if (id === undefined) continue
+    try {
+      adapter.update(id, { state: 'u' })
+      updated++
+    } catch (err) {
+      errors.push(`update ${tag}:${slot}: ${describeError(err)}`)
+    }
+  }
+
+  let deleted = 0
+  for (const slot of shuffled(MIXED_DELETE_SLOTS, seed + 2)) {
+    const id = idBySlot[slot]
+    if (id === undefined) continue
+    try {
+      if (adapter.delete(id)) deleted++
+      else errors.push(`delete ${tag}:${slot}: row not found`)
+    } catch (err) {
+      errors.push(`delete ${tag}:${slot}: ${describeError(err)}`)
+    }
+  }
+
+  let batchUpdated = 0
+  const batchItems = MIXED_BATCH_SLOTS
+    .filter(slot => idBySlot[slot] !== undefined)
+    .map(slot => ({ id: idBySlot[slot], data: { state: 'b' } }))
+  try {
+    batchUpdated = adapter.batchUpdate(batchItems).length
+  } catch (err) {
+    errors.push(`batchUpdate ${tag}: ${describeError(err)}`)
+  }
+
+  return { tag, seed, inserted, updated, deleted, batchUpdated, errors }
+}
+
+export interface MixedTagReport {
+  tag: string
+  survivors: number
+  expectedSurvivors: number
+  missingSlots: number[]
+  unexpectedSlots: number[]
+  wrongStates: string[]
+}
+
+export interface MixedCheckResult {
+  ok: boolean
+  rowCount: number
+  expectedRowCount: number
+  tags: MixedTagReport[]
+  duplicateIds: string[]
+  duplicateKeys: string[]
+  /** Rows whose fields do not all belong to the same caller — the corruption signature. */
+  contaminated: string[]
+  unknownTags: string[]
+}
+
+/**
+ * Verify the mixed workload WITHOUT assuming any interleaving.
+ *
+ * A row is self-consistent only when its `key` — written once, at insert time,
+ * as `<tag>:<slot>` — still reconstructs from its own `tag` and `slot` cells.
+ * A row that mixes two callers' values (a partial overwrite, a write that
+ * landed on a shifted row number) fails that reconstruction, which is what
+ * "cross-tag contamination" means here.
+ */
+export function mixedCheck(tags: string[], spreadsheetId?: string): MixedCheckResult {
+  const adapter = new SheetsAdapter<MixedRow>({
+    spreadsheetId: spreadsheetId ?? getSpreadsheetId(),
+    sheetName: MIXED_SHEET,
+    columns: MIXED_COLUMNS
+  })
+  adapter.clearCache()
+  const rows = adapter.findAll()
+
+  const seenIds: Record<string, number> = {}
+  const seenKeys: Record<string, number> = {}
+  const duplicateIds: string[] = []
+  const duplicateKeys: string[] = []
+  const contaminated: string[] = []
+  const unknownTags: string[] = []
+  const stateByTagSlot: Record<string, string> = {}
+
+  for (const row of rows) {
+    const id = String(row.id)
+    seenIds[id] = (seenIds[id] ?? 0) + 1
+    if (seenIds[id] === 2) duplicateIds.push(id)
+
+    const rowTag = String(row.tag ?? '')
+    const rowSlot = String(row.slot ?? '')
+    const rowKey = String(row.key ?? '')
+
+    seenKeys[rowKey] = (seenKeys[rowKey] ?? 0) + 1
+    if (seenKeys[rowKey] === 2) duplicateKeys.push(rowKey)
+
+    // Self-consistency: tag + slot must rebuild the key written at insert time.
+    if (rowKey !== `${rowTag}:${rowSlot}`) {
+      contaminated.push(`id=${id} tag=${rowTag} slot=${rowSlot} key=${rowKey} state=${String(row.state ?? '')}`)
+      continue
+    }
+    if (tags.indexOf(rowTag) === -1) {
+      unknownTags.push(`id=${id} tag=${rowTag}`)
+      continue
+    }
+    stateByTagSlot[`${rowTag}:${rowSlot}`] = String(row.state ?? '')
+  }
+
+  const tagReports: MixedTagReport[] = tags.map(tag => {
+    const missingSlots: number[] = []
+    const unexpectedSlots: number[] = []
+    const wrongStates: string[] = []
+    let survivors = 0
+
+    for (let slot = 0; slot < MIXED_INSERT_COUNT; slot++) {
+      const actual = stateByTagSlot[`${tag}:${slot}`]
+      const expected = expectedMixedState(slot)
+      if (actual === undefined) {
+        if (expected !== undefined) missingSlots.push(slot)
+        continue
+      }
+      survivors++
+      if (expected === undefined) unexpectedSlots.push(slot)
+      else if (actual !== expected) wrongStates.push(`${tag}:${slot} expected=${expected} actual=${actual}`)
+    }
+
+    return {
+      tag,
+      survivors,
+      expectedSurvivors: MIXED_EXPECTED_SURVIVORS,
+      missingSlots,
+      unexpectedSlots,
+      wrongStates
+    }
+  })
+
+  const expectedRowCount = MIXED_EXPECTED_SURVIVORS * tags.length
+  const ok =
+    rows.length === expectedRowCount &&
+    duplicateIds.length === 0 &&
+    duplicateKeys.length === 0 &&
+    contaminated.length === 0 &&
+    unknownTags.length === 0 &&
+    tagReports.every(
+      report =>
+        report.survivors === report.expectedSurvivors &&
+        report.missingSlots.length === 0 &&
+        report.unexpectedSlots.length === 0 &&
+        report.wrongStates.length === 0
+    )
+
+  return {
+    ok,
+    rowCount: rows.length,
+    expectedRowCount,
+    tags: tagReports,
+    duplicateIds,
+    duplicateKeys,
+    contaminated,
+    unknownTags
+  }
+}
+
+/** Parse `?tags=left,right` into a clean list, falling back to the CI defaults. */
+function parseTags(param: string | undefined): string[] {
+  const parsed = (param ?? '').split(',').map(tag => tag.trim()).filter(tag => tag.length > 0)
+  return parsed.length > 0 ? parsed : ['left', 'right']
+}
+
+/** Parse a numeric query parameter, falling back when it is absent or unparseable. */
+function parseNumber(param: string | undefined, fallback: number): number {
+  const parsed = Number(param)
+  return isNaN(parsed) ? fallback : parsed
+}
+
 function checkToken(param: string | undefined): boolean {
   if (typeof PropertiesService === 'undefined') return true
   const required = PropertiesService.getScriptProperties().getProperty('E2E_TOKEN')
@@ -185,6 +474,10 @@ export function doGet(e: DoGetEvent): GoogleAppsScript.Content.TextOutput {
         return respond(burst(params.tag ?? 'a', Number(params.n ?? '25')))
       case 'burstCheck':
         return respond(burstCheck(Number(params.expect ?? '50')))
+      case 'mixedBurst':
+        return respond(mixedBurst(params.tag ?? 'a', parseNumber(params.seed, 1)))
+      case 'mixedCheck':
+        return respond(mixedCheck(parseTags(params.tags)))
       case 'cleanup':
         return respond({ deleted: deleteAllE2ESheets(getSpreadsheetId()) })
       default:

--- a/e2e/gas/src/runner.ts
+++ b/e2e/gas/src/runner.ts
@@ -11,6 +11,13 @@ export interface TestResult {
   ok: boolean
   error?: string
   ms: number
+  /**
+   * Free-form notes a test emitted via {@link TestApi.info} — per-operation
+   * timings for the volume budget, "skipped under fakes" markers for the
+   * human-interference probes. Reported alongside the result so a green CI run
+   * still carries the numbers; never used for pass/fail.
+   */
+  info?: string
 }
 
 export interface SuiteResult {
@@ -22,13 +29,22 @@ export interface SuiteResult {
   results: TestResult[]
 }
 
+/** Handle passed to every test for attaching non-assertional notes. */
+export interface TestApi {
+  /** Record a note (timing, skip reason) on this test's result. */
+  info(message: string): void
+}
+
 /**
  * Tests must be fully synchronous: the GAS web-app dispatcher rejects a
  * Promise returned from doGet ("returned value is not a supported return
  * type" — verified against the real platform), so nothing in the request
  * path may await.
+ *
+ * The {@link TestApi} argument is optional at the call site — tests that need
+ * no notes keep the original `() => void` shape.
  */
-type TestFn = () => void
+type TestFn = (t: TestApi) => void
 
 const registry: { name: string; fn: TestFn }[] = []
 
@@ -46,12 +62,17 @@ export function runSuite(): SuiteResult {
 
   for (const { name, fn } of registry) {
     const start = Date.now()
+    const notes: string[] = []
+    // Notes survive a failure too: the timings/skips recorded before the throw
+    // are usually what explains it.
+    const api: TestApi = { info: (message: string) => { notes.push(message) } }
+    const info = (): string | undefined => (notes.length > 0 ? notes.join(' | ') : undefined)
     try {
-      fn()
-      results.push({ name, ok: true, ms: Date.now() - start })
+      fn(api)
+      results.push({ name, ok: true, ms: Date.now() - start, info: info() })
     } catch (err) {
       const error = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
-      results.push({ name, ok: false, error, ms: Date.now() - start })
+      results.push({ name, ok: false, error, ms: Date.now() - start, info: info() })
     }
   }
 

--- a/e2e/gas/src/tests.ts
+++ b/e2e/gas/src/tests.ts
@@ -14,6 +14,35 @@ import { SheetsAdapter } from '@gsquery/core'
 import type { ColumnType } from '@gsquery/core'
 import { assertEq, assertOk, assertThrows, test } from './runner'
 
+/**
+ * Structural views used to feature-detect real-GAS-only methods.
+ *
+ * The in-repo fakes implement an allowlisted subset of the Sheets surface and
+ * deliberately omit what they cannot simulate faithfully (`Range.sort`,
+ * `Sheet.insertRowBefore`). The human-interference probes below therefore test
+ * for the method before using it and skip only that sub-assertion under fakes —
+ * a missing fake method must never turn the local check red.
+ */
+interface SortableRange {
+  sort?: (spec: { column: number; ascending: boolean }) => unknown
+}
+interface RowInsertingSheet {
+  insertRowBefore?: (rowIndex: number) => unknown
+}
+interface ColumnInsertingSheet {
+  insertColumnBefore?: (columnIndex: number) => unknown
+}
+
+/** A cell as read back, normalized to a string so number/string cell coercion differences don't matter. */
+function cellText(value: unknown): string {
+  return value === null || value === undefined ? '' : String(value)
+}
+
+/** MigrationRunner's emptiness test, inlined (it is not exported from core). */
+function isEmptyValue(value: unknown): boolean {
+  return value === undefined || value === null || value === ''
+}
+
 export interface HarnessContext {
   spreadsheetId: string
   runId: string
@@ -236,6 +265,365 @@ export function registerTests(ctx: HarnessContext): void {
     adapter.clearCache()
     const all = adapter.findAll()
     assertEq(all.length, 100, '100 rows read back')
+  })
+
+  // ── Shared helpers for the production scenarios (S2–S4) ──────────────────
+
+  /** Open a sheet by name; throws (via the caller's assertOk) when absent. */
+  const openSheet = (name: string): GoogleAppsScript.Spreadsheet.Sheet | null =>
+    SpreadsheetApp.openById(ctx.spreadsheetId).getSheetByName(name)
+
+  /**
+   * Read a rectangle of the physical grid as strings.
+   *
+   * The assertions below are about *layout* — which value sits under which
+   * header — so they must bypass the adapter's positional mapping entirely,
+   * and must not care whether GAS hands back `1` or `'1'` for a numeric cell.
+   */
+  const rawCells = (
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number
+  ): string[][] => {
+    const values = sheet.getRange(row, col, numRows, numCols).getValues() as unknown[][]
+    return values.map(line => line.map(cellText))
+  }
+
+  const rawRow = (
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    row: number,
+    numCols: number
+  ): string[] => rawCells(sheet, row, 1, 1, numCols)[0]
+
+  // ══ S2. Human interference ═══════════════════════════════════════════════
+  // Production sheets are not owned by the script: people open them and sort,
+  // insert rows, add their own columns. These three probes seed data through
+  // the adapter and then edit the sheet the way a human would — directly via
+  // SpreadsheetApp — to find out which edits the positional adapter survives.
+
+  // ── 12. Human sorts the data range by a non-id column ────────────────────
+  test('human edit: sorting the data range by a non-id column keeps update/findById on target', t => {
+    const adapter = makeAdapter('humansort', ['id', 'name', 'score'])
+    const rows = adapter.batchInsert(
+      // Descending score, so an ascending sort by score reverses every row.
+      Array.from({ length: 6 }, (_, i) => ({ name: `p${i}`, score: 50 - i * 10 }))
+    )
+    const sheet = openSheet(`e2e_${ctx.runId}_humansort`)
+    assertOk(sheet, 'seeded sheet exists')
+    if (!sheet) return
+
+    const range = sheet.getRange(2, 1, rows.length, 3)
+    const sortable = range as unknown as SortableRange
+    if (typeof sortable.sort === 'function') {
+      sortable.sort({ column: 3, ascending: true })
+      const scores = rawCells(sheet, 2, 3, rows.length, 1).map(([value]) => Number(value))
+      assertEq(scores, [0, 10, 20, 30, 40, 50], 'the human sort really did reorder the physical rows')
+    } else {
+      t.info('skipped Range.sort (not implemented by the fakes)')
+    }
+
+    // The adapter resolves rows by scanning the id column, so physical order
+    // must be irrelevant to both reads and writes.
+    adapter.clearCache()
+    assertEq(adapter.findAll().length, 6, 'all rows still readable after the sort')
+    assertEq(adapter.findById(rows[0].id)?.name, 'p0', 'findById still resolves the first-inserted row')
+    assertEq(adapter.findById(rows[5].id)?.name, 'p5', 'findById still resolves the last-inserted row')
+
+    adapter.update(rows[2].id, { name: 'p2-updated' })
+    assertEq(adapter.findById(rows[2].id)?.name, 'p2-updated', 'update landed on the intended record')
+    assertEq(adapter.findById(rows[1].id)?.name, 'p1', 'neighbour above untouched')
+    assertEq(adapter.findById(rows[3].id)?.name, 'p3', 'neighbour below untouched')
+    assertEq(adapter.findAll().length, 6, 'no row gained or lost')
+  })
+
+  // ── 13. Human inserts a blank row in the middle ──────────────────────────
+  test('human edit: a blank row inserted mid-table is skipped by reads and does not corrupt neighbours', t => {
+    const adapter = makeAdapter('humanrow', ['id', 'name'])
+    const rows = adapter.batchInsert(Array.from({ length: 5 }, (_, i) => ({ name: `r${i}` })))
+    const sheet = openSheet(`e2e_${ctx.runId}_humanrow`)
+    assertOk(sheet, 'seeded sheet exists')
+    if (!sheet) return
+
+    const inserter = sheet as unknown as RowInsertingSheet
+    let blankRowIndex = -1
+    if (typeof inserter.insertRowBefore === 'function') {
+      // Physical row 4 holds r2 (row 1 is the header) — the blank lands between
+      // r1 and r2, i.e. in the middle of the record block.
+      blankRowIndex = 4
+      inserter.insertRowBefore(blankRowIndex)
+      assertEq(rawRow(sheet, blankRowIndex, 2), ['', ''], 'the inserted row really is blank')
+    } else {
+      t.info('skipped Sheet.insertRowBefore (not implemented by the fakes)')
+    }
+
+    adapter.clearCache()
+    const all = adapter.findAll()
+    assertEq(all.length, 5, 'the all-empty row is filtered out of reads')
+    assertOk(all.every(row => !isEmptyValue(row.id)), 'no phantom row with an empty id leaked into the result')
+
+    // A write below the gap must still land on its own record.
+    adapter.update(rows[3].id, { name: 'r3-updated' })
+    assertEq(adapter.findById(rows[3].id)?.name, 'r3-updated', 'update below the blank row hit the right record')
+    assertEq(adapter.findById(rows[2].id)?.name, 'r2', 'record above the write untouched')
+    assertEq(adapter.findById(rows[4].id)?.name, 'r4', 'record below the write untouched')
+
+    // ...and the human's blank row must survive the write untouched.
+    if (blankRowIndex > 0) {
+      assertEq(rawRow(sheet, blankRowIndex, 2), ['', ''], 'the blank row was not overwritten by the update')
+      assertEq(adapter.findAll().length, 5, 'still five records, blank row still ignored')
+    }
+  })
+
+  // ── 14. Human inserts a foreign column in the middle — EXPECTED TO BREAK ──
+  // This adapter is positional: `rowToObject` maps cell index i to
+  // `columns[i]`. A column inserted to the LEFT of an existing one shifts every
+  // value one place right, and nothing in the read path re-checks the header.
+  // The point of this test is to pin down HOW it breaks (silent misread, no
+  // error) with exact evidence, not to fix it. Do not "repair" the adapter here.
+  test('human edit: a foreign column inserted mid-table silently misaligns reads and writes [documents #TBD]', t => {
+    const adapter = makeAdapter('humancol', ['id', 'name', 'score'])
+    const rows = adapter.batchInsert([
+      { name: 'p0', score: 10 },
+      { name: 'p1', score: 20 },
+      { name: 'p2', score: 30 }
+    ])
+    const sheet = openSheet(`e2e_${ctx.runId}_humancol`)
+    assertOk(sheet, 'seeded sheet exists')
+    if (!sheet) return
+
+    const inserter = sheet as unknown as ColumnInsertingSheet
+    if (typeof inserter.insertColumnBefore !== 'function') {
+      t.info('skipped Sheet.insertColumnBefore (not implemented by this runtime)')
+      return
+    }
+
+    // The human adds their own "owner" column between `id` and `name`.
+    inserter.insertColumnBefore(2)
+    sheet.getRange(1, 2, 1, 1).setValues([['owner']])
+    sheet.getRange(2, 2, 3, 1).setValues([['alice'], ['bob'], ['carol']])
+    assertEq(rawRow(sheet, 1, 4), ['id', 'owner', 'name', 'score'], 'the sheet now has a column the schema knows nothing about')
+
+    adapter.clearCache()
+
+    // CHARACTERIZED BEHAVIOR (read side): no error, no warning — the adapter
+    // reads three cells positionally and every field after `id` is off by one.
+    const all = adapter.findAll()
+    assertEq(all.length, 3, 'CURRENT: row count still looks correct — the corruption is silent')
+    const first = adapter.findById(rows[0].id)
+    assertOk(first, 'CURRENT: findById still resolves — the id column did not move')
+    assertEq(cellText(first?.name), 'alice', "CURRENT: `name` reads the human's `owner` cell")
+    assertEq(cellText(first?.score), 'p0', 'CURRENT: `score` reads the old `name` cell')
+    assertEq(cellText(all[2]?.score), 'p2', 'CURRENT: every row is shifted the same way, so nothing looks anomalous')
+    t.info('read side: silent misread (no error), every field right of `id` shifted by one column')
+
+    // CHARACTERIZED BEHAVIOR (write side): the update writes columns 1..3, so
+    // it destroys the human's column and never touches the real `score`.
+    const updated = adapter.update(rows[0].id, { name: 'renamed' })
+    assertOk(updated, 'CURRENT: update reports success')
+    assertEq(
+      rawRow(sheet, 2, 4),
+      [cellText(rows[0].id), 'renamed', 'p0', '10'],
+      "CURRENT: the write overwrote the human's `owner` cell; the real `score` column (4) is left stale"
+    )
+    assertEq(
+      rawCells(sheet, 3, 2, 2, 1).map(([value]) => value),
+      ['bob', 'carol'],
+      'CURRENT: only the row that was written is damaged — untouched rows keep their owner value'
+    )
+    t.info('write side: clobbers the foreign column, real trailing column left stale — silent data loss')
+  })
+
+  // ══ S3. Volume budget ════════════════════════════════════════════════════
+
+  // ── 15. 2,000 rows: correctness plus loose ceilings ──────────────────────
+  // One shared sheet for the whole scenario — re-seeding per assertion would
+  // dominate the suite's wall clock. The bounds are ceilings, not targets: they
+  // exist to catch an egregious blowup (a per-row write path sneaking back into
+  // batchInsert), not to benchmark Google's backend.
+  test('volume: 2,000-row table — batchInsert, findAll, filter, scattered batchUpdate, single update', t => {
+    const ROW_COUNT = 2000
+    const adapter = makeAdapter('vol', ['id', 'name', 'bucket', 'score'])
+
+    const insertStart = Date.now()
+    const inserted = adapter.batchInsert(
+      Array.from({ length: ROW_COUNT }, (_, i) => ({ name: `v${i}`, bucket: `b${i % 10}`, score: i }))
+    )
+    const insertMs = Date.now() - insertStart
+    assertEq(inserted.length, ROW_COUNT, 'batchInsert returned every row')
+    const insertedIds = inserted.map(row => Number(row.id)).sort((a, b) => a - b)
+    assertEq(
+      insertedIds[ROW_COUNT - 1] - insertedIds[0],
+      ROW_COUNT - 1,
+      'ids are one contiguous run — a single locked allocation, not 2,000 of them'
+    )
+
+    adapter.clearCache()
+    const findAllStart = Date.now()
+    const all = adapter.findAll()
+    const findAllMs = Date.now() - findAllStart
+    assertEq(all.length, ROW_COUNT, 'findAll read every row back')
+
+    const filterStart = Date.now()
+    const filtered = adapter.find({ where: [{ field: 'bucket', operator: '=', value: 'b7' }], orderBy: [] })
+    const filterMs = Date.now() - filterStart
+    assertEq(filtered.length, ROW_COUNT / 10, 'filtered query returned exactly the matching decile')
+    assertOk(filtered.every(row => row.bucket === 'b7'), 'no non-matching row leaked into the filtered result')
+
+    // 200 deliberately non-adjacent rows: every run is length 1, which is the
+    // worst case for writeRowRuns (one ranged write per dirty row).
+    const targets = Array.from({ length: 200 }, (_, i) => i * 9 + 3)
+    const batchStart = Date.now()
+    adapter.batchUpdate(targets.map(i => ({ id: inserted[i].id, data: { name: `u${i}` } })))
+    const batchMs = Date.now() - batchStart
+
+    const lastIndex = ROW_COUNT - 1
+    const updateStart = Date.now()
+    adapter.update(inserted[lastIndex].id, { name: 'tail' })
+    const updateMs = Date.now() - updateStart
+
+    adapter.clearCache()
+    const after = adapter.findAll()
+    assertEq(after.length, ROW_COUNT, 'row count unchanged by the updates')
+    const byId: Record<string, string> = {}
+    for (const row of after) byId[String(row.id)] = cellText(row.name)
+
+    for (const i of targets) {
+      assertEq(byId[String(inserted[i].id)], `u${i}`, `scattered batchUpdate landed on row ${i}`)
+    }
+    assertEq(byId[String(inserted[lastIndex].id)], 'tail', 'single update landed on the tail row')
+
+    const touched: Record<number, true> = {}
+    for (const i of targets) touched[i] = true
+    touched[lastIndex] = true
+    for (let i = 0; i < ROW_COUNT; i += 37) {
+      if (!touched[i]) assertEq(byId[String(inserted[i].id)], `v${i}`, `untouched row ${i} kept its value`)
+    }
+
+    t.info(
+      `batchInsert(${ROW_COUNT})=${insertMs}ms findAll=${findAllMs}ms filter=${filterMs}ms ` +
+      `batchUpdate(200 scattered)=${batchMs}ms update(1)=${updateMs}ms`
+    )
+
+    // Loose ceilings — only an egregious regression trips these.
+    assertOk(insertMs < 60_000, `batchInsert(${ROW_COUNT}) took ${insertMs}ms (ceiling 60000ms)`)
+    assertOk(findAllMs < 45_000, `findAll took ${findAllMs}ms (ceiling 45000ms)`)
+    assertOk(filterMs < 45_000, `filtered query took ${filterMs}ms (ceiling 45000ms)`)
+    assertOk(batchMs < 120_000, `batchUpdate(200 scattered) took ${batchMs}ms (ceiling 120000ms)`)
+    assertOk(updateMs < 20_000, `single update took ${updateMs}ms (ceiling 20000ms)`)
+  })
+
+  // ══ S4. Live migration chain v1 → v3 ═════════════════════════════════════
+
+  // ── 16. addColumn → renameColumn → removeColumn over live data ───────────
+  // MigrationRunner.migrate() is async (withScriptLockAsync), and the web-app
+  // request path must stay synchronous (see runner.ts), so this drives the
+  // adapter operations a chain would issue, in the same order, asserting the
+  // physical layout after every step.
+  //
+  // Only `addColumn` reaches the adapter as a schema operation; `renameColumn`
+  // and `removeColumn` are VALUE operations in MigrationRunner (they update
+  // cells and never touch the header). Against a positional adapter that is a
+  // meaningful difference, and the assertions below pin down exactly what it
+  // costs. Characterization, not repair — hence the tag.
+  test('migration chain v1→v3 on live data: addColumn is physical, rename/remove are value-only [documents #TBD]', t => {
+    const name = sheetName('chain')
+    const makeStore = (columns: string[]): SheetsAdapter<E2ERow> =>
+      new SheetsAdapter<E2ERow>({ spreadsheetId: ctx.spreadsheetId, sheetName: name, columns })
+
+    // v0 — the shape production is already running.
+    const v0 = makeStore(['id', 'name', 'legacy'])
+    const ann = v0.insert({ name: 'ann', legacy: 'L1' })
+    const bob = v0.insert({ name: 'bob', legacy: 'L2' })
+
+    const sheet = openSheet(name)
+    assertOk(sheet, 'chain sheet exists')
+    if (!sheet) return
+    assertEq(rawRow(sheet, 1, 3), ['id', 'name', 'legacy'], 'v0 header')
+
+    // ── v1: addColumn('status', default 'active') ────────────────────────────
+    const v1 = makeStore(['id', 'name', 'legacy', 'status'])
+    v1.addColumn('status', { default: 'active' })
+
+    assertEq(rawRow(sheet, 1, 4), ['id', 'name', 'legacy', 'status'], 'v1: header physically extended')
+    assertEq(rawRow(sheet, 2, 4), [cellText(ann.id), 'ann', 'L1', 'active'], 'v1: data still under its own headers')
+    assertEq(rawRow(sheet, 3, 4), [cellText(bob.id), 'bob', 'L2', 'active'], 'v1: second row aligned too')
+    assertEq(v1.findById(ann.id)?.status, 'active', 'v1: the backfilled default reads back')
+    v1.update(bob.id, { status: 'archived' })
+    assertEq(v1.findById(bob.id)?.status, 'archived', 'v1: writes to the new column land')
+    assertEq(v1.findById(bob.id)?.name, 'bob', 'v1: the write did not disturb the other columns')
+
+    // ── v2: renameColumn('name' → 'displayName') ────────────────────────────
+    // MigrationRunner semantics: for each row, when the old field has a value
+    // and the new one is empty, move the value across with update().
+    const v2 = makeStore(['id', 'displayName', 'legacy', 'status'])
+    let renameWrites = 0
+    for (const row of v2.findAll()) {
+      const record = row as Record<string, unknown>
+      if (!isEmptyValue(record['name']) && isEmptyValue(record['displayName'])) {
+        v2.update(row.id, { name: undefined, displayName: record['name'] })
+        renameWrites++
+      }
+    }
+
+    assertEq(
+      renameWrites,
+      0,
+      'CURRENT: the value-level rename is a no-op here — the adapter already reads column 2 as `displayName`, ' +
+      'so the "old" field is never present and the copy condition is never true'
+    )
+    assertEq(
+      rawRow(sheet, 1, 4),
+      ['id', 'name', 'legacy', 'status'],
+      'CURRENT: the physical header still says `name` — renameColumn never touches it, so header and schema now disagree'
+    )
+    assertEq(v2.findById(ann.id)?.displayName, 'ann', 'CURRENT: reads work anyway — position, not the header, decides the mapping')
+    v2.update(ann.id, { displayName: 'ann2' })
+    assertEq(
+      rawRow(sheet, 2, 4),
+      [cellText(ann.id), 'ann2', 'L1', 'active'],
+      'CURRENT: a write under the new name lands in the column still headed `name`'
+    )
+    t.info('v2 rename: value-op is a no-op; data survives by position; header left stale (`name` vs schema `displayName`)')
+
+    // ── v3: removeColumn('legacy') ──────────────────────────────────────────
+    const v3 = makeStore(['id', 'displayName', 'legacy', 'status'])
+    let clearedCells = 0
+    for (const row of v3.findAll()) {
+      if (!isEmptyValue((row as Record<string, unknown>)['legacy'])) {
+        v3.update(row.id, { legacy: undefined })
+        clearedCells++
+      }
+    }
+    assertEq(clearedCells, 2, 'v3: the value-level removeColumn cleared both legacy cells')
+    assertEq(
+      rawRow(sheet, 1, 4),
+      ['id', 'name', 'legacy', 'status'],
+      'CURRENT: removeColumn leaves the physical column and its header in place — it only blanks the values'
+    )
+    assertEq(rawRow(sheet, 2, 4), [cellText(ann.id), 'ann2', '', 'active'], 'v3: values cleared, layout unchanged')
+    assertEq(rawRow(sheet, 3, 4), [cellText(bob.id), 'bob', '', 'archived'], 'v3: second row cleared the same way')
+
+    // The dangerous part: the NEXT deploy declares the post-v3 schema, with
+    // `legacy` gone. The sheet still has four physical columns.
+    const v3Narrow = makeStore(['id', 'displayName', 'status'])
+    const narrowed = v3Narrow.findById(ann.id)
+    assertOk(narrowed, 'CURRENT: the narrowed adapter still finds the row — the id column is still column 1')
+    assertEq(cellText(narrowed?.displayName), 'ann2', 'CURRENT: columns left of the drop still read correctly')
+    assertEq(
+      cellText(narrowed?.status),
+      '',
+      'CURRENT: `status` silently reads the abandoned (now-empty) `legacy` column; the real status in column 4 is unreachable'
+    )
+
+    v3Narrow.update(ann.id, { status: 'live' })
+    assertEq(
+      rawRow(sheet, 2, 4),
+      [cellText(ann.id), 'ann2', 'live', 'active'],
+      'CURRENT: the write lands in the abandoned `legacy` column while the real `status` column keeps its stale value'
+    )
+    t.info('v3 remove: value-op only; a schema that later drops the column misreads and miswrites every column to its right')
   })
 
   // Expose for cleanup by the harness entrypoint.


### PR DESCRIPTION
## Summary

Four production scenarios derived from the coverage-gap measurement, added to the real-GAS harness (11 → 16 tests + one new CI step):

- **S1 Mixed concurrent workload** — new `mixedBurst`/`mixedCheck` actions: two parallel callers each run 10 inserts + 5 updates + 3 deletes + 1 batchUpdate on their own rows; op sets are designed so the per-tag end state is interleaving-independent (7 survivors, fixed slot states). Checks: no duplicate ids/keys, no cross-tag contamination (a `key` column written at insert must reconstruct from the row's own `tag`+`slot` — partial overwrites fail it), per-tag slot audit. Seeded shuffle varies interleaving. CI gains a parallel mixed-burst step mirroring the existing burst step; local-check gains positive and negative cases so the check isn't vacuous.
- **S2 Human interference** — sort by non-id column and blank-row insertion are asserted survivable; **foreign-column insertion is characterized, not fixed** (`[documents #TBD]`): under fakes, reads silently shift one column right of `id`, and `update()` destroys the human's column while missing the real one. Real-GAS confirmation comes from this PR's CI run.
- **S3 Volume budget** — one 2,000-row sheet: batchInsert / findAll / filtered query / 200-row scattered batchUpdate / single update, correctness plus ~10× loose ceilings; per-op timings reported via a new non-assertional `info` channel on the runner.
- **S4 Live migration chain** — addColumn → renameColumn → removeColumn with physical-header and grid-alignment assertions after each step; characterizes that only addColumn is physical (rename is a positional no-op leaving header≠schema; remove clears values but leaves a ghost column that silently misaligns the *next* deploy) — `[documents #TBD]`.

Local: harness test/typecheck/build green, full `pnpm test` green (67 files), `test:coverage` exit 0.

## Related Issues

Related: #143 (scenario coverage), #138/#137 context; `[documents #TBD]` tags will be replaced by issue numbers filed from this run's real-GAS evidence.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_