### PR TITLE
test: local production scenario suites (offline lifecycle, two-client convergence, referential integrity)

### DIFF
--- a/packages/client/tests/scenario/offline-session-lifecycle.scenario.test.ts
+++ b/packages/client/tests/scenario/offline-session-lifecycle.scenario.test.ts
@@ -1,0 +1,558 @@
+/**
+ * S5 — Offline session lifecycle (production scenario).
+ *
+ * One realistic user session driven end-to-end through `createClientDB`:
+ *
+ *   pull initial data → go offline → 15 mixed mutations → backoff while the
+ *   network is down → page reload (new createClientDB over the SAME mutation
+ *   storage) → come back online → sync → converge with the server.
+ *
+ * plus the poisoned-mutation path (a row the backend permanently refuses)
+ * exercised through the public `onPoisonedMutation` hook rather than against
+ * SyncEngine directly.
+ *
+ * IndexedDB is disabled (Node), so only the MutationQueue survives the
+ * "reload" — that is deliberate: it isolates the queue's durability, which is
+ * the thing an offline session depends on.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { RowWithId } from '@gsquery/core'
+import { createClientDB } from '../../src/local/create-client-db.js'
+import type { ClientDBResult, ClientDBSchema } from '../../src/local/create-client-db.js'
+import { MockTransport } from '../../src/transports/mock-transport.js'
+import type { MutationStorage } from '../../src/local/mutation-queue.js'
+import type {
+  MergedMutation,
+  PoisonedMutationInfo,
+  SyncEvent,
+  SyncPushResult,
+  SyncTransport,
+} from '../../src/local/sync-transport.js'
+
+interface Task extends RowWithId {
+  id: string
+  title: string
+  status: string
+  priority: number
+}
+
+type Tables = { Task: Task }
+
+const schema: ClientDBSchema = {
+  tables: {
+    Task: { columns: ['id', 'title', 'status', 'priority'] },
+  },
+}
+
+/** Server state the session starts from. */
+const SEED: Task[] = [
+  { id: 't1', title: 'Task 1', status: 'todo', priority: 1 },
+  { id: 't2', title: 'Task 2', status: 'todo', priority: 2 },
+  { id: 't3', title: 'Task 3', status: 'todo', priority: 3 },
+  { id: 't4', title: 'Task 4', status: 'todo', priority: 4 },
+  { id: 't5', title: 'Task 5', status: 'todo', priority: 5 },
+]
+
+/**
+ * The deterministic outcome of the 15 offline edits below, once they reach the
+ * server. Also the state both the server and the local store must end in.
+ */
+const CONVERGED: Task[] = [
+  { id: 't1', title: 'Task 1', status: 'done', priority: 1 },
+  { id: 't2', title: 'Task 2 edited', status: 'todo', priority: 20 },
+  { id: 't4', title: 'Task 4 renamed', status: 'todo', priority: 40 },
+  { id: 't6', title: 'Task 6', status: 'doing', priority: 6 },
+  { id: 't8', title: 'Task 8', status: 'todo', priority: 8 },
+  { id: 't9', title: 'Task 9 edited', status: 'todo', priority: 9 },
+]
+
+/** `CONVERGED` minus t8, i.e. the outcome when the backend refuses t8. */
+const CONVERGED_WITHOUT_T8 = CONVERGED.filter(t => t.id !== 't8')
+
+/** Merged form of the 15 raw mutations, in the queue's first-seen order. */
+const EXPECTED_MERGED: MergedMutation<Task>[] = [
+  { id: 't1', type: 'update', data: { status: 'done' } },
+  { id: 't2', type: 'update', data: { priority: 20, title: 'Task 2 edited' } },
+  { id: 't6', type: 'insert', data: { id: 't6', title: 'Task 6', status: 'doing', priority: 6 } },
+  { id: 't3', type: 'delete', data: undefined },
+  { id: 't8', type: 'insert', data: { id: 't8', title: 'Task 8', status: 'todo', priority: 8 } },
+  { id: 't4', type: 'update', data: { title: 'Task 4 renamed', priority: 40 } },
+  { id: 't5', type: 'delete', data: undefined },
+  { id: 't9', type: 'insert', data: { id: 't9', title: 'Task 9 edited', status: 'todo', priority: 9 } },
+]
+
+/** In-memory MutationStorage that outlives a `createClientDB` instance. */
+function createPersistentStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+/**
+ * A network link in front of a MockTransport "server".
+ *
+ * Models the two things a real Apps Script deployment does that MockTransport
+ * alone cannot: it can be unreachable, and it can permanently refuse
+ * individual rows (a validation rule on the sheet). Two refusal styles are
+ * supported, both of which real `syncPush` handlers are written in the wild:
+ *
+ * - `partial-commit` — commit what is valid, report the rest via the
+ *   documented `appliedIds` contract with `success: false`.
+ * - `all-or-nothing` — reject the whole batch (the naive implementation).
+ */
+class GasBackendLink implements SyncTransport {
+  online = true
+  rejectionMode: 'partial-commit' | 'all-or-nothing' = 'partial-commit'
+  readonly rejectedIds = new Set<string>()
+  readonly pushAttempts: Array<{ table: string; ids: (string | number)[] }> = []
+  readonly pullAttempts: string[] = []
+
+  constructor(private readonly server: MockTransport) {}
+
+  async pull<T extends RowWithId>(tableName: string): Promise<{ rows: T[] }> {
+    this.pullAttempts.push(tableName)
+    this.assertReachable()
+    return this.server.pull<T>(tableName)
+  }
+
+  async push<T extends RowWithId>(
+    tableName: string,
+    mutations: MergedMutation<T>[]
+  ): Promise<SyncPushResult<T>> {
+    this.pushAttempts.push({ table: tableName, ids: mutations.map(m => m.id) })
+    this.assertReachable()
+
+    const refused = mutations.filter(m => this.rejectedIds.has(String(m.id)))
+    if (refused.length === 0) {
+      return this.server.push(tableName, mutations)
+    }
+
+    if (this.rejectionMode === 'all-or-nothing') {
+      throw new Error(
+        `syncPush: validation failed for ${refused.map(m => m.id).join(', ')} — batch rejected`
+      )
+    }
+
+    const accepted = mutations.filter(m => !this.rejectedIds.has(String(m.id)))
+    if (accepted.length > 0) {
+      await this.server.push(tableName, accepted)
+    }
+    return { success: false, appliedIds: accepted.map(m => m.id) }
+  }
+
+  pushAttemptCount(): number {
+    return this.pushAttempts.length
+  }
+
+  private assertReachable(): void {
+    if (!this.online) {
+      throw new Error('NetworkError: failed to reach the Apps Script web app')
+    }
+  }
+}
+
+function sortById<T extends RowWithId>(rows: readonly T[]): T[] {
+  return [...rows].sort((a, b) => String(a.id).localeCompare(String(b.id)))
+}
+
+function serverRows(server: MockTransport): Task[] {
+  return sortById((server.serverData.get('Task') ?? []) as Task[])
+}
+
+/**
+ * The 15 raw offline actions, including two same-row sequences (t1, t4), an
+ * insert-then-edit (t6, t9) and an insert-then-delete that cancels out (t7).
+ */
+function applyOfflineEdits(session: ClientDBResult<Tables>): void {
+  const tasks = session.db.from('Task')
+
+  tasks.update('t1', { status: 'doing' }) //  1
+  tasks.update('t1', { status: 'done' }) //  2  same row again
+  tasks.update('t2', { priority: 20 }) //  3
+  tasks.create({ id: 't6', title: 'Task 6', status: 'todo', priority: 6 }) //  4
+  tasks.update('t6', { status: 'doing' }) //  5  edit of an unsynced insert
+  tasks.create({ id: 't7', title: 'Task 7', status: 'todo', priority: 7 }) //  6
+  tasks.delete('t7') //  7  cancels out with 6
+  tasks.delete('t3') //  8
+  tasks.create({ id: 't8', title: 'Task 8', status: 'todo', priority: 8 }) //  9
+  tasks.update('t4', { title: 'Task 4 renamed' }) // 10
+  tasks.update('t4', { priority: 40 }) // 11  same row again
+  tasks.delete('t5') // 12
+  tasks.create({ id: 't9', title: 'Task 9', status: 'todo', priority: 9 }) // 13
+  tasks.update('t9', { title: 'Task 9 edited' }) // 14
+  tasks.update('t2', { title: 'Task 2 edited' }) // 15  same row as 3
+}
+
+describe('S5 offline session lifecycle', () => {
+  let server: MockTransport
+  let storage: MutationStorage
+
+  beforeEach(() => {
+    server = new MockTransport()
+    server.setServerData<Task>('Task', SEED)
+    storage = createPersistentStorage()
+  })
+
+  function openSession(
+    link: GasBackendLink,
+    options: {
+      maxRetries?: number
+      retryBaseDelayMs?: number
+      onPoisonedMutation?: (info: PoisonedMutationInfo) => 'discard' | 'retain' | void
+    } = {}
+  ): Promise<ClientDBResult<Tables>> {
+    return createClientDB<Tables>({
+      schema,
+      transport: link,
+      disableIDB: true,
+      mutationStorage: storage,
+      ...options,
+    })
+  }
+
+  it('survives going offline, a reload and coming back online', async () => {
+    const link = new GasBackendLink(server)
+
+    // ── Session 1: online, load the working set ───────────────────────
+    const session1 = await openSession(link, { maxRetries: 0, retryBaseDelayMs: 1000 })
+    await session1.sync.pull()
+    expect(session1.db.from('Task').findAll()).toEqual(SEED)
+
+    // ── Go offline and keep working ───────────────────────────────────
+    const pullsWhileOnline = link.pullAttempts.length
+    expect(pullsWhileOnline).toBe(1)
+    link.online = false
+    applyOfflineEdits(session1)
+
+    const queue1 = session1.adapters.Task.queue
+    expect(queue1.length).toBe(15)
+    expect(queue1.getMerged()).toEqual(EXPECTED_MERGED)
+
+    // The UI still shows a consistent, fully-edited view while offline.
+    expect(sortById(session1.db.from('Task').findAll())).toEqual(CONVERGED)
+
+    // ── Backoff: repeated auto-sync ticks do not hammer a dead server ─
+    vi.useFakeTimers()
+    try {
+      const events: SyncEvent[] = []
+      session1.sync.on(e => events.push(e))
+      session1.sync.startAutoSync(200)
+
+      // Ticks at 200/400/600/800/1000 — only the first attempt gets through;
+      // the rest fall inside the 1000ms window opened by that failure.
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(link.pushAttemptCount()).toBe(1)
+
+      // The tick at 1200 is past the deadline, so exactly one retry lands.
+      await vi.advanceTimersByTimeAsync(300)
+      expect(link.pushAttemptCount()).toBe(2)
+
+      session1.sync.stopAutoSync()
+
+      // The failure was reported, not swallowed...
+      expect(events.some(e => e.type === 'error' && e.table === 'Task')).toBe(true)
+      // ...and a failed push never lets a pull clobber the offline edits:
+      // sync() aborts the table before its pull phase.
+      expect(link.pullAttempts).toHaveLength(pullsWhileOnline)
+      // Nothing was ever accepted by the server during the outage.
+      expect(events.some(e => e.type === 'push-complete')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // Nothing was lost while the network was down.
+    expect(queue1.length).toBe(15)
+    expect(queue1.getMerged()).toEqual(EXPECTED_MERGED)
+    expect(sortById(session1.db.from('Task').findAll())).toEqual(CONVERGED)
+
+    // ── "Page reload": new client over the same storage and server ────
+    await session1.close()
+    const link2 = new GasBackendLink(server)
+    const session2 = await openSession(link2, { maxRetries: 0, retryBaseDelayMs: 1000 })
+    const queue2 = session2.adapters.Task.queue
+
+    // The pending work survived the reload, merge semantics intact.
+    expect(queue2.length).toBe(15)
+    expect(queue2.getMerged()).toEqual(EXPECTED_MERGED)
+
+    // With IndexedDB off, the *rows* did not survive — only the queue did, so
+    // the reloaded page renders empty until the first sync.
+    expect(session2.db.from('Task').findAll()).toEqual([])
+
+    // ── Back online: sync and converge ────────────────────────────────
+    await session2.sync.sync()
+
+    expect(serverRows(server)).toEqual(CONVERGED)
+    expect(sortById(session2.db.from('Task').findAll())).toEqual(CONVERGED)
+    // local === server, field for field.
+    expect(sortById(session2.db.from('Task').findAll())).toEqual(serverRows(server))
+
+    // The server saw exactly one batch, containing exactly the merged set.
+    expect(server.pushHistory).toHaveLength(1)
+    expect(server.pushHistory[0].mutations).toEqual(EXPECTED_MERGED)
+
+    // Everything that could be pushed has been pushed.
+    expect(queue2.getMerged()).toEqual([])
+
+    await session2.close()
+  })
+
+  it(
+    'reports a completed sync for a pass whose only table was skipped by backoff ' +
+      '[documents: backoff-emits-false-sync-complete]',
+    async () => {
+      const link = new GasBackendLink(server)
+      const session = await openSession(link, { maxRetries: 0, retryBaseDelayMs: 1000 })
+      await session.sync.pull()
+
+      link.online = false
+      applyOfflineEdits(session)
+
+      vi.useFakeTimers()
+      try {
+        const events: SyncEvent[] = []
+        session.sync.on(e => events.push(e))
+        session.sync.startAutoSync(200)
+
+        // Five ticks (200/400/600/800/1000). The first attempts the push and
+        // fails, opening a 1000ms backoff window; the other four skip the
+        // table entirely.
+        await vi.advanceTimersByTimeAsync(1000)
+        session.sync.stopAutoSync()
+
+        expect(link.pushAttemptCount()).toBe(1)
+        expect(events.filter(e => e.type === 'error' && e.table === 'Task')).toHaveLength(1)
+
+        // THE DEFECT: a pass in which every table was skipped has no recorded
+        // failures, so it is reported as a completed sync. Four of the five
+        // offline ticks announce success while 15 mutations sit unsent and the
+        // network is down — an "all changes saved" indicator wired to
+        // `sync-complete` turns green mid-outage.
+        expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(4)
+
+        // Those passes moved nothing in either direction.
+        expect(events.filter(e => e.type === 'push-complete')).toHaveLength(0)
+        expect(events.filter(e => e.type === 'pull-complete')).toHaveLength(0)
+        expect(session.adapters.Task.queue.getMerged()).toEqual(EXPECTED_MERGED)
+      } finally {
+        vi.useRealTimers()
+      }
+
+      await session.close()
+    }
+  )
+
+  it(
+    'never purges mutations that cancelled each other out ' +
+      '[documents: cancelled-mutations-never-purged]',
+    async () => {
+      const link = new GasBackendLink(server)
+      const session = await openSession(link)
+      await session.sync.pull()
+      applyOfflineEdits(session)
+      await session.sync.sync()
+
+      const queue = session.adapters.Task.queue
+
+      // There is genuinely nothing left to send...
+      expect(queue.getMerged()).toEqual([])
+      expect(serverRows(server)).toEqual(CONVERGED)
+
+      // ...but the two raw mutations for t7 (insert then delete, which merge to
+      // a no-op) are still in the queue, and in localStorage behind it. A push
+      // only clears the ids present in the *merged* batch, and t7 is not one of
+      // them, so this pair is never collected.
+      expect(queue.length).toBe(2)
+
+      // Therefore `hasPending` reports work that does not exist. An app that
+      // gates "safe to close this tab?" on it can never let the user leave.
+      expect(queue.hasPending).toBe(true)
+
+      const persisted = storage.getItem('gsquery:Task:mutations')
+      expect(persisted).not.toBeNull()
+      const parsed = JSON.parse(persisted as string) as Array<{
+        id: string
+        type: string
+      }>
+      expect(parsed.map(m => [m.id, m.type])).toEqual([
+        ['t7', 'insert'],
+        ['t7', 'delete'],
+      ])
+
+      // It is a permanent leak, not a timing artifact: further clean syncs
+      // never remove it.
+      await session.sync.sync()
+      await session.sync.sync()
+      expect(queue.length).toBe(2)
+
+      await session.close()
+    }
+  )
+
+  it('dead-letters a permanently-refused row and syncs the rest cleanly', async () => {
+    const link = new GasBackendLink(server)
+    link.rejectedIds.add('t8') // a sheet validation rule refuses this row
+
+    const poisoned: PoisonedMutationInfo[] = []
+    const events: SyncEvent[] = []
+    const session = await openSession(link, {
+      maxRetries: 2,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: info => {
+        poisoned.push(info)
+        return 'discard'
+      },
+    })
+    session.sync.on(e => events.push(e))
+
+    await session.sync.pull()
+    link.online = false
+    applyOfflineEdits(session)
+    link.online = true
+
+    // Attempt 1: the backend commits the 7 valid rows and refuses t8.
+    await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
+    expect(poisoned).toHaveLength(0) // one refusal is not poison yet
+    expect(session.adapters.Task.queue.getMerged().map(m => m.id)).toEqual(['t8'])
+    expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
+
+    // Attempt 2: t8 is refused again, hitting maxRetries.
+    await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
+
+    expect(poisoned).toHaveLength(1)
+    expect(poisoned[0].table).toBe('Task')
+    expect(poisoned[0].attempts).toBe(2)
+    expect(poisoned[0].mutations.map(m => m.id)).toEqual(['t8'])
+    expect(poisoned[0].error.message).toContain('server reported failure without conflicts')
+
+    const dead = events.filter(e => e.type === 'mutation-dead')
+    expect(dead).toHaveLength(1)
+    expect(dead[0].mutations?.map(m => m.id)).toEqual(['t8'])
+
+    // The handler discarded it, so the table is unblocked.
+    expect(session.adapters.Task.queue.getMerged()).toEqual([])
+
+    // Attempt 3: a clean, complete sync — everything except t8 converged.
+    await expect(session.sync.sync()).resolves.toBeUndefined()
+    expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
+    expect(sortById(session.db.from('Task').findAll())).toEqual(CONVERGED_WITHOUT_T8)
+    expect(events.some(e => e.type === 'sync-complete')).toBe(true)
+
+    // The discarded row is gone from the local view too: the pull that follows
+    // the unblocked push replaces local state with the server's, and the app is
+    // never told which row vanished beyond the one `mutation-dead` event.
+    expect(session.db.from('Task').repo.findByIdOrNull('t8')).toBeUndefined()
+
+    await session.close()
+  })
+
+  it(
+    "discarding a poisoned batch destroys every innocent write in it " +
+      '[documents: poison-discard-drops-whole-batch]',
+    async () => {
+      const link = new GasBackendLink(server)
+      // The naive Apps Script handler: one invalid row rejects the whole batch.
+      link.rejectionMode = 'all-or-nothing'
+      link.rejectedIds.add('t8')
+
+      const poisoned: PoisonedMutationInfo[] = []
+      const session = await openSession(link, {
+        maxRetries: 1,
+        retryBaseDelayMs: 0,
+        onPoisonedMutation: info => {
+          poisoned.push(info)
+          return 'discard'
+        },
+      })
+
+      await session.sync.pull()
+      link.online = false
+      applyOfflineEdits(session)
+      link.online = true
+
+      await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
+
+      // `onPoisonedMutation` is called at BATCH granularity: the app is handed
+      // all 8 merged mutations and its only choices are keep-all or drop-all.
+      expect(poisoned).toHaveLength(1)
+      expect(poisoned[0].mutations.map(m => m.id)).toEqual([
+        't1',
+        't2',
+        't6',
+        't3',
+        't8',
+        't4',
+        't5',
+        't9',
+      ])
+      expect(poisoned[0].mutations).toHaveLength(8)
+
+      // Choosing 'discard' to unblock the table drops all 8 — the 7 innocent
+      // merged mutations (12 of the user's 15 raw offline actions) included.
+      expect(session.adapters.Task.queue.getMerged()).toEqual([])
+
+      // Nothing ever reached the server: it is still exactly as it was seeded.
+      expect(serverRows(server)).toEqual(SEED)
+
+      // And the next sync overwrites the local view with that untouched server
+      // state, so the user's whole offline session disappears with no further
+      // signal.
+      await expect(session.sync.sync()).resolves.toBeUndefined()
+      expect(sortById(session.db.from('Task').findAll())).toEqual(SEED)
+
+      await session.close()
+    }
+  )
+
+  it(
+    'reports already-committed rows as part of the poisoned batch ' +
+      '[documents: dead-letter-reports-applied-mutations]',
+    async () => {
+      const link = new GasBackendLink(server)
+      link.rejectedIds.add('t8')
+
+      const poisoned: PoisonedMutationInfo[] = []
+      const session = await openSession(link, {
+        maxRetries: 1, // dead-letter on the very first refusal
+        retryBaseDelayMs: 0,
+        onPoisonedMutation: info => {
+          poisoned.push(info)
+          return 'retain'
+        },
+      })
+
+      await session.sync.pull()
+      link.online = false
+      applyOfflineEdits(session)
+      link.online = true
+
+      await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
+
+      // The backend committed 7 of the 8 rows and said so via `appliedIds`,
+      // and the queue was cleared accordingly...
+      expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
+      expect(session.adapters.Task.queue.getMerged().map(m => m.id)).toEqual(['t8'])
+
+      // ...yet the dead-letter report names all 8, including the 7 the server
+      // accepted. An app that logs or re-queues `info.mutations` for manual
+      // repair would act on 7 writes that already landed.
+      expect(poisoned).toHaveLength(1)
+      expect(poisoned[0].mutations.map(m => m.id)).toEqual([
+        't1',
+        't2',
+        't6',
+        't3',
+        't8',
+        't4',
+        't5',
+        't9',
+      ])
+      expect(poisoned[0].mutations.filter(m => m.id !== 't8')).toHaveLength(7)
+
+      await session.close()
+    }
+  )
+})

--- a/packages/client/tests/scenario/two-client-convergence.scenario.test.ts
+++ b/packages/client/tests/scenario/two-client-convergence.scenario.test.ts
@@ -1,0 +1,414 @@
+/**
+ * S6 — Two-client convergence measurement (production scenario).
+ *
+ * Two independent `createClientDB` instances (two browsers, two mutation
+ * queues) against ONE shared, stateful mock Apps Script backend. Both pull the
+ * same snapshot, both edit overlapping rows offline, then A syncs, then B
+ * syncs, then both pull.
+ *
+ * The suite MEASURES the outcome rather than asserting a policy: how many of
+ * client A's field-writes survive, and which were silently overwritten. The
+ * root cause is #138 — `MergedMutation` carries `{id, type, data}` and nothing
+ * else, so the server has no base version to compare against and can never
+ * populate `conflicts`. Both clients report a clean, successful, "converged"
+ * sync while writes disappear.
+ *
+ * Two backend write policies are measured, because the loss depends on the
+ * server's granularity and both shapes are written in practice:
+ *
+ * - `row-replace`  — the naive handler rewrites the whole sheet row from the
+ *   pushed object. Columns the pusher never mentioned are blanked.
+ * - `field-merge`  — the careful handler patches only the pushed columns.
+ *   This is the loss FLOOR: even here A's writes vanish with no signal.
+ */
+import { describe, it, expect } from 'vitest'
+import type { RowWithId } from '@gsquery/core'
+import { createClientDB } from '../../src/local/create-client-db.js'
+import type { ClientDBResult, ClientDBSchema } from '../../src/local/create-client-db.js'
+import type { MutationStorage } from '../../src/local/mutation-queue.js'
+import type {
+  MergedMutation,
+  SyncEvent,
+  SyncPushResult,
+  SyncTransport,
+} from '../../src/local/sync-transport.js'
+
+interface Doc extends RowWithId {
+  id: string
+  x: string
+  y: string
+  z: string
+  note: string
+}
+
+type Tables = { Doc: Doc }
+
+/**
+ * A row as it actually comes back from the shared backend. Under
+ * `row-replace` the server drops columns nobody pushed, so the runtime shape
+ * is a subset of `Doc` even though the client types it as `Doc`.
+ */
+type ServerDoc = Partial<Doc> & RowWithId
+
+const schema: ClientDBSchema = {
+  tables: {
+    Doc: { columns: ['id', 'x', 'y', 'z', 'note'] },
+  },
+}
+
+const SEED: Doc[] = Array.from({ length: 8 }, (_, i) => {
+  const n = i + 1
+  return { id: `r${n}`, x: `x${n}`, y: `y${n}`, z: `z${n}`, note: `n${n}` }
+})
+
+/** How the backend writes an `update` mutation back to the sheet. */
+type ServerWritePolicy = 'row-replace' | 'field-merge'
+
+/**
+ * One shared, stateful backend for both clients.
+ *
+ * Honors the documented push contract minimally: inserts are upserts, deletes
+ * are no-ops when the row is gone, and `appliedIds` reports exactly what was
+ * committed. It never reports a conflict — not out of laziness, but because
+ * the protocol gives it nothing to detect one with (#138).
+ */
+class SharedGasBackend {
+  private readonly rows = new Map<string | number, ServerDoc>()
+  readonly pushLog: Array<{ client: string; mutations: MergedMutation<ServerDoc>[] }> = []
+  conflictsReported = 0
+
+  constructor(private readonly policy: ServerWritePolicy) {
+    for (const row of SEED) this.rows.set(row.id, { ...row })
+  }
+
+  snapshot(): ServerDoc[] {
+    return [...this.rows.values()].map(r => ({ ...r }))
+  }
+
+  apply(client: string, mutations: MergedMutation<ServerDoc>[]): SyncPushResult<ServerDoc> {
+    this.pushLog.push({ client, mutations: mutations.map(m => ({ ...m })) })
+
+    for (const m of mutations) {
+      if (m.type === 'delete') {
+        this.rows.delete(m.id)
+        continue
+      }
+      if (m.type === 'insert') {
+        this.rows.set(m.id, { ...m.data, id: m.id } as ServerDoc)
+        continue
+      }
+      const existing = this.rows.get(m.id)
+      if (!existing) continue
+      this.rows.set(
+        m.id,
+        this.policy === 'row-replace'
+          ? ({ ...m.data, id: m.id } as ServerDoc)
+          : ({ ...existing, ...m.data, id: m.id } as ServerDoc)
+      )
+    }
+
+    // No base version arrives with the batch, so there is nothing to compare
+    // the stored row against. `conflicts` stays empty by construction.
+    return { success: true, appliedIds: mutations.map(m => m.id) }
+  }
+}
+
+/** Per-client link to the shared backend. */
+class ClientLink implements SyncTransport {
+  constructor(
+    private readonly backend: SharedGasBackend,
+    private readonly clientName: string
+  ) {}
+
+  async pull<T extends RowWithId>(_tableName: string): Promise<{ rows: T[] }> {
+    return { rows: this.backend.snapshot() as unknown as T[] }
+  }
+
+  async push<T extends RowWithId>(
+    _tableName: string,
+    mutations: MergedMutation<T>[]
+  ): Promise<SyncPushResult<T>> {
+    return this.backend.apply(
+      this.clientName,
+      mutations as unknown as MergedMutation<ServerDoc>[]
+    ) as unknown as SyncPushResult<T>
+  }
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+function openClient(
+  backend: SharedGasBackend,
+  name: string
+): Promise<ClientDBResult<Tables>> {
+  return createClientDB<Tables>({
+    schema,
+    transport: new ClientLink(backend, name),
+    disableIDB: true,
+    mutationStorage: createMemoryStorage(),
+    namespace: name,
+  })
+}
+
+function sortById(rows: readonly ServerDoc[]): ServerDoc[] {
+  return [...rows].sort((a, b) => String(a.id).localeCompare(String(b.id)))
+}
+
+function localRows(session: ClientDBResult<Tables>): ServerDoc[] {
+  return sortById(session.db.from('Doc').findAll() as ServerDoc[])
+}
+
+/** One intended field-level write by a client. */
+interface FieldWrite {
+  row: string
+  field: 'x' | 'y' | 'z'
+  value: string
+}
+
+/** Client A edits fields x and y of rows 1-5. */
+const A_WRITES: FieldWrite[] = [1, 2, 3, 4, 5].flatMap(n => [
+  { row: `r${n}`, field: 'x' as const, value: `A-x${n}` },
+  { row: `r${n}`, field: 'y' as const, value: `A-y${n}` },
+])
+
+/** Client B edits fields y and z of rows 3-8. */
+const B_WRITES: FieldWrite[] = [3, 4, 5, 6, 7, 8].flatMap(n => [
+  { row: `r${n}`, field: 'y' as const, value: `B-y${n}` },
+  { row: `r${n}`, field: 'z' as const, value: `B-z${n}` },
+])
+
+function applyWrites(session: ClientDBResult<Tables>, writes: FieldWrite[]): void {
+  const byRow = new Map<string, Partial<Doc>>()
+  for (const w of writes) {
+    const patch = byRow.get(w.row) ?? {}
+    patch[w.field] = w.value
+    byRow.set(w.row, patch)
+  }
+  for (const [id, patch] of byRow) {
+    session.db.from('Doc').update(id, patch)
+  }
+}
+
+/** Split intended writes into the ones still visible on the server and the ones gone. */
+function measure(
+  writes: FieldWrite[],
+  final: readonly ServerDoc[]
+): { kept: FieldWrite[]; lost: FieldWrite[] } {
+  const byId = new Map(final.map(r => [String(r.id), r]))
+  const kept: FieldWrite[] = []
+  const lost: FieldWrite[] = []
+  for (const w of writes) {
+    if (byId.get(w.row)?.[w.field] === w.value) kept.push(w)
+    else lost.push(w)
+  }
+  return { kept, lost }
+}
+
+function describeWrites(writes: readonly FieldWrite[]): string[] {
+  return writes.map(w => `${w.row}.${w.field}`)
+}
+
+/**
+ * Drives the full two-client workflow and returns the shared final state.
+ * Both clients end up reading the same rows, which is what makes the loss
+ * invisible to either of them.
+ */
+async function runConvergence(policy: ServerWritePolicy): Promise<{
+  backend: SharedGasBackend
+  final: ServerDoc[]
+  clientA: ClientDBResult<Tables>
+  clientB: ClientDBResult<Tables>
+  events: { a: SyncEvent[]; b: SyncEvent[] }
+}> {
+  const backend = new SharedGasBackend(policy)
+  const clientA = await openClient(backend, 'clientA')
+  const clientB = await openClient(backend, 'clientB')
+
+  const events = { a: [] as SyncEvent[], b: [] as SyncEvent[] }
+  clientA.sync.on(e => events.a.push(e))
+  clientB.sync.on(e => events.b.push(e))
+
+  // Both load the same snapshot.
+  await clientA.sync.pull()
+  await clientB.sync.pull()
+  expect(localRows(clientA)).toEqual(SEED)
+  expect(localRows(clientB)).toEqual(SEED)
+
+  // Both edit offline (no transport traffic until sync is called).
+  applyWrites(clientA, A_WRITES)
+  applyWrites(clientB, B_WRITES)
+
+  // A syncs, then B syncs, then both refresh.
+  await clientA.sync.sync()
+  await clientB.sync.sync()
+  await clientA.sync.pull()
+  await clientB.sync.pull()
+
+  return { backend, final: sortById(backend.snapshot()), clientA, clientB, events }
+}
+
+describe('S6 two-client convergence', () => {
+  it('carries no base version on the wire, so conflicts are undetectable [#138]', async () => {
+    const { backend, clientA, clientB, events } = await runConvergence('field-merge')
+
+    // Every pushed mutation is exactly {id, type, data} — no version, no
+    // timestamp, no seq. The server cannot tell a fresh write from a stale one.
+    const pushed = backend.pushLog.flatMap(entry => entry.mutations)
+    expect(pushed.length).toBeGreaterThan(0)
+    for (const mutation of pushed) {
+      expect(Object.keys(mutation).sort()).toEqual(['data', 'id', 'type'])
+    }
+
+    // Consequently no conflict was ever reported, and both clients experienced
+    // a completely clean sync.
+    expect(backend.conflictsReported).toBe(0)
+    expect(events.a.filter(e => e.type === 'error')).toEqual([])
+    expect(events.b.filter(e => e.type === 'error')).toEqual([])
+    expect(events.a.some(e => e.type === 'sync-complete')).toBe(true)
+    expect(events.b.some(e => e.type === 'sync-complete')).toBe(true)
+
+    await clientA.close()
+    await clientB.close()
+  })
+
+  it(
+    'loses 6 of client A\'s 10 field-writes to whole-row LWW ' +
+      '[documents: lww-field-loss]',
+    async () => {
+      const { final, clientA, clientB } = await runConvergence('row-replace')
+
+      // ── Exact converged state ───────────────────────────────────────
+      // Rows 1-2 keep A's write (B never touched them). Rows 3-5 were
+      // overlapping and B pushed last, so its whole-row write is all that
+      // remains. Rows 6-8 are B's alone.
+      expect(final).toEqual([
+        { id: 'r1', x: 'A-x1', y: 'A-y1' },
+        { id: 'r2', x: 'A-x2', y: 'A-y2' },
+        { id: 'r3', y: 'B-y3', z: 'B-z3' },
+        { id: 'r4', y: 'B-y4', z: 'B-z4' },
+        { id: 'r5', y: 'B-y5', z: 'B-z5' },
+        { id: 'r6', y: 'B-y6', z: 'B-z6' },
+        { id: 'r7', y: 'B-y7', z: 'B-z7' },
+        { id: 'r8', y: 'B-y8', z: 'B-z8' },
+      ])
+
+      // ── A's losses ──────────────────────────────────────────────────
+      const a = measure(A_WRITES, final)
+      expect(A_WRITES).toHaveLength(10)
+      expect(a.kept).toHaveLength(4)
+      expect(a.lost).toHaveLength(6)
+      expect(describeWrites(a.kept)).toEqual(['r1.x', 'r1.y', 'r2.x', 'r2.y'])
+      expect(describeWrites(a.lost)).toEqual([
+        'r3.x',
+        'r3.y',
+        'r4.x',
+        'r4.y',
+        'r5.x',
+        'r5.y',
+      ])
+
+      // Half of A's losses are fields B NEVER WROTE. B pushed only {y, z} for
+      // rows 3-5; x was collateral damage of the whole-row write.
+      const bTouched = new Set(B_WRITES.map(w => `${w.row}.${w.field}`))
+      const clobberedUntouched = a.lost.filter(w => !bTouched.has(`${w.row}.${w.field}`))
+      expect(describeWrites(clobberedUntouched)).toEqual(['r3.x', 'r4.x', 'r5.x'])
+      expect(clobberedUntouched).toHaveLength(3)
+
+      // ── B's writes all survive: last writer takes everything ────────
+      const b = measure(B_WRITES, final)
+      expect(B_WRITES).toHaveLength(12)
+      expect(b.lost).toEqual([])
+      expect(b.kept).toHaveLength(12)
+
+      // ── Collateral loss of columns neither client edited ────────────
+      // `note` was on all 8 seeded rows and is now on none of them.
+      expect(final.filter(r => r.note !== undefined)).toEqual([])
+      expect(SEED.filter(r => r.note !== undefined)).toHaveLength(8)
+
+      // ── Both clients "converge" — on the lossy state ────────────────
+      expect(localRows(clientA)).toEqual(final)
+      expect(localRows(clientB)).toEqual(final)
+      expect(localRows(clientA)).toEqual(localRows(clientB))
+
+      // Neither queue has anything left, so neither client has any record
+      // that A's writes were ever made.
+      expect(clientA.adapters.Doc.queue.getMerged()).toEqual([])
+      expect(clientB.adapters.Doc.queue.getMerged()).toEqual([])
+
+      await clientA.close()
+      await clientB.close()
+    }
+  )
+
+  it(
+    "loses 3 of client A's 10 field-writes even to a field-merging server " +
+      '[documents: lww-field-loss]',
+    async () => {
+      const { final, clientA, clientB } = await runConvergence('field-merge')
+
+      // A careful backend that patches only the pushed columns preserves
+      // untouched data — but it still cannot see that B's `y` is based on a
+      // read that predates A's `y`.
+      expect(final).toEqual([
+        { id: 'r1', x: 'A-x1', y: 'A-y1', z: 'z1', note: 'n1' },
+        { id: 'r2', x: 'A-x2', y: 'A-y2', z: 'z2', note: 'n2' },
+        { id: 'r3', x: 'A-x3', y: 'B-y3', z: 'B-z3', note: 'n3' },
+        { id: 'r4', x: 'A-x4', y: 'B-y4', z: 'B-z4', note: 'n4' },
+        { id: 'r5', x: 'A-x5', y: 'B-y5', z: 'B-z5', note: 'n5' },
+        { id: 'r6', x: 'x6', y: 'B-y6', z: 'B-z6', note: 'n6' },
+        { id: 'r7', x: 'x7', y: 'B-y7', z: 'B-z7', note: 'n7' },
+        { id: 'r8', x: 'x8', y: 'B-y8', z: 'B-z8', note: 'n8' },
+      ])
+
+      const a = measure(A_WRITES, final)
+      expect(a.kept).toHaveLength(7)
+      expect(a.lost).toHaveLength(3)
+      // This is the floor: exactly the fields both clients wrote, lost to the
+      // later pusher with no conflict raised.
+      expect(describeWrites(a.lost)).toEqual(['r3.y', 'r4.y', 'r5.y'])
+
+      // Untouched columns are safe under this policy.
+      expect(final.every(r => r.note !== undefined)).toBe(true)
+
+      const b = measure(B_WRITES, final)
+      expect(b.lost).toEqual([])
+
+      expect(localRows(clientA)).toEqual(final)
+      expect(localRows(clientB)).toEqual(final)
+
+      await clientA.close()
+      await clientB.close()
+    }
+  )
+
+  it('reverses the loss when the sync order reverses (pure last-writer-wins)', async () => {
+    // Same edits, B first: the losses move to B, confirming the outcome is
+    // decided by push order alone and not by any property of the data.
+    const backend = new SharedGasBackend('field-merge')
+    const clientA = await openClient(backend, 'clientA')
+    const clientB = await openClient(backend, 'clientB')
+
+    await clientA.sync.pull()
+    await clientB.sync.pull()
+    applyWrites(clientA, A_WRITES)
+    applyWrites(clientB, B_WRITES)
+
+    await clientB.sync.sync()
+    await clientA.sync.sync()
+    await clientB.sync.pull()
+
+    const final = sortById(backend.snapshot())
+    expect(measure(A_WRITES, final).lost).toEqual([])
+    expect(describeWrites(measure(B_WRITES, final).lost)).toEqual(['r3.y', 'r4.y', 'r5.y'])
+
+    await clientA.close()
+    await clientB.close()
+  })
+})

--- a/packages/core/tests/scenario/referential-integrity.scenario.test.ts
+++ b/packages/core/tests/scenario/referential-integrity.scenario.test.ts
@@ -1,0 +1,287 @@
+/**
+ * S7 — Referential integrity under id reuse (production scenario).
+ *
+ * A realistic two-table workflow (`users` + `orders`, with `orders.userId` as
+ * a foreign key) driven end-to-end through the public API: SheetsAdapter in
+ * its default `auto` id mode, backed by @gsquery/core/testing fakes, wired
+ * into a SheetsDB and queried with `joinQuery()`.
+ *
+ * The scenario exercises the interaction nobody tests in isolation: `auto` ids
+ * are allocated as `max(id) + 1` (SheetsAdapter.getNextId), so deleting the
+ * highest-numbered row hands its id straight to the next insert. Any row in
+ * another table still pointing at the deleted id silently re-points at the new
+ * occupant. Nothing in the library detects this — there are no foreign keys,
+ * no cascade, and no tombstones.
+ *
+ * These tests pin the behavior as it is today; they do not assert what a
+ * relational database would do.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { SheetsAdapter, createSheetsDB } from '../../src/index'
+import type { RowWithId, SheetsDB } from '../../src/index'
+import { installGasFakes, fromArrays } from '../../src/testing/index'
+import type { GasFakesHandle } from '../../src/testing/index'
+
+const SPREADSHEET_ID = 'referential-integrity-scenario'
+
+interface User extends RowWithId {
+  id: number
+  name: string
+  email: string
+}
+
+interface Order extends RowWithId {
+  id: number
+  userId: number
+  item: string
+  amount: number
+}
+
+type Tables = { users: User; orders: Order }
+
+const USER_COLUMNS = ['id', 'name', 'email']
+const ORDER_COLUMNS = ['id', 'userId', 'item', 'amount']
+
+/** A joined order row as `exec()` returns it (left join under the `user` key). */
+type JoinedOrder = Order & Record<string, unknown>
+
+/** Reads the joined `user` property of a result row, typed. */
+function joinedUser(row: JoinedOrder): User | null {
+  return (row.user ?? null) as User | null
+}
+
+interface Harness {
+  db: SheetsDB<Tables>
+  handle: GasFakesHandle
+}
+
+/**
+ * Two empty sheets (header rows only) behind SheetsAdapters in the default
+ * `auto` id mode, wired into a SheetsDB so `joinQuery()` can resolve stores.
+ */
+function setupHarness(): Harness {
+  const spreadsheet = fromArrays(
+    {
+      Users: [USER_COLUMNS],
+      Orders: [ORDER_COLUMNS],
+    },
+    'ReferentialIntegrityScenario'
+  )
+
+  const handle = installGasFakes({
+    spreadsheets: { [SPREADSHEET_ID]: spreadsheet },
+    activeId: SPREADSHEET_ID,
+  })
+
+  const users = new SheetsAdapter<User>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Users',
+    columns: USER_COLUMNS,
+  })
+  const orders = new SheetsAdapter<Order>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Orders',
+    columns: ORDER_COLUMNS,
+  })
+
+  const db = createSheetsDB<Tables>({
+    config: {
+      tables: {
+        users: { columns: ['id', 'name', 'email'], sheetName: 'Users' },
+        orders: { columns: ['id', 'userId', 'item', 'amount'], sheetName: 'Orders' },
+      },
+    },
+    stores: { users, orders },
+  })
+
+  return { db, handle }
+}
+
+/** Seeds 5 users and one order per user, mirroring a small live dataset. */
+function seedUsersAndOrders(db: SheetsDB<Tables>): void {
+  const names = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve']
+  for (const name of names) {
+    db.from('users').create({ name, email: `${name.toLowerCase()}@corp.test` })
+  }
+  for (let i = 1; i <= 5; i++) {
+    db.from('orders').create({ userId: i, item: `item-${i}`, amount: i * 10 })
+  }
+}
+
+function ordersWithUser(db: SheetsDB<Tables>): JoinedOrder[] {
+  return db
+    .from('orders')
+    .joinQuery()
+    .leftJoin('users', 'userId', 'id', { as: 'user' })
+    .orderBy('id')
+    .exec()
+}
+
+describe('S7 referential integrity under id reuse', () => {
+  let harness: Harness | undefined
+
+  afterEach(() => {
+    harness?.handle.restore()
+    harness = undefined
+  })
+
+  it('allocates sequential auto ids and joins orders to the right users', () => {
+    harness = setupHarness()
+    const { db } = harness
+
+    seedUsersAndOrders(db)
+
+    expect(db.from('users').findAll().map(u => u.id)).toEqual([1, 2, 3, 4, 5])
+    expect(db.from('orders').findAll().map(o => o.id)).toEqual([1, 2, 3, 4, 5])
+
+    // Baseline: every order resolves to its own user.
+    expect(ordersWithUser(db).map(o => [o.id, joinedUser(o)?.name])).toEqual([
+      [1, 'Alice'],
+      [2, 'Bob'],
+      [3, 'Carol'],
+      [4, 'Dave'],
+      [5, 'Eve'],
+    ])
+  })
+
+  it(
+    'silently re-points an orphaned order at the new owner of a reused id ' +
+      '[documents: id-reuse-dangling-join]',
+    () => {
+      harness = setupHarness()
+      const { db } = harness
+
+      seedUsersAndOrders(db)
+
+      // Eve is the highest-numbered user. Deleting her frees id 5 — auto mode
+      // allocates max(id) + 1, and after the delete max(id) is 4.
+      db.from('users').delete(5)
+      expect(db.from('users').findAll().map(u => u.id)).toEqual([1, 2, 3, 4])
+
+      // Order 5 is now an orphan: it still stores userId 5, and no user has it.
+      expect(db.from('orders').findById(5).userId).toBe(5)
+      expect(db.from('users').repo.exists(5)).toBe(false)
+      expect(joinedUser(ordersWithUser(db)[4])).toBeNull()
+
+      // A brand-new, unrelated signup. No error, no warning: it receives the
+      // id the deleted user used to own.
+      const frank = db.from('users').create({ name: 'Frank', email: 'frank@corp.test' })
+      expect(frank.id).toBe(5)
+
+      const joined = ordersWithUser(db)
+
+      // THE DEFECT: order 5 was Eve's. It now reports Frank as its user, with
+      // no error, no null, and no way for the caller to tell.
+      expect(joined[4]).toEqual({
+        id: 5,
+        userId: 5,
+        item: 'item-5',
+        amount: 50,
+        user: { id: 5, name: 'Frank', email: 'frank@corp.test' },
+      })
+      expect(joinedUser(joined[4])?.name).toBe('Frank')
+
+      // Every other order is unaffected, so nothing about the result set looks
+      // suspicious — the corruption is a single silently-rebound row.
+      expect(joined.map(o => [o.id, joinedUser(o)?.name])).toEqual([
+        [1, 'Alice'],
+        [2, 'Bob'],
+        [3, 'Carol'],
+        [4, 'Dave'],
+        [5, 'Frank'],
+      ])
+
+      // An inner join keeps it too: the FK resolves, so it is not filtered out.
+      const inner = db
+        .from('orders')
+        .joinQuery()
+        .innerJoin('users', 'userId', 'id', { as: 'user' })
+        .orderBy('id')
+        .exec()
+      expect(inner).toHaveLength(5)
+      expect(joinedUser(inner[4])?.name).toBe('Frank')
+    }
+  )
+
+  it('does not reuse the id of a deleted middle row', () => {
+    harness = setupHarness()
+    const { db } = harness
+
+    seedUsersAndOrders(db)
+
+    // Carol is not the max id, so her id is not freed for reallocation.
+    db.from('users').delete(3)
+    expect(db.from('users').findAll().map(u => u.id)).toEqual([1, 2, 4, 5])
+
+    const grace = db.from('users').create({ name: 'Grace', email: 'grace@corp.test' })
+    expect(grace.id).toBe(6)
+    expect(db.from('users').findAll().map(u => u.id)).toEqual([1, 2, 4, 5, 6])
+  })
+
+  it('left-joins a dangling FK to null and inner-joins it away (delete-middle)', () => {
+    harness = setupHarness()
+    const { db } = harness
+
+    seedUsersAndOrders(db)
+    db.from('users').delete(3)
+    db.from('users').create({ name: 'Grace', email: 'grace@corp.test' })
+
+    // Left join: the orphan row is KEPT, with the joined property set to null
+    // (not undefined, not omitted, and the row is not dropped).
+    const left = ordersWithUser(db)
+    expect(left).toHaveLength(5)
+    expect(left[2]).toEqual({
+      id: 3,
+      userId: 3,
+      item: 'item-3',
+      amount: 30,
+      user: null,
+    })
+    expect(Object.prototype.hasOwnProperty.call(left[2], 'user')).toBe(true)
+    expect(left.map(o => [o.id, joinedUser(o)?.name ?? null])).toEqual([
+      [1, 'Alice'],
+      [2, 'Bob'],
+      [3, null],
+      [4, 'Dave'],
+      [5, 'Eve'],
+    ])
+
+    // Inner join: the orphan row is DROPPED.
+    const inner = db
+      .from('orders')
+      .joinQuery()
+      .innerJoin('users', 'userId', 'id', { as: 'user' })
+      .orderBy('id')
+      .exec()
+    expect(inner.map(o => o.id)).toEqual([1, 2, 4, 5])
+    expect(
+      db
+        .from('orders')
+        .joinQuery()
+        .innerJoin('users', 'userId', 'id', { as: 'user' })
+        .count()
+    ).toBe(4)
+  })
+
+  it('reuses the id again after the reused row is itself deleted', () => {
+    harness = setupHarness()
+    const { db } = harness
+
+    seedUsersAndOrders(db)
+
+    // Repeated churn at the tail keeps handing out the same id, so a table
+    // that only ever appends at the end can bind one FK value to a whole
+    // sequence of unrelated records over its lifetime.
+    for (const name of ['Frank', 'Grace', 'Heidi']) {
+      db.from('users').delete(5)
+      const created = db.from('users').create({ name, email: `${name.toLowerCase()}@corp.test` })
+      expect(created.id).toBe(5)
+    }
+
+    expect(joinedUser(ordersWithUser(db)[4])).toEqual({
+      id: 5,
+      name: 'Heidi',
+      email: 'heidi@corp.test',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Three end-to-end scenario suites (15 tests) driving full production workflows through public APIs, each **pinning** real defects/limitations rather than fixing them (`[documents: …]` tags). Deterministic via fake timers (reusing the sync-resilience technique); no `src/` or existing-test changes; vitest globs already pick up `tests/scenario/`.

- **S5 Offline session lifecycle** — pull → offline → 15 mutations (merge to 8) → backoff → reload (new `createClientDB`, same storage) → online → sync; poisoned-mutation dead-letter path end-to-end. Happy paths pinned green.
- **S6 Two-client convergence** — quantifies #138: whole-row LWW loses 6/10 of a client's field-writes (3 of them collateral to columns the other client never touched); a field-merging backend still loses 3/10; both clients converge on the lossy state with zero conflicts/errors and clean `sync-complete`. Root cause pinned: pushed mutations carry only `{data,id,type}` — no version.
- **S7 Referential integrity** — `auto` id mode reallocates a deleted max id, silently re-pointing a foreign key at a new record (exact wrong-join output pinned); delete-middle (no reuse) behaves as documented (left-join null, inner-join drop).

Findings become GitHub issues filed separately from this run's evidence.

Local: `pnpm test` green (core 676, client 167), `test:coverage` exit 0, typecheck clean.

## Related Issues

Related: #138 (S6 quantifies it). New issues filed from the six pinned findings.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_