### PR TITLE
fix(core): lock sheet auto-creation and re-check inside the critical section

### DIFF
--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -190,19 +190,30 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
 
       if (!sheet) {
         if (this.createIfNotExists) {
-          // insertSheet is not idempotent — a retry after a spurious failure
-          // would either create a second sheet or throw on the taken name.
-          const created = this.sheetsCallOnce(() => ss.insertSheet(this.sheetName))
-          sheet = created
-          // Write header row
-          this.sheetsCall(() =>
-            created.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
-          )
+          // Creation is a cross-execution critical section (#178): two
+          // executions touching a not-yet-created table both see null above
+          // and would both insertSheet — one throws on the taken name, and
+          // the loser's early rows can be clobbered by the winner's header
+          // write (acknowledged-row loss, observed on the live platform).
+          // Re-check inside the lock; the lock's flush-before-release (#164)
+          // makes the creation durably visible before the lock hands over.
+          sheet = this.withLock(() => {
+            const existing = this.sheetsCall(() => ss.getSheetByName(this.sheetName))
+            if (existing) return existing
+            // insertSheet is not idempotent — a retry after a spurious failure
+            // would either create a second sheet or throw on the taken name.
+            const created = this.sheetsCallOnce(() => ss.insertSheet(this.sheetName))
+            // Write header row
+            this.sheetsCall(() =>
+              created.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
+            )
+            return created
+          })
         } else {
           throw new Error(`Sheet '${this.sheetName}' not found`)
         }
       }
-      
+
       this._sheet = sheet
     }
     return this._sheet

--- a/packages/core/tests/unit/sheet-creation-race.test.ts
+++ b/packages/core/tests/unit/sheet-creation-race.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #178 — sheet auto-creation must be a locked critical section.
+ *
+ * Two executions touching a not-yet-created table both used to see
+ * `getSheetByName() === null` and both called `insertSheet`: the loser threw
+ * "a sheet named X already exists", and its already-acknowledged early rows
+ * could be clobbered by the winner's header write (observed on the live
+ * platform by the mixed-workload scenario).
+ *
+ * These tests model the race at the lock boundary: the "intruder" wins the
+ * creation while our adapter is blocked in `waitLock`. The fix re-checks
+ * inside the lock, so the loser adopts the existing sheet instead of racing
+ * a second creation.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { FakeSpreadsheet, installGasFakes } from '../../src/testing'
+
+interface Row {
+  id: number
+  name: string
+  [key: string]: unknown
+}
+
+function makeAdapter(): SheetsAdapter<Row> {
+  return new SheetsAdapter<Row>({ spreadsheetId: 'S', sheetName: 'users', columns: ['id', 'name'] })
+}
+
+describe('sheet auto-creation race (#178)', () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  it('adopts a sheet created by a concurrent execution inside the race window', () => {
+    const spreadsheet = new FakeSpreadsheet('S')
+    const handle = installGasFakes({ spreadsheets: { S: spreadsheet }, activeId: 'S' })
+    restore = () => handle.restore()
+
+    // Model the exact race window: the loser's first existence check reads a
+    // stale "no such sheet" view, while the winner's creation lands in the
+    // same instant. The first getSheetByName('users') spawns the winner's
+    // full insert (sheet + header + one row) and still reports null — every
+    // later check sees the truth. Pre-fix, the loser then called insertSheet
+    // on the taken name and threw; the fixed path re-checks under the lock
+    // and adopts the winner's sheet.
+    const realGetSheetByName = spreadsheet.getSheetByName.bind(spreadsheet)
+    let staleReads = 0
+    spreadsheet.getSheetByName = (name: string) => {
+      const found = realGetSheetByName(name)
+      if (name === 'users' && !found && staleReads === 0) {
+        staleReads++
+        const winner = makeAdapter()
+        winner.insert({ name: 'winner-row' })
+        return null // the loser's read was already in flight — stale view
+      }
+      return found
+    }
+
+    const loser = makeAdapter()
+    // Pre-fix this threw `insertSheet: a sheet named "users" already exists`.
+    const inserted = loser.insert({ name: 'loser-row' })
+
+    const rows = loser.findAll()
+    expect(rows.length).toBe(2)
+    expect(rows.map(r => r.name).sort()).toEqual(['loser-row', 'winner-row'])
+    expect(rows.find(r => r.id === inserted.id)?.name).toBe('loser-row')
+
+    // Exactly one physical sheet was created.
+    expect(spreadsheet.getSheets().length).toBe(1)
+    // The winner's header row survived intact (no clobber by a second creation).
+    expect(spreadsheet.getSheetByName('users')?.getRange(1, 1, 1, 2).getValues()[0]).toEqual(['id', 'name'])
+  })
+
+  it('creates the sheet exactly once when it truly does not exist', () => {
+    const spreadsheet = new FakeSpreadsheet('S')
+    const handle = installGasFakes({ spreadsheets: { S: spreadsheet }, activeId: 'S' })
+    restore = () => handle.restore()
+
+    const adapter = makeAdapter()
+    adapter.insert({ name: 'first' })
+
+    expect(spreadsheet.getSheets().length).toBe(1)
+    expect(adapter.findAll().length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #178, caught live by the S1 mixed-workload scenario (gas-e2e run 31298563680): two executions touching a not-yet-created table both saw `getSheetByName() === null` and both called `insertSheet` — the loser threw *"a sheet named 'e2e_mixed' already exists"*, and one **acknowledged row was lost** (reported inserted, absent at check time) when the winner's header write clobbered it.

`getSheet()`'s create path now runs under `withLock` with a re-check inside the critical section: a racing loser adopts the winner's sheet instead of racing a second creation, and the lock's flush-before-release (#164) makes the creation durably visible before handover. Callers already holding the lock are safe via re-entrancy.

Regression test (`sheet-creation-race.test.ts`) models the stale-read window (first existence check spawns the winner's full insert and still reports null): pre-fix it reproduces the exact live error, post-fix the loser adopts the sheet, both rows survive, and exactly one physical sheet exists.

This should also turn the gas-e2e workflow green again — the mixedCheck step has been failing on this race since #171 landed.

## Related Issues

Closes #178

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated (red-then-green verified)
- [x] `pnpm test` passes (core 678)
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_