### PR TITLE
fix(core): survive stale spreadsheet handles in the sheet-creation critical section

### DIFF
--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -163,6 +163,20 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   /** Get the spreadsheet instance */
+  /**
+   * Drops the cached Spreadsheet handle and opens a fresh one.
+   *
+   * A handle's sheet list reflects the spreadsheet as of when the handle was
+   * materialized; a sheet created by ANOTHER execution afterwards can be
+   * invisible through the old handle even after that execution flushed
+   * (#178, second live repro). Creation-path re-checks must read through a
+   * fresh handle.
+   */
+  private reopenSpreadsheet(): GoogleAppsScript.Spreadsheet.Spreadsheet {
+    this._spreadsheet = null
+    return this.getSpreadsheet()
+  }
+
   private getSpreadsheet(): GoogleAppsScript.Spreadsheet.Spreadsheet {
     if (!this._spreadsheet) {
       // Opening a document is a read, and one of the likeliest calls to hit a
@@ -195,19 +209,37 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
           // and would both insertSheet — one throws on the taken name, and
           // the loser's early rows can be clobbered by the winner's header
           // write (acknowledged-row loss, observed on the live platform).
-          // Re-check inside the lock; the lock's flush-before-release (#164)
-          // makes the creation durably visible before the lock hands over.
+          //
+          // The lock alone is not enough: a Spreadsheet handle materializes
+          // its sheet list when opened, so even inside the lock a re-check
+          // through a stale handle can miss a sheet another execution just
+          // created (second live repro, gas-e2e run 31298880115). Hence the
+          // fresh re-open before the re-check, and the adopt-on-failure
+          // below as the final backstop — insertSheet's name-taken message
+          // is localized, so recovery keys on "the sheet exists after all",
+          // never on matching error text.
           sheet = this.withLock(() => {
-            const existing = this.sheetsCall(() => ss.getSheetByName(this.sheetName))
+            const fresh = this.reopenSpreadsheet()
+            const existing = this.sheetsCall(() => fresh.getSheetByName(this.sheetName))
             if (existing) return existing
-            // insertSheet is not idempotent — a retry after a spurious failure
-            // would either create a second sheet or throw on the taken name.
-            const created = this.sheetsCallOnce(() => ss.insertSheet(this.sheetName))
-            // Write header row
-            this.sheetsCall(() =>
-              created.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
-            )
-            return created
+            try {
+              // insertSheet is not idempotent — a retry after a spurious
+              // failure would either create a second sheet or throw on the
+              // taken name.
+              const created = this.sheetsCallOnce(() => fresh.insertSheet(this.sheetName))
+              // Write header row
+              this.sheetsCall(() =>
+                created.getRange(1, 1, 1, this.columns.length).setValues([this.columns])
+              )
+              return created
+            } catch (err) {
+              // A concurrent execution may have won a race even the fresh
+              // read could not see. If the sheet exists now, adopt it;
+              // otherwise the failure was real — rethrow it.
+              const adopted = this.sheetsCall(() => this.reopenSpreadsheet().getSheetByName(this.sheetName))
+              if (adopted) return adopted
+              throw err
+            }
           })
         } else {
           throw new Error(`Sheet '${this.sheetName}' not found`)

--- a/packages/core/tests/unit/sheet-creation-race.test.ts
+++ b/packages/core/tests/unit/sheet-creation-race.test.ts
@@ -74,6 +74,43 @@ describe('sheet auto-creation race (#178)', () => {
     expect(spreadsheet.getSheetByName('users')?.getRange(1, 1, 1, 2).getValues()[0]).toEqual(['id', 'name'])
   })
 
+  it('adopts the winner even when the in-lock re-check also reads stale (live repro of run 31298880115)', () => {
+    const spreadsheet = new FakeSpreadsheet('S')
+    const handle = installGasFakes({ spreadsheets: { S: spreadsheet }, activeId: 'S' })
+    restore = () => handle.restore()
+
+    // Model the harsher live failure: BOTH the unlocked check and the
+    // in-lock re-check read a stale "no such sheet" view (a Spreadsheet
+    // handle's sheet list can lag another execution's creation even under
+    // the lock). insertSheet then throws on the taken name, and only the
+    // adopt-on-failure path can recover.
+    const realGetSheetByName = spreadsheet.getSheetByName.bind(spreadsheet)
+    let staleReads = 0
+    spreadsheet.getSheetByName = (name: string) => {
+      const found = realGetSheetByName(name)
+      if (name === 'users' && found && staleReads < 2) {
+        staleReads++
+        return null // stale handle: the winner's sheet is not visible yet
+      }
+      if (name === 'users' && !found && staleReads === 0) {
+        staleReads++
+        const winner = makeAdapter()
+        winner.insert({ name: 'winner-row' })
+        return null
+      }
+      return found
+    }
+
+    const loser = makeAdapter()
+    const inserted = loser.insert({ name: 'loser-row' })
+
+    const rows = loser.findAll()
+    expect(rows.length).toBe(2)
+    expect(rows.map(r => r.name).sort()).toEqual(['loser-row', 'winner-row'])
+    expect(rows.find(r => r.id === inserted.id)?.name).toBe('loser-row')
+    expect(spreadsheet.getSheets().length).toBe(1)
+  })
+
   it('creates the sheet exactly once when it truly does not exist', () => {
     const spreadsheet = new FakeSpreadsheet('S')
     const handle = installGasFakes({ spreadsheets: { S: spreadsheet }, activeId: 'S' })


### PR DESCRIPTION
## Summary

Second live repro of #178 (gas-e2e run 31298880115, with #181 already deployed) proved the lock alone is insufficient: the acknowledged-row loss was gone (missing = exactly the errored slot), but the *"a sheet named 'e2e_mixed' already exists"* exception still fired — **a Spreadsheet handle materializes its sheet list at open time**, so even the in-lock re-check read a stale view and missed the sheet the other execution had just created.

Hardened in two layers:
1. The in-lock re-check reads through a **freshly re-opened handle** (`reopenSpreadsheet()` drops the cached `_spreadsheet`).
2. If `insertSheet` still fails, the adapter re-opens once more and **adopts the existing sheet** — recovery keys on "the sheet exists after all", never on matching the error text (the live message is localized Korean); a genuine failure still rethrows.

New regression case models the double-stale window (both checks read null, `insertSheet` throws): it reproduces the live failure against the #181-only code (verified red with src stashed) and passes with this fix. Full suite green (core 679), typecheck clean. The gas-e2e mixedCheck step should finally go green on this merge's run.

## Related Issues

Closes #178

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated (red-then-green verified against the prior fix)
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_