### PR TITLE
fix(client): sync hardening — honest sync-complete, granular dead-letter, queue purge, accurate payloads

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -53,6 +53,7 @@ export type {
   PoisonedMutationInfo,
   PoisonedMutationAction,
   PoisonedMutationHandler,
+  RejectedMutationIds,
 } from "./local/index.js";
 
 // Transports

--- a/packages/client/src/local/create-client-db.ts
+++ b/packages/client/src/local/create-client-db.ts
@@ -12,6 +12,7 @@ import type { SyncEngineOptions } from './sync-engine.js'
 import type {
   SyncTransport,
   ConflictStrategy,
+  PoisonedMutationAction,
   PoisonedMutationHandler,
 } from './sync-transport.js'
 import type { MutationStorage } from './mutation-queue.js'
@@ -38,7 +39,11 @@ export interface CreateClientDBOptions<Tables extends Record<string, RowWithId>>
   retryBaseDelayMs?: number
   /** Ceiling for the exponential backoff (default 60000ms) */
   maxRetryDelayMs?: number
-  /** Called when a table's batch has failed `maxRetries` times in a row */
+  /**
+   * Called when a table's batch has failed `maxRetries` times in a row, with
+   * the mutations still unapplied. Return `'retain'`, `'discard'`, or the exact
+   * ids to drop — see {@link PoisonedMutationAction}.
+   */
   onPoisonedMutation?: PoisonedMutationHandler
   /** Custom mutation storage (defaults to localStorage) */
   mutationStorage?: MutationStorage

--- a/packages/client/src/local/index.ts
+++ b/packages/client/src/local/index.ts
@@ -26,4 +26,5 @@ export type {
   PoisonedMutationInfo,
   PoisonedMutationAction,
   PoisonedMutationHandler,
+  RejectedMutationIds,
 } from './sync-transport.js'

--- a/packages/client/src/local/mutation-queue.ts
+++ b/packages/client/src/local/mutation-queue.ts
@@ -74,45 +74,50 @@ export class MutationQueue<T extends RowWithId = RowWithId> {
 
   /** Get all pending mutations after merge */
   getMerged(): MergedMutation<T>[] {
-    // Group by ID, then merge sequentially
-    const byId = new Map<string | number, MergedMutation<T> | null>()
-
-    for (const m of this.mutations) {
-      const existing = byId.get(m.id)
-
-      if (existing === undefined) {
-        // First mutation for this ID
-        byId.set(m.id, {
-          id: m.id,
-          type: m.type,
-          data: m.type === 'delete' ? undefined : { ...(m.row ?? m.data) } as Partial<T>,
-        })
-        continue
-      }
-
-      if (existing === null) {
-        // Previously cancelled out, start fresh
-        byId.set(m.id, {
-          id: m.id,
-          type: m.type,
-          data: m.type === 'delete' ? undefined : { ...(m.row ?? m.data) } as Partial<T>,
-        })
-        continue
-      }
-
-      // Merge with existing
-      const merged = this.mergePair(existing, m)
-      byId.set(m.id, merged)
-    }
-
-    // Collect non-null results
     const result: MergedMutation<T>[] = []
-    for (const entry of byId.values()) {
-      if (entry !== null) {
-        result.push(entry)
+    for (const group of this.groupById().values()) {
+      const merged = this.foldGroup(group)
+      if (merged !== null) {
+        result.push(merged)
       }
     }
     return result
+  }
+
+  /**
+   * Raw mutations per row id, in first-seen id order (which `getMerged()`
+   * preserves) and enqueue order within each id.
+   */
+  private groupById(): Map<string | number, Mutation<T>[]> {
+    const byId = new Map<string | number, Mutation<T>[]>()
+    for (const m of this.mutations) {
+      const group = byId.get(m.id)
+      if (group) group.push(m)
+      else byId.set(m.id, [m])
+    }
+    return byId
+  }
+
+  /**
+   * Fold one row's raw mutations into its net effect, or `null` when they
+   * cancel out entirely (insert followed by delete).
+   */
+  private foldGroup(group: Mutation<T>[]): MergedMutation<T> | null {
+    let acc: MergedMutation<T> | null = null
+    for (const m of group) {
+      // First mutation for this id, or a fresh start after a cancelling pair.
+      acc = acc === null ? this.seed(m) : this.mergePair(acc, m)
+    }
+    return acc
+  }
+
+  /** The merged form of a single mutation, with no history behind it. */
+  private seed(m: Mutation<T>): MergedMutation<T> {
+    return {
+      id: m.id,
+      type: m.type,
+      data: m.type === 'delete' ? undefined : ({ ...(m.row ?? m.data) } as Partial<T>),
+    }
   }
 
   /** Merge two mutations for the same row */
@@ -199,14 +204,47 @@ export class MutationQueue<T extends RowWithId = RowWithId> {
     this.persist()
   }
 
+  /**
+   * Drop the raw mutations of every row whose net effect is nothing.
+   *
+   * A row that was created and then deleted offline merges to `null`, so it has
+   * no id in `getMerged()` and a push-driven `clearForRows` can never collect
+   * it: the pair sat in the queue (and in localStorage) forever, growing without
+   * bound under create-then-delete churn (#175).
+   *
+   * `maxSeq` is the push boundary and is what makes this provable: a row is only
+   * collected when *all* of its raw mutations were enqueued at or below the
+   * boundary. If a later mutation exists (e.g. a delete that landed while the
+   * matching insert was in flight), the pair is not settled yet and is kept, so
+   * the delete still reaches the server on the next push (#109).
+   */
+  purgeCancelled(maxSeq?: number): void {
+    const doomed = new Set<string | number>()
+    for (const [id, group] of this.groupById()) {
+      if (maxSeq !== undefined && group.some(m => m.seq > maxSeq)) continue
+      if (this.foldGroup(group) === null) doomed.add(id)
+    }
+    if (doomed.size === 0) return
+
+    this.mutations = this.mutations.filter(m => !doomed.has(m.id))
+    this.persist()
+  }
+
   /** Get raw mutation count (before merge) */
   get length(): number {
     return this.mutations.length
   }
 
-  /** Check if queue has pending mutations */
+  /**
+   * Whether the queue holds work that still has to reach the server.
+   *
+   * Derived from the *merged* view, not the raw count: rows whose mutations
+   * cancel out carry no work, and reporting them made `hasPending` unusable as
+   * a "safe to close this tab?" gate (#175).
+   */
   get hasPending(): boolean {
-    return this.mutations.length > 0
+    if (this.mutations.length === 0) return false
+    return this.getMerged().length > 0
   }
 
   /** Persist to storage */

--- a/packages/client/src/local/sync-engine.ts
+++ b/packages/client/src/local/sync-engine.ts
@@ -12,6 +12,7 @@ import type {
   MergedMutation,
   PoisonedMutationAction,
   PoisonedMutationHandler,
+  RejectedMutationIds,
 } from './sync-transport.js'
 import type { LocalAdapter } from './local-adapter.js'
 import type { MutationQueue } from './mutation-queue.js'
@@ -41,7 +42,12 @@ export interface SyncEngineOptions {
   retryBaseDelayMs?: number
   /** Ceiling for the exponential backoff (default: 60000ms) */
   maxRetryDelayMs?: number
-  /** Called when a table's batch has failed `maxRetries` times in a row */
+  /**
+   * Called when a table's batch has failed `maxRetries` times in a row, with
+   * the mutations still unapplied at that point (#176). Its return value picks
+   * what leaves the queue: `'retain'`, `'discard'`, or an explicit list of ids
+   * (#174) — see {@link PoisonedMutationAction}.
+   */
   onPoisonedMutation?: PoisonedMutationHandler
 }
 
@@ -79,12 +85,69 @@ export class SyncError extends Error {
 class PushPhaseError extends Error {
   constructor(
     readonly inner: Error,
+    /**
+     * The mutations still unapplied when the push failed — the pushed batch
+     * minus whatever the server confirmed via `appliedIds`. Reporting the raw
+     * pre-push snapshot named rows that had already landed (#176).
+     */
     readonly mutations: MergedMutation[],
-    readonly boundary: number
+    readonly boundary: number,
+    /** Ids the transport named as refused, if it named any (#174) */
+    readonly rejectedIds?: readonly (string | number)[]
   ) {
     super(inner.message)
     this.name = 'PushPhaseError'
   }
+}
+
+/**
+ * Read the optional `rejectedIds` a transport may attach to the error it throws
+ * (see {@link RejectedMutationIds}). Defensive: the value crosses an untyped
+ * boundary, so anything that is not an array of ids is treated as absent.
+ */
+function readRejectedIds(source: unknown): readonly (string | number)[] | undefined {
+  if (typeof source !== 'object' || source === null) return undefined
+  const { rejectedIds } = source as RejectedMutationIds
+  if (!Array.isArray(rejectedIds)) return undefined
+  const ids = rejectedIds.filter(
+    (id): id is string | number => typeof id === 'string' || typeof id === 'number'
+  )
+  return ids.length > 0 ? ids : undefined
+}
+
+/**
+ * Translate a poisoned-batch decision into the exact set of ids to drop.
+ *
+ * The whole point is granularity (#174): with an all-or-nothing backend a
+ * single bad row used to cost the app every other mutation in the batch. Now
+ * the smallest defensible set wins — the handler's explicit list first, then the
+ * ids the transport named, and only as a last resort the whole batch, which is
+ * all the engine can distinguish when nobody says which row is at fault.
+ */
+function resolveDiscardIds(
+  action: PoisonedMutationAction | void,
+  batchIds: ReadonlySet<string | number>,
+  rejectedIds: readonly (string | number)[] | undefined
+): Set<string | number> {
+  if (Array.isArray(action)) {
+    return new Set(action.filter(id => batchIds.has(id)))
+  }
+  if (action !== 'discard') return new Set()
+  if (rejectedIds && rejectedIds.length > 0) return new Set(rejectedIds)
+  return new Set(batchIds)
+}
+
+/**
+ * What one pass over the requested tables left undone, beyond the failures it
+ * raises.
+ *
+ * This is what separates "everything asked for is in sync" from "nothing was
+ * even tried": a backoff-skipped table moved no data in either direction, so a
+ * pass that skipped one is not a completed sync (#173).
+ */
+interface SyncPassOutcome {
+  /** Tables skipped because their backoff window is still open */
+  deferred: string[]
 }
 
 /**
@@ -104,6 +167,7 @@ interface SyncQueue {
   getMerged(): MergedMutation[]
   currentSeq(): number
   clearForRows(ids: Set<string | number>, maxSeq?: number): void
+  purgeCancelled(maxSeq?: number): void
   push(type: 'insert' | 'update' | 'delete', id: string | number, data?: Partial<RowWithId>): void
 }
 
@@ -213,7 +277,7 @@ export class SyncEngine {
 
   /** Pull server data to local */
   async pull(tableName?: string): Promise<void> {
-    return this.serialize(() =>
+    await this.serialize(() =>
       this.runTables(tableName, false, name => this.pullTable(name))
     )
   }
@@ -228,14 +292,26 @@ export class SyncEngine {
       try {
         this.emit({ type: 'sync-start', table: tableName })
 
-        await this.runTables(tableName, background, async name => {
+        const outcome = await this.runTables(tableName, background, async name => {
           await this.pushTable(name)
           await this.pullTable(name)
         })
 
-        // Only a pass in which every table succeeded is a completed sync;
-        // failures were already reported as per-table 'error' events.
-        this.emit({ type: 'sync-complete', table: tableName })
+        // Failures never reach this point — they were reported as per-table
+        // 'error' events and raised as a SyncError. What is left is a pass in
+        // which nothing failed, which is only *complete* if nothing was left
+        // out either: a table skipped by backoff synced no data, and reporting
+        // that as a completed sync turned "all changes saved" green while the
+        // network was down (#173).
+        if (outcome.deferred.length > 0) {
+          this.emit({
+            type: 'sync-deferred',
+            table: tableName,
+            deferredTables: outcome.deferred,
+          })
+        } else {
+          this.emit({ type: 'sync-complete', table: tableName })
+        }
       } finally {
         this.syncing = false
       }
@@ -243,7 +319,7 @@ export class SyncEngine {
   }
 
   private async runPush(tableName: string | undefined, background: boolean): Promise<void> {
-    return this.serialize(() =>
+    await this.serialize(() =>
       this.runTables(tableName, background, name => this.pushTable(name))
     )
   }
@@ -256,17 +332,24 @@ export class SyncEngine {
    * rejected mutation stalled every table forever (#132). Failures are raised
    * together as a SyncError once the pass is done, so awaiting callers still
    * see them.
+   *
+   * Returns what the pass touched, so the caller can tell an idle pass from one
+   * that was entirely skipped by backoff (#173).
    */
   private async runTables(
     tableName: string | undefined,
     background: boolean,
     op: (name: string) => Promise<void>
-  ): Promise<void> {
+  ): Promise<SyncPassOutcome> {
     const tableNames = tableName ? [tableName] : Array.from(this.tables.keys())
     const errors: TableSyncError[] = []
+    const outcome: SyncPassOutcome = { deferred: [] }
 
     for (const name of tableNames) {
-      if (background && this.isBackedOff(name)) continue
+      if (background && this.isBackedOff(name)) {
+        outcome.deferred.push(name)
+        continue
+      }
 
       try {
         await op(name)
@@ -283,6 +366,7 @@ export class SyncEngine {
     }
 
     if (errors.length > 0) throw new SyncError(errors)
+    return outcome
   }
 
   // ── Retry / backoff / dead-letter ───────────────────────────────────
@@ -359,12 +443,19 @@ export class SyncEngine {
     // after another maxRetries attempts rather than going quiet forever.
     state.pushFailures = 0
 
+    const batchIds = new Set(failure.mutations.map(m => m.id))
+    // Only ids that are actually in the reported batch may be acted on; a
+    // transport naming something else must not cost the app unrelated writes.
+    const rejectedIds = failure.rejectedIds?.filter(id => batchIds.has(id))
+    const named = rejectedIds !== undefined && rejectedIds.length > 0
+
     this.emit({
       type: 'mutation-dead',
       table: tableName,
       error: failure.inner,
       mutations: failure.mutations,
       attempts,
+      rejectedIds: named ? rejectedIds : undefined,
     })
 
     let action: PoisonedMutationAction | void
@@ -374,20 +465,19 @@ export class SyncEngine {
         mutations: failure.mutations,
         error: failure.inner,
         attempts,
+        rejectedIds: named ? rejectedIds : undefined,
       })
     } catch {
       // A throwing handler must not break sync — treat it as 'retain'.
       action = undefined
     }
 
-    if (action !== 'discard') return
+    const discardIds = resolveDiscardIds(action, batchIds, named ? rejectedIds : undefined)
+    if (discardIds.size === 0) return
 
     // Respect the push boundary: writes enqueued after the batch was
     // snapshotted were never rejected and must survive (#109).
-    binding.queue.clearForRows(
-      new Set(failure.mutations.map(m => m.id)),
-      failure.boundary
-    )
+    binding.queue.clearForRows(discardIds, failure.boundary)
     // The blockage is gone, so let the table resume on the very next attempt.
     this.resetRetryState(tableName)
   }
@@ -399,7 +489,13 @@ export class SyncEngine {
     if (!binding) return
 
     const merged = binding.queue.getMerged()
-    if (merged.length === 0) return
+    if (merged.length === 0) {
+      // Nothing to send — but rows whose mutations cancelled out have no id in
+      // the merged batch, so no push will ever clear them. Collect them here
+      // too, or a queue holding only cancelled pairs would never shrink (#175).
+      binding.queue.purgeCancelled(binding.queue.currentSeq())
+      return
+    }
 
     // Boundary: only mutations enqueued up to this point are part of this push.
     // Anything enqueued during the await below (higher seq) must survive the
@@ -410,7 +506,8 @@ export class SyncEngine {
     try {
       result = await this.transport.push(tableName, merged)
     } catch (err) {
-      throw new PushPhaseError(toError(err), merged, boundary)
+      // The batch never reached the server, so nothing was applied.
+      throw new PushPhaseError(toError(err), merged, boundary, readRejectedIds(err))
     }
 
     // Ids that may leave the queue. A transport that reports appliedIds is
@@ -429,6 +526,10 @@ export class SyncEngine {
     }
 
     binding.queue.clearForRows(settledIds, boundary)
+    // Rows that cancelled each other out are settled by construction: they were
+    // never part of any batch and never will be. Their deadness does not depend
+    // on how this push went, only on the boundary (#175).
+    binding.queue.purgeCancelled(boundary)
 
     if (!result.success && conflicts.length === 0) {
       // success:false with no conflicts is a real push failure. Surface it so
@@ -438,8 +539,12 @@ export class SyncEngine {
         new Error(
           `Push failed for table "${tableName}": server reported failure without conflicts`
         ),
-        merged,
-        boundary
+        // Only what is still unapplied: a partial commit reported via
+        // appliedIds has already landed, and naming those rows in the
+        // dead-letter payload invited apps to re-apply them (#176).
+        merged.filter(m => !settledIds.has(m.id)),
+        boundary,
+        readRejectedIds(result)
       )
     }
 

--- a/packages/client/src/local/sync-transport.ts
+++ b/packages/client/src/local/sync-transport.ts
@@ -39,6 +39,23 @@ export interface ConflictItem<T extends RowWithId = RowWithId> {
 }
 
 /**
+ * Names the individual mutations a server actively refused.
+ *
+ * A transport may report them two ways, and the engine reads both:
+ * - on a returned {@link SyncPushResult}, alongside `success: false`,
+ * - as a `rejectedIds` property on the `Error` a failing `push()` throws
+ *   (the all-or-nothing style, where the batch never reaches the sheet).
+ *
+ * Naming the offenders is what lets the dead-letter path drop *only* the
+ * poisoned rows instead of the whole batch (#174). Ids that were not part of
+ * the pushed batch are ignored.
+ */
+export interface RejectedMutationIds {
+  /** Ids the server refused. Absent → the engine cannot tell them apart. */
+  rejectedIds?: readonly (string | number)[]
+}
+
+/**
  * Result of a transport push.
  *
  * `appliedIds` is the authoritative list of rows the server actually committed.
@@ -52,8 +69,13 @@ export interface ConflictItem<T extends RowWithId = RowWithId> {
  * A server that commits part of a batch should report `appliedIds` explicitly;
  * otherwise the client conservatively re-pushes the whole batch, which is safe
  * because every mutation is idempotent (see the `push` contract below).
+ *
+ * `rejectedIds` is the mirror image: the rows the server *refused*. It never
+ * affects what is cleared after a push — only what a dead-lettered batch
+ * discards (#174).
  */
-export interface SyncPushResult<T extends RowWithId = RowWithId> {
+export interface SyncPushResult<T extends RowWithId = RowWithId>
+  extends RejectedMutationIds {
   success: boolean
   conflicts?: ConflictItem<T>[]
   /** Ids the server confirms it applied. Absent → inferred from `success`. */
@@ -80,12 +102,24 @@ export interface SyncTransport {
   ): Promise<SyncPushResult<T>>
 }
 
-/** Sync event types */
+/**
+ * Sync event types.
+ *
+ * `sync-complete` is the "everything requested is now in sync" signal, and is
+ * safe to wire an "all changes saved" indicator to: it fires only when every
+ * table the pass asked for was actually attempted and none of them failed.
+ * A pass in which any table was skipped because its backoff window is still
+ * open ends in `sync-deferred` instead — no data moved for those tables, so
+ * calling that "complete" turned a saved indicator green mid-outage (#173).
+ * A pass with failures ends in per-table `error` events and a rejected promise,
+ * and emits neither.
+ */
 export type SyncEventType =
   | 'sync-start'
   | 'push-complete'
   | 'pull-complete'
   | 'sync-complete'
+  | 'sync-deferred'
   | 'error'
   | 'mutation-dead'
 
@@ -106,29 +140,68 @@ export interface SyncEvent {
   mutations?: MergedMutation[]
   /** Consecutive failed push attempts for the batch ('mutation-dead') */
   attempts?: number
+  /**
+   * Tables the pass left untouched because their backoff window is still open
+   * ('sync-deferred'). Always non-empty for that event; they will be retried on
+   * a later tick, or immediately by an explicit sync()/push()/pull().
+   */
+  deferredTables?: string[]
+  /**
+   * Ids the transport named as refused, when it did ('mutation-dead'). Absent
+   * means the server rejected the batch without saying which rows are at fault.
+   */
+  rejectedIds?: readonly (string | number)[]
 }
 
 export type SyncEventListener = (event: SyncEvent) => void
 
 /** Describes a batch the server has rejected `maxRetries` times in a row. */
-export interface PoisonedMutationInfo<T extends RowWithId = RowWithId> {
+export interface PoisonedMutationInfo<T extends RowWithId = RowWithId>
+  extends RejectedMutationIds {
   table: string
-  /** The merged batch that keeps failing */
+  /**
+   * The mutations that are still unapplied after the failing attempt.
+   *
+   * Rows the server confirmed via `appliedIds` are excluded: reporting them
+   * would invite an app to re-queue or alert on writes that already landed
+   * (#176).
+   */
   mutations: MergedMutation<T>[]
   /** The last error the transport reported */
   error: Error
   /** Number of consecutive failed push attempts */
   attempts: number
+  /**
+   * The subset of `mutations` the transport named as refused, if it named any
+   * (via `SyncPushResult.rejectedIds` or a `rejectedIds` property on the thrown
+   * error). When present, a plain `'discard'` drops exactly these and leaves
+   * the rest of the batch queued.
+   */
+  rejectedIds?: readonly (string | number)[]
 }
 
 /**
  * What the engine should do with a poisoned batch.
- * - `'discard'`: drop those mutations from the queue so the table can sync again
- *   (the local rows are left untouched — a later pull reconciles them).
- * - `'retain'` (also the default when the handler returns nothing): keep them and
- *   keep retrying.
+ *
+ * - `'discard'`: drop the poisoned work so the table can sync again. When the
+ *   transport named the offenders (`rejectedIds`), only those are dropped and
+ *   the rest of the batch stays queued; when it named none, the engine cannot
+ *   tell innocent from poisoned and drops the whole reported batch — so against
+ *   an all-or-nothing backend that stays silent, prefer returning an explicit
+ *   id list (#174).
+ * - `'retain'` (also the default when the handler returns nothing): keep
+ *   everything and keep retrying.
+ * - An array of ids: drop exactly those mutations and keep the rest. Ids
+ *   outside the reported batch are ignored, and an empty array means `'retain'`.
+ *
+ * Discarding never touches local rows — a later pull reconciles them — and
+ * always respects the push boundary, so writes made after the failed batch was
+ * snapshotted survive (#109).
  */
-export type PoisonedMutationAction = 'discard' | 'retain'
+export type PoisonedMutationAction =
+  | 'discard'
+  | 'retain'
+  | readonly (string | number)[]
 
 export type PoisonedMutationHandler = (
   info: PoisonedMutationInfo

--- a/packages/client/src/transports/mock-transport.ts
+++ b/packages/client/src/transports/mock-transport.ts
@@ -30,6 +30,16 @@ export class MockTransport implements SyncTransport {
   pullShouldFail = false
 
   /**
+   * Rows this "server" permanently refuses (a validation rule, say).
+   *
+   * A push containing one commits the rest and comes back with
+   * `success: false`, `appliedIds` for what landed and `rejectedIds` naming the
+   * offenders — the contract that lets a dead-lettered batch drop only the
+   * poisoned rows instead of every mutation beside them (#174).
+   */
+  readonly rejectedIds = new Set<string | number>()
+
+  /**
    * Whether a conflicting push still commits the mutations that did *not*
    * conflict. Off by default: the whole batch is rejected, which is the
    * conservative reading of the transport contract. When on, the applied rows
@@ -73,6 +83,17 @@ export class MockTransport implements SyncTransport {
         const applied = mutations.filter(m => !conflictIds.has(m.id))
         this.applyMutations(tableName, applied)
         return { success: false, conflicts, appliedIds: applied.map(m => m.id) }
+      }
+    }
+
+    const refused = mutations.filter(m => this.rejectedIds.has(m.id))
+    if (refused.length > 0) {
+      const accepted = mutations.filter(m => !this.rejectedIds.has(m.id))
+      this.applyMutations(tableName, accepted)
+      return {
+        success: false,
+        appliedIds: accepted.map(m => m.id),
+        rejectedIds: refused.map(m => m.id),
       }
     }
 

--- a/packages/client/tests/scenario/offline-session-lifecycle.scenario.test.ts
+++ b/packages/client/tests/scenario/offline-session-lifecycle.scenario.test.ts
@@ -23,7 +23,9 @@ import { MockTransport } from '../../src/transports/mock-transport.js'
 import type { MutationStorage } from '../../src/local/mutation-queue.js'
 import type {
   MergedMutation,
+  PoisonedMutationAction,
   PoisonedMutationInfo,
+  RejectedMutationIds,
   SyncEvent,
   SyncPushResult,
   SyncTransport,
@@ -102,10 +104,14 @@ function createPersistentStorage(): MutationStorage {
  * - `partial-commit` — commit what is valid, report the rest via the
  *   documented `appliedIds` contract with `success: false`.
  * - `all-or-nothing` — reject the whole batch (the naive implementation).
+ *
+ * `namesOffenders` upgrades either style to the `rejectedIds` contract, i.e. a
+ * handler that says *which* rows it refused rather than only that it refused.
  */
 class GasBackendLink implements SyncTransport {
   online = true
   rejectionMode: 'partial-commit' | 'all-or-nothing' = 'partial-commit'
+  namesOffenders = false
   readonly rejectedIds = new Set<string>()
   readonly pushAttempts: Array<{ table: string; ids: (string | number)[] }> = []
   readonly pullAttempts: string[] = []
@@ -131,16 +137,22 @@ class GasBackendLink implements SyncTransport {
     }
 
     if (this.rejectionMode === 'all-or-nothing') {
-      throw new Error(
+      const error: Error & RejectedMutationIds = new Error(
         `syncPush: validation failed for ${refused.map(m => m.id).join(', ')} — batch rejected`
       )
+      if (this.namesOffenders) error.rejectedIds = refused.map(m => m.id)
+      throw error
     }
 
     const accepted = mutations.filter(m => !this.rejectedIds.has(String(m.id)))
     if (accepted.length > 0) {
       await this.server.push(tableName, accepted)
     }
-    return { success: false, appliedIds: accepted.map(m => m.id) }
+    return {
+      success: false,
+      appliedIds: accepted.map(m => m.id),
+      rejectedIds: this.namesOffenders ? refused.map(m => m.id) : undefined,
+    }
   }
 
   pushAttemptCount(): number {
@@ -201,7 +213,7 @@ describe('S5 offline session lifecycle', () => {
     options: {
       maxRetries?: number
       retryBaseDelayMs?: number
-      onPoisonedMutation?: (info: PoisonedMutationInfo) => 'discard' | 'retain' | void
+      onPoisonedMutation?: (info: PoisonedMutationInfo) => PoisonedMutationAction | void
     } = {}
   ): Promise<ClientDBResult<Tables>> {
     return createClientDB<Tables>({
@@ -301,8 +313,8 @@ describe('S5 offline session lifecycle', () => {
   })
 
   it(
-    'reports a completed sync for a pass whose only table was skipped by backoff ' +
-      '[documents: backoff-emits-false-sync-complete]',
+    'defers, and never completes, a pass whose only table was skipped by backoff ' +
+      '[regression: #173 backoff-emits-false-sync-complete]',
     async () => {
       const link = new GasBackendLink(server)
       const session = await openSession(link, { maxRetries: 0, retryBaseDelayMs: 1000 })
@@ -326,12 +338,17 @@ describe('S5 offline session lifecycle', () => {
         expect(link.pushAttemptCount()).toBe(1)
         expect(events.filter(e => e.type === 'error' && e.table === 'Task')).toHaveLength(1)
 
-        // THE DEFECT: a pass in which every table was skipped has no recorded
-        // failures, so it is reported as a completed sync. Four of the five
-        // offline ticks announce success while 15 mutations sit unsent and the
-        // network is down — an "all changes saved" indicator wired to
-        // `sync-complete` turns green mid-outage.
-        expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(4)
+        // A pass in which every table was skipped has no recorded failures,
+        // but it is not a completed sync either: an "all changes saved"
+        // indicator wired to `sync-complete` must stay grey for the whole
+        // outage, with 15 mutations still unsent.
+        expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(0)
+
+        // The four skipped passes announce themselves as deferred instead, so a
+        // UI can show "retrying..." and name the tables still waiting.
+        const deferred = events.filter(e => e.type === 'sync-deferred')
+        expect(deferred).toHaveLength(4)
+        expect(deferred.every(e => e.deferredTables?.includes('Task'))).toBe(true)
 
         // Those passes moved nothing in either direction.
         expect(events.filter(e => e.type === 'push-complete')).toHaveLength(0)
@@ -346,8 +363,8 @@ describe('S5 offline session lifecycle', () => {
   )
 
   it(
-    'never purges mutations that cancelled each other out ' +
-      '[documents: cancelled-mutations-never-purged]',
+    'purges mutations that cancelled each other out ' +
+      '[regression: #175 cancelled-mutations-never-purged]',
     async () => {
       const link = new GasBackendLink(server)
       const session = await openSession(link)
@@ -361,32 +378,31 @@ describe('S5 offline session lifecycle', () => {
       expect(queue.getMerged()).toEqual([])
       expect(serverRows(server)).toEqual(CONVERGED)
 
-      // ...but the two raw mutations for t7 (insert then delete, which merge to
-      // a no-op) are still in the queue, and in localStorage behind it. A push
-      // only clears the ids present in the *merged* batch, and t7 is not one of
-      // them, so this pair is never collected.
+      // ...and nothing left in the queue either. The two raw mutations for t7
+      // (insert then delete, which merge to a no-op) have no id in the merged
+      // batch, so the push-driven clear cannot see them — they are collected
+      // separately, once the push boundary proves them dead.
+      expect(queue.length).toBe(0)
+
+      // So `hasPending` answers the question an app actually asks it: is there
+      // work that still has to reach the server? Safe to close this tab.
+      expect(queue.hasPending).toBe(false)
+
+      // Nothing is left behind in localStorage either — create-then-delete
+      // churn no longer grows the key without bound.
+      expect(storage.getItem('gsquery:Task:mutations')).toBeNull()
+
+      // A cancelled pair enqueued *after* the sync is still pending work as far
+      // as durability goes, and is collected by the next push boundary.
+      const tasks = session.db.from('Task')
+      tasks.create({ id: 't10', title: 'Task 10', status: 'todo', priority: 10 })
+      tasks.delete('t10')
       expect(queue.length).toBe(2)
+      expect(queue.hasPending).toBe(false) // ...but it is not work to send
 
-      // Therefore `hasPending` reports work that does not exist. An app that
-      // gates "safe to close this tab?" on it can never let the user leave.
-      expect(queue.hasPending).toBe(true)
-
-      const persisted = storage.getItem('gsquery:Task:mutations')
-      expect(persisted).not.toBeNull()
-      const parsed = JSON.parse(persisted as string) as Array<{
-        id: string
-        type: string
-      }>
-      expect(parsed.map(m => [m.id, m.type])).toEqual([
-        ['t7', 'insert'],
-        ['t7', 'delete'],
-      ])
-
-      // It is a permanent leak, not a timing artifact: further clean syncs
-      // never remove it.
       await session.sync.sync()
-      await session.sync.sync()
-      expect(queue.length).toBe(2)
+      expect(queue.length).toBe(0)
+      expect(serverRows(server)).toEqual(CONVERGED)
 
       await session.close()
     }
@@ -450,12 +466,82 @@ describe('S5 offline session lifecycle', () => {
   })
 
   it(
-    "discarding a poisoned batch destroys every innocent write in it " +
-      '[documents: poison-discard-drops-whole-batch]',
+    'discards only the poisoned mutation the handler names, keeping the innocent ones ' +
+      '[regression: #174 poison-discard-drops-whole-batch]',
     async () => {
       const link = new GasBackendLink(server)
-      // The naive Apps Script handler: one invalid row rejects the whole batch.
+      // The naive Apps Script handler: one invalid row rejects the whole batch,
+      // and it does not say which row that was.
       link.rejectionMode = 'all-or-nothing'
+      link.rejectedIds.add('t8')
+
+      const poisoned: PoisonedMutationInfo[] = []
+      const session = await openSession(link, {
+        maxRetries: 1,
+        retryBaseDelayMs: 0,
+        onPoisonedMutation: info => {
+          poisoned.push(info)
+          // The app knows the sheet's validation rule (or parses the error) and
+          // names the single offender instead of sacrificing the batch.
+          return [/t8/.test(info.error.message) ? 't8' : '']
+        },
+      })
+
+      await session.sync.pull()
+      link.online = false
+      applyOfflineEdits(session)
+      link.online = true
+
+      await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
+
+      // The report still shows the whole unapplied batch — with an
+      // all-or-nothing backend nothing was committed, so all 8 are genuinely
+      // still pending — and the backend named no offender.
+      expect(poisoned).toHaveLength(1)
+      expect(poisoned[0].mutations.map(m => m.id)).toEqual([
+        't1',
+        't2',
+        't6',
+        't3',
+        't8',
+        't4',
+        't5',
+        't9',
+      ])
+      expect(poisoned[0].rejectedIds).toBeUndefined()
+
+      // Returning a list drops exactly those ids. The 7 innocent merged
+      // mutations — 12 of the user's 15 raw offline actions — stay queued.
+      expect(session.adapters.Task.queue.getMerged().map(m => m.id)).toEqual([
+        't1',
+        't2',
+        't6',
+        't3',
+        't4',
+        't5',
+        't9',
+      ])
+
+      // Nothing reached the server yet, but the table is unblocked, so the very
+      // next sync lands the whole offline session except the refused row.
+      expect(serverRows(server)).toEqual(SEED)
+      await expect(session.sync.sync()).resolves.toBeUndefined()
+      expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
+      expect(sortById(session.db.from('Task').findAll())).toEqual(CONVERGED_WITHOUT_T8)
+
+      await session.close()
+    }
+  )
+
+  it(
+    "discards only the ids an all-or-nothing backend names in its error " +
+      '[regression: #174]',
+    async () => {
+      const link = new GasBackendLink(server)
+      link.rejectionMode = 'all-or-nothing'
+      // The upgraded Apps Script handler: still all-or-nothing, but it reports
+      // which rows its validation refused, per the `rejectedIds` contract.
+      link.namesOffenders = true
       link.rejectedIds.add('t8')
 
       const poisoned: PoisonedMutationInfo[] = []
@@ -475,46 +561,28 @@ describe('S5 offline session lifecycle', () => {
 
       await expect(session.sync.sync()).rejects.toThrow(/Sync failed for 1 table/)
 
-      // `onPoisonedMutation` is called at BATCH granularity: the app is handed
-      // all 8 merged mutations and its only choices are keep-all or drop-all.
-      expect(poisoned).toHaveLength(1)
-      expect(poisoned[0].mutations.map(m => m.id)).toEqual([
-        't1',
-        't2',
-        't6',
-        't3',
-        't8',
-        't4',
-        't5',
-        't9',
-      ])
-      expect(poisoned[0].mutations).toHaveLength(8)
+      // The engine surfaces the named offenders, so a plain 'discard' is now
+      // precise: it drops t8 and nothing else.
+      expect(poisoned[0].rejectedIds).toEqual(['t8'])
+      expect(session.adapters.Task.queue.getMerged().map(m => m.id)).not.toContain('t8')
+      expect(session.adapters.Task.queue.getMerged()).toHaveLength(7)
 
-      // Choosing 'discard' to unblock the table drops all 8 — the 7 innocent
-      // merged mutations (12 of the user's 15 raw offline actions) included.
-      expect(session.adapters.Task.queue.getMerged()).toEqual([])
-
-      // Nothing ever reached the server: it is still exactly as it was seeded.
-      expect(serverRows(server)).toEqual(SEED)
-
-      // And the next sync overwrites the local view with that untouched server
-      // state, so the user's whole offline session disappears with no further
-      // signal.
       await expect(session.sync.sync()).resolves.toBeUndefined()
-      expect(sortById(session.db.from('Task').findAll())).toEqual(SEED)
+      expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
 
       await session.close()
     }
   )
 
   it(
-    'reports already-committed rows as part of the poisoned batch ' +
-      '[documents: dead-letter-reports-applied-mutations]',
+    'reports only the still-unapplied rows in the poisoned batch ' +
+      '[regression: #176 dead-letter-reports-applied-mutations]',
     async () => {
       const link = new GasBackendLink(server)
       link.rejectedIds.add('t8')
 
       const poisoned: PoisonedMutationInfo[] = []
+      const events: SyncEvent[] = []
       const session = await openSession(link, {
         maxRetries: 1, // dead-letter on the very first refusal
         retryBaseDelayMs: 0,
@@ -523,6 +591,7 @@ describe('S5 offline session lifecycle', () => {
           return 'retain'
         },
       })
+      session.sync.on(e => events.push(e))
 
       await session.sync.pull()
       link.online = false
@@ -536,21 +605,17 @@ describe('S5 offline session lifecycle', () => {
       expect(serverRows(server)).toEqual(CONVERGED_WITHOUT_T8)
       expect(session.adapters.Task.queue.getMerged().map(m => m.id)).toEqual(['t8'])
 
-      // ...yet the dead-letter report names all 8, including the 7 the server
-      // accepted. An app that logs or re-queues `info.mutations` for manual
-      // repair would act on 7 writes that already landed.
+      // ...and the dead-letter report agrees with the queue: it names only the
+      // row that is still unapplied. An app that logs or re-queues
+      // `info.mutations` for manual repair acts on exactly the failed write.
       expect(poisoned).toHaveLength(1)
-      expect(poisoned[0].mutations.map(m => m.id)).toEqual([
-        't1',
-        't2',
-        't6',
-        't3',
-        't8',
-        't4',
-        't5',
-        't9',
-      ])
-      expect(poisoned[0].mutations.filter(m => m.id !== 't8')).toHaveLength(7)
+      expect(poisoned[0].mutations.map(m => m.id)).toEqual(['t8'])
+      expect(poisoned[0].mutations[0].data).toMatchObject({ title: 'Task 8' })
+
+      // The same payload reaches the event listener.
+      const dead = events.filter(e => e.type === 'mutation-dead')
+      expect(dead).toHaveLength(1)
+      expect(dead[0].mutations?.map(m => m.id)).toEqual(['t8'])
 
       await session.close()
     }

--- a/packages/client/tests/unit/local/mutation-queue.test.ts
+++ b/packages/client/tests/unit/local/mutation-queue.test.ts
@@ -194,6 +194,85 @@ describe('MutationQueue', () => {
     })
   })
 
+  // ── Cancelled pairs ────────────────────────────────────────────────
+
+  describe('purgeCancelled [#175]', () => {
+    it('drops the raw mutations of a row that cancelled itself out', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      queue.push('delete', 'a')
+      expect(queue.length).toBe(2)
+
+      queue.purgeCancelled()
+
+      expect(queue.length).toBe(0)
+      expect(queue.getMerged()).toEqual([])
+      expect(storage.store.has('gsquery:test:mutations')).toBe(false)
+    })
+
+    it('leaves rows that still have a net effect alone', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      queue.push('delete', 'a')
+      queue.push('update', 'b', { value: 2 })
+      queue.push('delete', 'c')
+
+      queue.purgeCancelled()
+
+      expect(queue.getMerged().map(m => m.id)).toEqual(['b', 'c'])
+      expect(queue.length).toBe(2)
+    })
+
+    it('keeps a pair that is not fully below the boundary', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      const boundary = queue.currentSeq()
+      queue.push('delete', 'a')
+
+      // The delete arrived after the boundary, so the pair is not settled by
+      // the push that boundary belongs to.
+      queue.purgeCancelled(boundary)
+      expect(queue.length).toBe(2)
+
+      queue.purgeCancelled(queue.currentSeq())
+      expect(queue.length).toBe(0)
+    })
+
+    it('re-creation after a cancelling pair is not collected', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      queue.push('delete', 'a')
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A again', value: 2 })
+
+      queue.purgeCancelled(queue.currentSeq())
+
+      // The net effect is an insert, so every raw mutation behind it stays.
+      expect(queue.getMerged()).toHaveLength(1)
+      expect(queue.length).toBe(3)
+    })
+
+    it('is a no-op on an empty queue', () => {
+      queue.purgeCancelled(queue.currentSeq())
+      expect(queue.length).toBe(0)
+    })
+  })
+
+  describe('hasPending reflects the merged view [#175]', () => {
+    it('is false when every mutation cancels out', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      queue.push('delete', 'a')
+
+      // Raw mutations are still there (they are only collected at a push
+      // boundary), but there is no work left to send.
+      expect(queue.length).toBe(2)
+      expect(queue.hasPending).toBe(false)
+    })
+
+    it('is true again as soon as real work is queued', () => {
+      queue.push('insert', 'a', undefined, { id: 'a', name: 'A', value: 1 })
+      queue.push('delete', 'a')
+      queue.push('update', 'b', { value: 2 })
+
+      expect(queue.hasPending).toBe(true)
+    })
+  })
+
   // ── Persistence ────────────────────────────────────────────────────
 
   describe('localStorage persistence', () => {

--- a/packages/client/tests/unit/local/sync-hardening.test.ts
+++ b/packages/client/tests/unit/local/sync-hardening.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Sync hardening tests — the four offline-lifecycle defects found by scenario
+ * S5: false sync-complete while offline (#173), batch-wide dead-letter discard
+ * (#174), cancelled mutation pairs leaking (#175), and dead-letter payloads
+ * naming already-applied rows (#176).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { RowWithId } from '@gsquery/core'
+import { LocalAdapter } from '../../../src/local/local-adapter.js'
+import { SyncEngine } from '../../../src/local/sync-engine.js'
+import type { MutationStorage } from '../../../src/local/mutation-queue.js'
+import type {
+  MergedMutation,
+  PoisonedMutationAction,
+  PoisonedMutationInfo,
+  RejectedMutationIds,
+  SyncEvent,
+  SyncPushResult,
+  SyncTransport,
+} from '../../../src/local/sync-transport.js'
+
+interface Todo extends RowWithId {
+  id: string
+  title: string
+}
+
+function createMemoryStorage(): MutationStorage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+  }
+}
+
+function createAdapter(tableName: string): LocalAdapter<Todo> {
+  return new LocalAdapter<Todo>({
+    tableName,
+    idMode: 'client',
+    disableIDB: true,
+    mutationStorage: createMemoryStorage(),
+  })
+}
+
+/**
+ * A server whose refusals are configurable in the two dimensions that matter
+ * here: whether it commits the rest of the batch, and whether it says which
+ * rows it refused.
+ */
+class RefusingTransport implements SyncTransport {
+  readonly refused = new Set<string | number>()
+  /** Commit the acceptable rows and report them via appliedIds */
+  partialCommit = true
+  /** Report the refused rows via the `rejectedIds` contract */
+  namesOffenders = false
+  /** Throw instead of returning a result (the all-or-nothing style) */
+  throwOnRefusal = false
+  readonly pushed: MergedMutation[][] = []
+  readonly applied: MergedMutation[] = []
+
+  async pull<T extends RowWithId>(): Promise<{ rows: T[] }> {
+    return { rows: [] }
+  }
+
+  async push<T extends RowWithId>(
+    _tableName: string,
+    mutations: MergedMutation<T>[]
+  ): Promise<SyncPushResult<T>> {
+    this.pushed.push([...mutations])
+    const refused = mutations.filter(m => this.refused.has(m.id))
+    if (refused.length === 0) {
+      this.applied.push(...mutations)
+      return { success: true, appliedIds: mutations.map(m => m.id) }
+    }
+
+    if (this.throwOnRefusal) {
+      const error: Error & RejectedMutationIds = new Error('batch rejected')
+      if (this.namesOffenders) error.rejectedIds = refused.map(m => m.id)
+      throw error
+    }
+
+    const accepted = this.partialCommit
+      ? mutations.filter(m => !this.refused.has(m.id))
+      : []
+    this.applied.push(...accepted)
+    return {
+      success: false,
+      appliedIds: accepted.map(m => m.id),
+      rejectedIds: this.namesOffenders ? refused.map(m => m.id) : undefined,
+    }
+  }
+}
+
+describe('sync-complete only for a pass that actually ran [#173]', () => {
+  let transport: RefusingTransport
+  let tableA: LocalAdapter<Todo>
+  let tableB: LocalAdapter<Todo>
+
+  beforeEach(() => {
+    transport = new RefusingTransport()
+    tableA = createAdapter('A')
+    tableB = createAdapter('B')
+  })
+
+  function createEngine(retryBaseDelayMs: number): SyncEngine {
+    const engine = new SyncEngine({ transport, maxRetries: 0, retryBaseDelayMs })
+    engine.registerTable('A', tableA, tableA.queue)
+    engine.registerTable('B', tableB, tableB.queue)
+    return engine
+  }
+
+  it('emits sync-deferred, not sync-complete, when every table is backed off', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine(1000)
+      const events: SyncEvent[] = []
+      engine.on(e => events.push(e))
+
+      transport.refused.add('a1')
+      transport.refused.add('b1')
+      tableA.insert({ id: 'a1', title: 'A1' })
+      tableB.insert({ id: 'b1', title: 'B1' })
+
+      engine.startAutoSync(200)
+      // Ticks at 200/400/600/800/1000: the first attempts both tables and
+      // fails, the other four find both windows still open.
+      await vi.advanceTimersByTimeAsync(1000)
+      engine.stopAutoSync()
+
+      expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(0)
+      const deferred = events.filter(e => e.type === 'sync-deferred')
+      expect(deferred).toHaveLength(4)
+      expect(deferred[0].deferredTables).toEqual(['A', 'B'])
+
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('defers a pass in which only some tables were skipped', async () => {
+    vi.useFakeTimers()
+    try {
+      const engine = createEngine(1000)
+      const events: SyncEvent[] = []
+      engine.on(e => events.push(e))
+
+      // Only A is poisoned, so only A backs off; B keeps syncing cleanly.
+      transport.refused.add('a1')
+      tableA.insert({ id: 'a1', title: 'A1' })
+
+      engine.startAutoSync(200)
+      await vi.advanceTimersByTimeAsync(1000)
+      engine.stopAutoSync()
+
+      // B synced on every tick, but A's work is still outstanding — that is not
+      // "all changes saved", so the pass reports itself as deferred.
+      expect(events.filter(e => e.type === 'pull-complete').length).toBeGreaterThan(0)
+      expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(0)
+      const deferred = events.filter(e => e.type === 'sync-deferred')
+      expect(deferred).toHaveLength(4)
+      expect(deferred[0].deferredTables).toEqual(['A'])
+
+      engine.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still completes a pass in which every table was attempted', async () => {
+    const engine = createEngine(1000)
+    const events: SyncEvent[] = []
+    engine.on(e => events.push(e))
+
+    tableA.insert({ id: 'a1', title: 'A1' })
+    await engine.sync()
+
+    expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(1)
+    expect(events.some(e => e.type === 'sync-deferred')).toBe(false)
+    engine.dispose()
+  })
+
+  it('completes an explicit sync() even while a backoff window is open', async () => {
+    const engine = createEngine(60_000)
+    const events: SyncEvent[] = []
+    engine.on(e => events.push(e))
+
+    transport.refused.add('a1')
+    tableA.insert({ id: 'a1', title: 'A1' })
+
+    // Open the window with a failing pass...
+    await expect(engine.sync()).rejects.toThrow()
+    // ...then unblock the row: an explicit sync ignores backoff, so nothing is
+    // deferred and the pass genuinely completes.
+    transport.refused.clear()
+    await expect(engine.sync()).resolves.toBeUndefined()
+
+    expect(events.some(e => e.type === 'sync-deferred')).toBe(false)
+    expect(events.filter(e => e.type === 'sync-complete')).toHaveLength(1)
+    engine.dispose()
+  })
+})
+
+describe('per-mutation dead-letter discard [#174]', () => {
+  let transport: RefusingTransport
+  let table: LocalAdapter<Todo>
+
+  beforeEach(() => {
+    transport = new RefusingTransport()
+    table = createAdapter('A')
+  })
+
+  function createEngine(
+    onPoisonedMutation: (info: PoisonedMutationInfo) => PoisonedMutationAction | void
+  ): SyncEngine {
+    const engine = new SyncEngine({
+      transport,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation,
+    })
+    engine.registerTable('A', table, table.queue)
+    return engine
+  }
+
+  function seedThreeRows(): void {
+    table.insert({ id: 'a1', title: 'A1' })
+    table.insert({ id: 'bad', title: 'Bad' })
+    table.insert({ id: 'a2', title: 'A2' })
+    transport.refused.add('bad')
+    transport.partialCommit = false
+    transport.throwOnRefusal = true
+  }
+
+  it('drops exactly the ids the handler returns', async () => {
+    const engine = createEngine(() => ['bad'])
+    seedThreeRows()
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['a1', 'a2'])
+    engine.dispose()
+  })
+
+  it('treats an empty id list as retain', async () => {
+    const engine = createEngine(() => [])
+    seedThreeRows()
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(table.queue.getMerged()).toHaveLength(3)
+    engine.dispose()
+  })
+
+  it('ignores ids the handler names outside the reported batch', async () => {
+    // 'later' is enqueued while the push is in flight, so it was never part of
+    // the rejected batch — naming it must not cost the app that write (#109).
+    const gated: SyncTransport = {
+      async pull<T extends RowWithId>(): Promise<{ rows: T[] }> {
+        return { rows: [] }
+      },
+      async push<T extends RowWithId>(): Promise<SyncPushResult<T>> {
+        table.insert({ id: 'later', title: 'Later' })
+        throw new Error('batch rejected')
+      },
+    }
+    const engine = new SyncEngine({
+      transport: gated,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: () => ['bad', 'later', 'never-existed'],
+    })
+    engine.registerTable('A', table, table.queue)
+    seedThreeRows()
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['a1', 'a2', 'later'])
+    engine.dispose()
+  })
+
+  it("drops the whole batch on 'discard' when nobody names the offender", async () => {
+    const engine = createEngine(() => 'discard')
+    seedThreeRows()
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    // Unchanged, documented fallback: with an all-or-nothing backend that says
+    // nothing, the engine cannot tell innocent from poisoned.
+    expect(table.queue.getMerged()).toHaveLength(0)
+    engine.dispose()
+  })
+
+  it("drops only the ids a thrown error names on 'discard'", async () => {
+    const seen: PoisonedMutationInfo[] = []
+    const engine = createEngine(info => {
+      seen.push(info)
+      return 'discard'
+    })
+    seedThreeRows()
+    transport.namesOffenders = true
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(seen[0].rejectedIds).toEqual(['bad'])
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['a1', 'a2'])
+    engine.dispose()
+  })
+
+  it("drops only the ids a push result names on 'discard'", async () => {
+    const events: SyncEvent[] = []
+    const engine = createEngine(() => 'discard')
+    engine.on(e => events.push(e))
+    seedThreeRows()
+    transport.throwOnRefusal = false
+    transport.namesOffenders = true
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    const dead = events.filter(e => e.type === 'mutation-dead')
+    expect(dead).toHaveLength(1)
+    expect(dead[0].rejectedIds).toEqual(['bad'])
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['a1', 'a2'])
+    engine.dispose()
+  })
+
+  it('unblocks the table after a partial discard, so the innocent rows land', async () => {
+    const engine = createEngine(() => ['bad'])
+    seedThreeRows()
+
+    await expect(engine.sync()).rejects.toThrow()
+    // 'bad' is gone, so the retried batch is acceptable.
+    await expect(engine.sync()).resolves.toBeUndefined()
+
+    expect(transport.applied.map(m => m.id)).toEqual(['a1', 'a2'])
+    expect(table.queue.hasPending).toBe(false)
+    engine.dispose()
+  })
+})
+
+describe('cancelled mutation pairs are collected [#175]', () => {
+  let transport: RefusingTransport
+  let table: LocalAdapter<Todo>
+  let engine: SyncEngine
+
+  beforeEach(() => {
+    transport = new RefusingTransport()
+    table = createAdapter('A')
+    engine = new SyncEngine({ transport })
+    engine.registerTable('A', table, table.queue)
+  })
+
+  it('purges a pair whose merged result is nothing, with no push at all', async () => {
+    table.insert({ id: 'gone', title: 'Gone' })
+    table.delete('gone')
+    expect(table.queue.length).toBe(2)
+
+    await engine.push()
+
+    // Nothing was worth sending, and nothing is left behind.
+    expect(transport.pushed).toHaveLength(0)
+    expect(table.queue.length).toBe(0)
+    engine.dispose()
+  })
+
+  it('purges the pair alongside a real push', async () => {
+    table.insert({ id: 'keep', title: 'Keep' })
+    table.insert({ id: 'gone', title: 'Gone' })
+    table.delete('gone')
+
+    await engine.push()
+
+    expect(transport.pushed[0].map(m => m.id)).toEqual(['keep'])
+    expect(table.queue.length).toBe(0)
+    engine.dispose()
+  })
+
+  it('keeps a pair that is not fully below the push boundary', async () => {
+    let releasePush!: () => void
+    const gate = new Promise<void>(r => {
+      releasePush = r
+    })
+    const gated: SyncTransport = {
+      async pull<T extends RowWithId>(): Promise<{ rows: T[] }> {
+        return { rows: [] }
+      },
+      async push<T extends RowWithId>(
+        _table: string,
+        mutations: MergedMutation<T>[]
+      ): Promise<SyncPushResult<T>> {
+        // Both halves of this pair are enqueued after the snapshot, so the
+        // boundary cannot prove them settled yet.
+        table.insert({ id: 'mid', title: 'Mid' })
+        table.delete('mid')
+        await gate
+        return { success: true, appliedIds: mutations.map(m => m.id) }
+      },
+    }
+    const gatedEngine = new SyncEngine({ transport: gated })
+    gatedEngine.registerTable('A', table, table.queue)
+
+    table.insert({ id: 'keep', title: 'Keep' })
+    const p = gatedEngine.push()
+    releasePush()
+    await p
+
+    expect(table.queue.length).toBe(2)
+
+    // The next boundary covers them, so they are collected then.
+    await gatedEngine.push()
+    expect(table.queue.length).toBe(0)
+    gatedEngine.dispose()
+  })
+
+  it('a failed push does not resurrect a cancelled pair', async () => {
+    transport.refused.add('bad')
+    transport.partialCommit = false
+    table.insert({ id: 'bad', title: 'Bad' })
+    table.insert({ id: 'gone', title: 'Gone' })
+    table.delete('gone')
+
+    await expect(engine.push()).rejects.toThrow()
+
+    // The failing row is preserved for a retry; the pair that means nothing is
+    // not (it was never part of any batch and never will be).
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['bad'])
+    expect(table.queue.length).toBe(1)
+    engine.dispose()
+  })
+})
+
+describe('dead-letter reports only unapplied mutations [#176]', () => {
+  it('subtracts the ids the server confirmed via appliedIds', async () => {
+    const transport = new RefusingTransport()
+    transport.refused.add('bad')
+    transport.partialCommit = true
+
+    const table = createAdapter('A')
+    const seen: PoisonedMutationInfo[] = []
+    const events: SyncEvent[] = []
+    const engine = new SyncEngine({
+      transport,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: info => {
+        seen.push(info)
+        return 'retain'
+      },
+    })
+    engine.on(e => events.push(e))
+    engine.registerTable('A', table, table.queue)
+
+    table.insert({ id: 'a1', title: 'A1' })
+    table.insert({ id: 'bad', title: 'Bad' })
+    table.insert({ id: 'a2', title: 'A2' })
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    // a1/a2 landed and left the queue; the report must agree with the queue.
+    expect(transport.applied.map(m => m.id)).toEqual(['a1', 'a2'])
+    expect(table.queue.getMerged().map(m => m.id)).toEqual(['bad'])
+    expect(seen[0].mutations.map(m => m.id)).toEqual(['bad'])
+    expect(events.find(e => e.type === 'mutation-dead')?.mutations?.map(m => m.id)).toEqual([
+      'bad',
+    ])
+    engine.dispose()
+  })
+
+  it('reports the whole batch when the transport applied nothing', async () => {
+    const transport = new RefusingTransport()
+    transport.refused.add('bad')
+    transport.partialCommit = false
+    transport.throwOnRefusal = true
+
+    const table = createAdapter('A')
+    const seen: PoisonedMutationInfo[] = []
+    const engine = new SyncEngine({
+      transport,
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+      onPoisonedMutation: info => {
+        seen.push(info)
+        return 'retain'
+      },
+    })
+    engine.registerTable('A', table, table.queue)
+
+    table.insert({ id: 'a1', title: 'A1' })
+    table.insert({ id: 'bad', title: 'Bad' })
+
+    await expect(engine.sync()).rejects.toThrow()
+
+    expect(seen[0].mutations.map(m => m.id)).toEqual(['a1', 'bad'])
+    engine.dispose()
+  })
+})

--- a/website/docs/local-first-client.md
+++ b/website/docs/local-first-client.md
@@ -44,7 +44,7 @@ Passing a generated schema carries its `columnTypes` (so `datetime` columns hydr
 | `pushDebounceMs` | off | Auto-push this long after the last local mutation |
 | `maxRetries` | `5` | Consecutive push failures per table before dead-lettering (`0` = never) |
 | `retryBaseDelayMs` / `maxRetryDelayMs` | `1000` / `60000` | Exponential backoff window for background retries |
-| `onPoisonedMutation` | — | Called after `maxRetries` failures; return `'discard'` or `'retain'` |
+| `onPoisonedMutation` | — | Called after `maxRetries` failures; return `'discard'`, `'retain'`, or an array of ids to drop |
 | `namespace` | — | Partition key isolating IndexedDB + queue storage per instance (e.g. per team) |
 | `mutationStorage` | localStorage | Custom queue persistence |
 | `disableIDB` / `initialData` | — | Testing helpers: skip IndexedDB, pre-seed rows |
@@ -54,21 +54,49 @@ The result is `{ db, sync, adapters, close }`. Call `close()` on teardown — it
 ## Sync behavior
 
 - **Push before pull.** `sync.sync()` pushes each table's queued mutations, then pulls server rows. Pull rebases still-pending local mutations on top of server data, so unsynced edits are never clobbered.
-- **Durable queue.** Mutations persist to localStorage at enqueue time, before any network attempt. Mutations per row are merged (insert+update → insert, insert+delete → nothing) and carry a sequence number, so edits made *while* a push is in flight are never lost.
+- **Durable queue.** Mutations persist to localStorage at enqueue time, before any network attempt. Mutations per row are merged (insert+update → insert, insert+delete → nothing) and carry a sequence number, so edits made *while* a push is in flight are never lost. Rows that cancel out are collected once a successful push proves them settled, so `queue.hasPending` means "work still has to reach the server" and create-then-delete churn doesn't grow storage.
 - **Conflicts.** When the server rejects rows, the strategy decides: `server-wins` overwrites local, `client-wins` keeps the local edit queued for re-push, and a custom resolver's merged row is re-enqueued so it reaches the server and survives the next pull.
 - **Partial failures.** A transport may return `appliedIds` to state exactly which mutations it committed; without it, a failed batch clears nothing. One table's failure doesn't block other tables — `sync()` isolates per table, emits per-table `error` events, and rethrows an aggregate `SyncError`.
-- **Retries and dead-lettering.** Background attempts (auto-sync, debounced pushes) back off exponentially per failing table. Explicit `sync()`/`push()`/`pull()` always run (`resetRetryState()` clears the backoff window). After `maxRetries` consecutive failures a `mutation-dead` event fires and `onPoisonedMutation` decides the batch's fate.
+- **Retries and dead-lettering.** Background attempts (auto-sync, debounced pushes) back off exponentially per failing table. Explicit `sync()`/`push()`/`pull()` always run (`resetRetryState()` clears the backoff window). After `maxRetries` consecutive failures a `mutation-dead` event fires and `onPoisonedMutation` decides the fate of what is still unapplied.
+
+### Naming the rows a push refused
+
+A push result carries two independent lists, both optional:
+
+```typescript
+async push(tableName, mutations) {
+  return {
+    success: false,
+    appliedIds: ['t1', 't2'],   // committed → cleared from the queue
+    rejectedIds: ['t8'],        // refused   → the only rows 'discard' drops
+  }
+}
+```
+
+An all-or-nothing backend that throws can name them the same way, by putting a `rejectedIds` array on the thrown `Error`.
+
+This matters when a batch is dead-lettered. `onPoisonedMutation` receives only the mutations that are **still unapplied** (rows confirmed via `appliedIds` are never reported, so you cannot re-queue a write that already landed) plus `rejectedIds` when the server named them, and may return:
+
+| Return | Effect |
+|---|---|
+| `'retain'` (or nothing) | Keep everything queued and keep retrying |
+| `'discard'` | Drop the named `rejectedIds` — or, if the server named none, the whole reported batch |
+| `['t8', …]` | Drop exactly these ids and keep the rest queued |
+
+Against an all-or-nothing backend that doesn't report `rejectedIds`, a bare `'discard'` therefore throws away every innocent mutation that shared the batch. Return an explicit id list (or teach the backend `rejectedIds`) to lose only the poisoned row. Discarding never touches local rows — a later pull reconciles them — and never drops writes made after the failed batch was snapshotted.
 
 ### Events
 
 ```typescript
 const off = sync.on((event) => {
-  // 'sync-start' | 'sync-complete' | 'push-complete' | 'pull-complete'
-  // | 'error' (per-table or run-level) | 'mutation-dead'
+  // 'sync-start' | 'sync-complete' | 'sync-deferred' | 'push-complete'
+  // | 'pull-complete' | 'error' (per-table or run-level) | 'mutation-dead'
 })
 sync.startAutoSync(30_000)  // periodic background sync
 sync.stopAutoSync()
 ```
+
+`sync-complete` is the "everything requested is now in sync" signal — safe to wire an *all changes saved* indicator to. It fires only when every table in the pass was actually attempted and none failed. When a background pass skips tables whose backoff window is still open, it ends in `sync-deferred` (with `deferredTables`) instead: nothing moved for those tables, so the indicator should read *retrying…* rather than turning green mid-outage. A pass with failures emits per-table `error` events and rejects with a `SyncError`, and emits neither.
 
 ## `GasApiTransport`
 


### PR DESCRIPTION
## Summary

Fixes the four defects pinned by the S5 offline-lifecycle scenario:

- **#173** — `sync-complete` no longer fires for passes where tables were skipped by backoff. Strict semantics: every requested table attempted AND none failed; any deferral emits the new `sync-deferred` event carrying `deferredTables`. (Pin flip: 4 false completions during an outage → 0 completions + 4 deferrals.)
- **#174** — dead-lettering gains per-mutation granularity, three backward-compatible additions: optional `rejectedIds` on `SyncPushResult` **and** parsed off thrown transport errors; `onPoisonedMutation` may now return an id list; precedence explicit-list → transport-named → whole-batch fallback, always respecting the #109 boundary. (Pin flip: discarding `['t8']` preserves the 7 innocent mutations and the next sync converges.)
- **#175** — new `MutationQueue.purgeCancelled(maxSeq)` reuses the exact merge fold to collect insert+delete pairs fully below the push boundary; `hasPending` now derives from merged reality (all 8 call sites audited). (Pin flip: after a converged sync — length 0, `hasPending` false, storage key removed.)
- **#176** — `PushPhaseError`/`mutation-dead` payloads exclude mutations the server confirmed via `appliedIds`; the thrown-transport path keeps the full batch (nothing applied — correct).

17 new unit tests + 4 scenario pins flipped to `[regression: #NNN]`; #109/#110/#131/#132 regression tests untouched and green. Docs: local-first wiki page gains the rejected-ids contract section and the `sync-deferred` event.

Suite: 1,143 tests green (client 167→192), typecheck clean, coverage exit 0.

## Related Issues

Closes #173
Closes #174
Closes #175
Closes #176

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_