### PR TITLE
fix(core): physical renameColumn/removeColumn on SheetsAdapter (completes the #127 pattern)

### DIFF
--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -5,7 +5,7 @@ Runs a golden test suite for `@gsquery/core` **inside a real Apps Script runtime
 - Real `USER_ENTERED` parsing semantics (formula-injection escaping round-trips, the #130 assumption)
 - Real date/timezone cell coercion through `columnTypes`
 - Real `LockService` contention (two parallel web-app calls bursting inserts into one sheet)
-- Physical migration `addColumn` on a live sheet (header insert + single-pass backfill, #127)
+- Physical migration schema ops on a live sheet (`addColumn` header insert + single-pass backfill, #127; `renameColumn` header-cell rewrite and `removeColumn` column delete, #180)
 - `DuplicateIdError`, batch write correctness, stale-index safety — all against the live API
 
 ### Production scenarios
@@ -17,7 +17,7 @@ On top of the golden suite, four scenarios model what a real deployment does to 
 | S1 | **Mixed concurrent workload** | `?action=mixedBurst&tag=&seed=` ×2 in parallel, then `?action=mixedCheck` | Two callers each run 10 inserts + 5 updates + 3 deletes + 1 batchUpdate against one sheet. Each touches only its own rows and its op sets are disjoint, so the per-tag end state is fixed *whatever the interleaving*: 7 survivors, slots 0–1 `u`, slots 2–6 `b`, slots 7–9 gone. The check asserts that, plus no duplicate ids/keys and no **cross-tag contamination** (a row whose `key` no longer reconstructs from its own `tag`+`slot` was partially overwritten). `seed` shuffles op order to explore different interleavings without changing the end state. |
 | S2 | **Human interference** | `?action=run` (3 tests) | People edit production sheets. Sorting the data range by a non-id column and inserting a blank row mid-table are both survivable (the adapter resolves rows by scanning the id column, and all-empty rows are filtered out). Inserting a **foreign column** mid-table is not — it is tagged `[documents #TBD]` and asserts the *current* failure mode rather than fixing it. |
 | S3 | **Volume budget** | `?action=run` (1 test, one shared 2,000-row sheet) | batchInsert / findAll / filtered query / 200-row scattered batchUpdate / single update stay correct at 2k rows, within loose ceilings that only trip on an egregious blowup. Per-operation timings are reported in the result's `info` field. This test dominates the suite's wall clock. |
-| S4 | **Live migration chain** | `?action=run` (1 test) | v1 `addColumn` → v2 `renameColumn` → v3 `removeColumn` driven synchronously in the order a chain would issue them, asserting the physical header and grid alignment after every step. Also `[documents #TBD]`: only `addColumn` is a physical schema op. |
+| S4 | **Live migration chain** | `?action=run` (1 test) | v1 `addColumn` → v2 `renameColumn` → v3 `removeColumn` driven synchronously in the order a chain would issue them, each version's store declaring the schema that version deploys. All three are physical (#127, #180): the header row is extended, then its cell rewritten in place, then the dropped column deleted outright — with the grid alignment, the post-op reads/writes and the byte-identical rerun asserted after every step. |
 
 `Range.sort` and `Sheet.insertRowBefore` are not implemented by the fakes, so S2's first two probes feature-detect them and record a skip note in `info`; every other assertion in those tests still runs locally.
 
@@ -103,5 +103,6 @@ pnpm --filter @gsquery/gas-e2e-harness build       # produces dist/Code.js
 | `mixedCheck` reports `contaminated` rows | A write landed on a row number resolved before a concurrent delete shifted it — the stale-index race of #128/#155 |
 | `mixedCheck` reports `wrongStates`/`missingSlots` | An update, delete or batchUpdate was silently lost under contention |
 | A `[documents #TBD]` test fails | The characterized behavior *changed* — re-read the assertion, then update it (or the issue) rather than "fixing" the test |
+| `migration chain v1→v3` fails a header or alignment assertion | A schema op stopped being physical — regression of #127/#180. `renameColumn` must rewrite the header cell and move no data; `removeColumn` must delete the column so the post-removal schema keeps reading its own values |
 | `volume` trips a time ceiling | A per-row write path crept back into a batch operation — the ceilings are ~10x the expected cost, not tight benchmarks |
 | Suite green locally, HTTP error in CI | Deployment/auth issue (redeploy the web app, check token), not a library bug |

--- a/e2e/gas/src/tests.ts
+++ b/e2e/gas/src/tests.ts
@@ -522,12 +522,14 @@ export function registerTests(ctx: HarnessContext): void {
   // adapter operations a chain would issue, in the same order, asserting the
   // physical layout after every step.
   //
-  // Only `addColumn` reaches the adapter as a schema operation; `renameColumn`
-  // and `removeColumn` are VALUE operations in MigrationRunner (they update
-  // cells and never touch the header). Against a positional adapter that is a
-  // meaningful difference, and the assertions below pin down exactly what it
-  // costs. Characterization, not repair — hence the tag.
-  test('migration chain v1→v3 on live data: addColumn is physical, rename/remove are value-only [documents #TBD]', t => {
+  // All three are PHYSICAL schema operations on the adapter (#127, #180): each
+  // version's store declares the schema that version deploys, `addColumn`
+  // extends the header, `renameColumn` rewrites the header cell, and
+  // `removeColumn` deletes the column outright. Before #180 the last two were
+  // value-only, which left a header reading `name` under a schema declaring
+  // `displayName`, and a ghost `legacy` column that made the next deploy
+  // misread and miswrite every column to its right.
+  test('migration chain v1→v3 on live data: addColumn, renameColumn and removeColumn are all physical (#180)', t => {
     const name = sheetName('chain')
     const makeStore = (columns: string[]): SheetsAdapter<E2ERow> =>
       new SheetsAdapter<E2ERow>({ spreadsheetId: ctx.spreadsheetId, sheetName: name, columns })
@@ -555,75 +557,71 @@ export function registerTests(ctx: HarnessContext): void {
     assertEq(v1.findById(bob.id)?.name, 'bob', 'v1: the write did not disturb the other columns')
 
     // ── v2: renameColumn('name' → 'displayName') ────────────────────────────
-    // MigrationRunner semantics: for each row, when the old field has a value
-    // and the new one is empty, move the value across with update().
+    // The store declares the POST-rename schema, which is what the deploy
+    // carrying this migration ships. The adapter rewrites the one header cell;
+    // no data moves, because the value is already in the right column.
     const v2 = makeStore(['id', 'displayName', 'legacy', 'status'])
-    let renameWrites = 0
-    for (const row of v2.findAll()) {
-      const record = row as Record<string, unknown>
-      if (!isEmptyValue(record['name']) && isEmptyValue(record['displayName'])) {
-        v2.update(row.id, { name: undefined, displayName: record['name'] })
-        renameWrites++
-      }
-    }
+    v2.renameColumn('name', 'displayName')
 
     assertEq(
-      renameWrites,
-      0,
-      'CURRENT: the value-level rename is a no-op here — the adapter already reads column 2 as `displayName`, ' +
-      'so the "old" field is never present and the copy condition is never true'
-    )
-    assertEq(
       rawRow(sheet, 1, 4),
-      ['id', 'name', 'legacy', 'status'],
-      'CURRENT: the physical header still says `name` — renameColumn never touches it, so header and schema now disagree'
+      ['id', 'displayName', 'legacy', 'status'],
+      'v2: the header cell was physically rewritten — header and schema agree again'
     )
-    assertEq(v2.findById(ann.id)?.displayName, 'ann', 'CURRENT: reads work anyway — position, not the header, decides the mapping')
+    assertEq(rawRow(sheet, 2, 4), [cellText(ann.id), 'ann', 'L1', 'active'], 'v2: the rename moved no data')
+    assertEq(rawRow(sheet, 3, 4), [cellText(bob.id), 'bob', 'L2', 'archived'], 'v2: second row untouched too')
+    assertEq(v2.findById(ann.id)?.displayName, 'ann', 'v2: reads resolve under the new name')
     v2.update(ann.id, { displayName: 'ann2' })
     assertEq(
       rawRow(sheet, 2, 4),
       [cellText(ann.id), 'ann2', 'L1', 'active'],
-      'CURRENT: a write under the new name lands in the column still headed `name`'
+      'v2: a write under the new name lands in its own column'
     )
-    t.info('v2 rename: value-op is a no-op; data survives by position; header left stale (`name` vs schema `displayName`)')
+
+    // Convergence: re-running the rename must not touch the grid at all.
+    const wideGrid = (): string => JSON.stringify(sheet.getRange(1, 1, 3, 4).getValues())
+    const beforeRenameRerun = wideGrid()
+    v2.renameColumn('name', 'displayName')
+    assertEq(wideGrid(), beforeRenameRerun, 'v2: rerun leaves the grid byte-identical')
+    t.info('v2 rename: header cell rewritten in place, data untouched, rerun converges')
 
     // ── v3: removeColumn('legacy') ──────────────────────────────────────────
-    const v3 = makeStore(['id', 'displayName', 'legacy', 'status'])
-    let clearedCells = 0
-    for (const row of v3.findAll()) {
-      if (!isEmptyValue((row as Record<string, unknown>)['legacy'])) {
-        v3.update(row.id, { legacy: undefined })
-        clearedCells++
-      }
-    }
-    assertEq(clearedCells, 2, 'v3: the value-level removeColumn cleared both legacy cells')
-    assertEq(
-      rawRow(sheet, 1, 4),
-      ['id', 'name', 'legacy', 'status'],
-      'CURRENT: removeColumn leaves the physical column and its header in place — it only blanks the values'
-    )
-    assertEq(rawRow(sheet, 2, 4), [cellText(ann.id), 'ann2', '', 'active'], 'v3: values cleared, layout unchanged')
-    assertEq(rawRow(sheet, 3, 4), [cellText(bob.id), 'bob', '', 'archived'], 'v3: second row cleared the same way')
+    // Again the store declares the POST-removal schema — the one the next
+    // deploy runs with. Destructive by contract: the legacy values go with the
+    // column and nothing can restore them.
+    const v3 = makeStore(['id', 'displayName', 'status'])
+    v3.removeColumn('legacy')
 
-    // The dangerous part: the NEXT deploy declares the post-v3 schema, with
-    // `legacy` gone. The sheet still has four physical columns.
-    const v3Narrow = makeStore(['id', 'displayName', 'status'])
-    const narrowed = v3Narrow.findById(ann.id)
-    assertOk(narrowed, 'CURRENT: the narrowed adapter still finds the row — the id column is still column 1')
-    assertEq(cellText(narrowed?.displayName), 'ann2', 'CURRENT: columns left of the drop still read correctly')
     assertEq(
-      cellText(narrowed?.status),
-      '',
-      'CURRENT: `status` silently reads the abandoned (now-empty) `legacy` column; the real status in column 4 is unreachable'
+      rawRow(sheet, 1, 3),
+      ['id', 'displayName', 'status'],
+      'v3: the column was physically deleted, not just blanked'
     )
+    assertEq(rawRow(sheet, 2, 3), [cellText(ann.id), 'ann2', 'active'], 'v3: the columns right of the drop shifted with their data')
+    assertEq(rawRow(sheet, 3, 3), [cellText(bob.id), 'bob', 'archived'], 'v3: second row aligned the same way')
 
-    v3Narrow.update(ann.id, { status: 'live' })
+    // The formerly dangerous part: a schema without `legacy` now reads and
+    // writes the real columns instead of the abandoned one.
+    v3.clearCache()
+    const narrowed = v3.findById(ann.id)
+    assertOk(narrowed, 'v3: the post-removal schema still finds the row')
+    assertEq(cellText(narrowed?.displayName), 'ann2', 'v3: columns left of the drop still read correctly')
+    assertEq(cellText(narrowed?.status), 'active', 'v3: `status` reads the real status, not the abandoned column')
+
+    v3.update(ann.id, { status: 'live' })
     assertEq(
-      rawRow(sheet, 2, 4),
-      [cellText(ann.id), 'ann2', 'live', 'active'],
-      'CURRENT: the write lands in the abandoned `legacy` column while the real `status` column keeps its stale value'
+      rawRow(sheet, 2, 3),
+      [cellText(ann.id), 'ann2', 'live'],
+      'v3: the write lands in the real `status` column'
     )
-    t.info('v3 remove: value-op only; a schema that later drops the column misreads and miswrites every column to its right')
+    assertEq(v3.findAll().length, 2, 'v3: both records survived the column delete')
+
+    // Convergence: the column is already gone, so a rerun is a no-op.
+    const narrowGrid = (): string => JSON.stringify(sheet.getRange(1, 1, 3, 3).getValues())
+    const beforeRemoveRerun = narrowGrid()
+    v3.removeColumn('legacy')
+    assertEq(narrowGrid(), beforeRemoveRerun, 'v3: rerun leaves the grid byte-identical')
+    t.info('v3 remove: column physically deleted, remaining data stays aligned, rerun converges')
   })
 
   // Expose for cleanup by the harness entrypoint.

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -127,8 +127,9 @@ export interface SheetsAdapterOptions {
  *
  * Sheets API calls that are safe to repeat (all reads, and `setValues` over a
  * fixed range) are retried with bounded backoff; calls that are not
- * idempotent (`appendRow`, `deleteRow`, `insertSheet`, `insertColumnBefore`)
- * are attempted exactly once. See {@link SheetsAdapter.sheetsCall}.
+ * idempotent (`appendRow`, `deleteRow`, `insertSheet`, `insertColumnBefore`,
+ * `deleteColumn`) are attempted exactly once. See
+ * {@link SheetsAdapter.sheetsCall}.
  */
 export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   private spreadsheetId?: string
@@ -505,11 +506,12 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
    * Run one **non-idempotent** Sheets API call: classify its failure, never
    * repeat it (#136).
    *
-   * `appendRow`, `deleteRow`, `insertSheet` and `insertColumnBefore` change
-   * the sheet's shape. A timeout from one of them does not say whether the
-   * mutation landed, so retrying risks a second append (in auto id mode, a
-   * duplicate row under a duplicate id) or a second deleted row. Losing the
-   * operation is recoverable; silently doubling it is not.
+   * `appendRow`, `deleteRow`, `insertSheet`, `insertColumnBefore` and
+   * `deleteColumn` change the sheet's shape. A timeout from one of them does
+   * not say whether the mutation landed, so retrying risks a second append (in
+   * auto id mode, a duplicate row under a duplicate id), a second deleted row,
+   * or a second deleted column. Losing the operation is recoverable; silently
+   * doubling it is not.
    */
   private sheetsCallOnce<R>(fn: () => R): R {
     return withRetries(fn, { attempts: 1 })
@@ -991,6 +993,198 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     }
 
     this.backfillColumn(targetIndex + 1, defaultCell)
+  }
+
+  /**
+   * Physically rename a column: rewrite the single header cell (#180).
+   *
+   * The declared `columns` are the POST-rename schema, so `newName` must be
+   * declared and `oldName` must not — that is the shape a deploy has once its
+   * types are regenerated. The header cell at `newName`'s schema position must
+   * currently read `oldName`; the values themselves never move, because this
+   * adapter maps cells by position and the column is already in the right one.
+   *
+   * A value-level rename could not do this: the adapter already reads that cell
+   * as `newName`, so the "old" field is never present, no row is ever written,
+   * and the header keeps the old name while the schema declares the new one —
+   * the exact live failure of #180.
+   *
+   * Idempotent: when the header already reads `newName` nothing is written, so
+   * a re-run converges. Cost is one read plus at most one cell write,
+   * independent of the row count.
+   *
+   * When the store declares BOTH names, the two columns are real and distinct
+   * in this layout; the header must not change, so the operation degrades to
+   * moving the values across (the name-keyed semantics), still as ranged
+   * reads/writes rather than one `update()` per row.
+   *
+   * @throws {UnknownColumnError} `newName` is not in the declared schema
+   * @throws {SchemaMismatchError} the header cell holds neither name
+   */
+  renameColumn(oldName: string, newName: string): void {
+    const targetIndex = this.columns.indexOf(newName)
+    if (targetIndex < 0) {
+      throw new UnknownColumnError(newName, this.sheetName, [...this.columns])
+    }
+    const sourceIndex = this.columns.indexOf(oldName)
+
+    // Locked so the header rewrite (or the value move, which is a read then a
+    // write) cannot interleave with another execution's write, and flushed
+    // before the lock is released (#128, #164). Re-entrant under migrate().
+    this.withLock(() => {
+      if (sourceIndex >= 0) {
+        this.moveColumnValues(sourceIndex + 1, targetIndex + 1)
+        return
+      }
+
+      const sheet = this.getSheet()
+      const header = this.readHeader()
+      const current = header[targetIndex]
+
+      // Already renamed (or a sheet this adapter created with the new header):
+      // converge instead of rewriting.
+      if (current === newName) return
+      if (current !== oldName) {
+        throw new SchemaMismatchError(this.sheetName, header, [...this.columns])
+      }
+
+      this.sheetsCall(() =>
+        sheet.getRange(1, targetIndex + 1, 1, 1).setValues([[newName]])
+      )
+      this.invalidateDataCache()
+    })
+  }
+
+  /**
+   * Physically delete a column from the sheet (#180).
+   *
+   * **Destructive by contract**: `deleteColumn` removes the header AND every
+   * value in that column. Nothing can bring them back — a `down` migration can
+   * re-create the column, never its data. Back the sheet up before running a
+   * removal against production.
+   *
+   * The declared `columns` are the POST-removal schema, so the column must NOT
+   * be declared. Leaving it physically in place is what corrupts the NEXT
+   * deploy: the schema that no longer declares it maps every column to the
+   * right of the ghost one position off, so reads return the neighbour's value
+   * and writes land in the abandoned column (#180, live evidence).
+   *
+   * A column the schema still DOES declare is part of this store's positional
+   * map, and dropping it here would misalign this very adapter. Its values are
+   * cleared with one ranged write instead (the value-level meaning of the
+   * operation) and the layout is kept; the physical delete happens under the
+   * deploy whose schema no longer declares it.
+   *
+   * Idempotent: a column that is not on the sheet is a no-op, and a
+   * cleared-values column is not cleared twice. Cost is one read plus one
+   * structural call, independent of the row count.
+   *
+   * @throws {SchemaMismatchError} the header around the column contradicts the schema
+   */
+  removeColumn(column: string): void {
+    const declaredIndex = this.columns.indexOf(column)
+
+    this.withLock(() => {
+      const sheet = this.getSheet()
+      const header = this.readHeader()
+
+      if (declaredIndex >= 0) {
+        if (header[declaredIndex] !== column) {
+          // Not on the sheet at all: nothing to clear. Anywhere else means the
+          // positional mapping is already broken.
+          if (header.indexOf(column) < 0) return
+          throw new SchemaMismatchError(this.sheetName, header, [...this.columns])
+        }
+        this.clearColumnValues(declaredIndex + 1)
+        return
+      }
+
+      const headerIndex = header.indexOf(column)
+      if (headerIndex < 0) return
+
+      // What is left after the delete must be the declared schema (or a prefix
+      // of it, for a sheet that is behind on later columns). Anything else and
+      // the shift would move live data under the wrong headers.
+      const remaining = header.slice(0, headerIndex).concat(header.slice(headerIndex + 1))
+      if (!isPrefix(remaining, this.columns)) {
+        throw new SchemaMismatchError(this.sheetName, header, [...this.columns])
+      }
+
+      // deleteColumn shifts every later column left, so a repeat after a
+      // spurious failure would destroy a second, innocent column.
+      this.sheetsCallOnce(() => sheet.deleteColumn(headerIndex + 1))
+      this.invalidateDataCache()
+    })
+  }
+
+  /**
+   * Move each cell of the column at `fromPosition` into the column at
+   * `toPosition`, for rows whose source has a value and whose target is empty.
+   *
+   * Mirrors MigrationRunner's value-level rename guard (an emptiness test, not
+   * an `in` test — #99/#112), but as two ranged writes instead of one
+   * `update()` per row. Cells are copied verbatim, so escaping and typing
+   * survive untouched. Writes nothing when no row qualifies, so a re-run
+   * converges.
+   */
+  private moveColumnValues(fromPosition: number, toPosition: number): void {
+    const sheet = this.getSheet()
+    const lastRow = sheet.getLastRow()
+    if (lastRow <= 1) return
+
+    const rowCount = lastRow - 1
+    const sourceRange = sheet.getRange(2, fromPosition, rowCount, 1)
+    const targetRange = sheet.getRange(2, toPosition, rowCount, 1)
+    const source = this.sheetsCall(() => sourceRange.getValues())
+    const target = this.sheetsCall(() => targetRange.getValues())
+
+    let moved = 0
+    const nextSource: unknown[][] = []
+    const nextTarget: unknown[][] = []
+    for (let i = 0; i < rowCount; i++) {
+      const from = source[i][0]
+      const to = target[i][0]
+      if (!isEmptyCellValue(from) && isEmptyCellValue(to)) {
+        moved++
+        nextSource.push([''])
+        nextTarget.push([from])
+      } else {
+        nextSource.push([from])
+        nextTarget.push([to])
+      }
+    }
+
+    if (moved === 0) return
+
+    // Target first: if the second write is lost, the value exists in both
+    // columns and the next run converges. The other order would clear the
+    // source before the copy landed and lose the data outright.
+    this.sheetsCall(() => targetRange.setValues(nextTarget))
+    this.sheetsCall(() => sourceRange.setValues(nextSource))
+    this.invalidateDataCache()
+  }
+
+  /**
+   * Blank every non-empty cell of a column with one ranged write, leaving the
+   * column itself in place. Writes nothing when the column is already empty, so
+   * a re-run converges.
+   */
+  private clearColumnValues(position: number): void {
+    const sheet = this.getSheet()
+    const lastRow = sheet.getLastRow()
+    if (lastRow <= 1) return
+
+    const range = sheet.getRange(2, position, lastRow - 1, 1)
+    const current = this.sheetsCall(() => range.getValues())
+
+    let filled = 0
+    for (const [value] of current) {
+      if (!isEmptyCellValue(value)) filled++
+    }
+    if (filled === 0) return
+
+    this.sheetsCall(() => range.setValues(current.map(() => [''])))
+    this.invalidateDataCache()
   }
 
   /** Read the current header row, trailing empty cells trimmed. */

--- a/packages/core/src/core/migration.ts
+++ b/packages/core/src/core/migration.ts
@@ -311,45 +311,79 @@ export class MigrationRunner {
   private applyOperation(operation: SchemaOperation): void {
     const store = this.storeResolver<RowWithId>(operation.table)
 
-    if (operation.type === 'addColumn') {
-      this.applyAddColumn(store, operation)
+    switch (operation.type) {
+      case 'addColumn':
+        this.applyAddColumn(store, operation)
+        return
+      case 'removeColumn':
+        this.applyRemoveColumn(store, operation)
+        return
+      case 'renameColumn':
+        this.applyRenameColumn(store, operation)
+        return
+    }
+  }
+
+  /**
+   * Apply a removeColumn operation.
+   *
+   * Same capability probe as {@link MigrationRunner.applyAddColumn} (#127): a
+   * store whose columns are physical and positional (SheetsAdapter) has to drop
+   * the column itself, because clearing values leaves the column — and the next
+   * deploy, whose schema no longer declares it, then maps every column to its
+   * right one position off (#180).
+   *
+   * Name-keyed stores (MockAdapter, LocalAdapter) have no physical column, so
+   * the value clear below is the whole operation: the key is left `undefined`
+   * (Sheets: the cell blanked). addColumn's empty-cell guard (#99) lets a later
+   * re-add re-apply its default over the cleared value.
+   */
+  private applyRemoveColumn(store: DataStore<RowWithId>, operation: SchemaOperation): void {
+    const column = operation.column!
+
+    if (store.removeColumn) {
+      store.removeColumn(column)
       return
     }
 
-    const rows = store.findAll()
-
-    switch (operation.type) {
-      case 'removeColumn': {
-        // Clears the column's value (in-memory: key left undefined; Sheets: cell
-        // cleared). This is a value operation — it does not drop the column from
-        // the sheet header. addColumn's empty-cell guard (#99) lets a later
-        // re-add re-apply its default over the cleared value.
-        for (const row of rows) {
-          if (!isEmptyCell((row as Record<string, unknown>)[operation.column!])) {
-            store.update(row.id as string | number, {
-              [operation.column!]: undefined
-            })
-          }
-        }
-        break
+    for (const row of store.findAll()) {
+      if (!isEmptyCell((row as Record<string, unknown>)[column])) {
+        store.update(row.id as string | number, { [column]: undefined })
       }
+    }
+  }
 
-      case 'renameColumn': {
-        for (const row of rows) {
-          const r = row as Record<string, unknown>
-          // Rename when the source has a value and the target is empty
-          // (missing, or cleared by a prior op) — an emptiness test rather than
-          // `in`, consistent with the addColumn guard (#99). Using `in` here
-          // would wrongly skip the rename when the target key lingers from an
-          // earlier removeColumn/rename.
-          if (!isEmptyCell(r[operation.oldColumn!]) && isEmptyCell(r[operation.newColumn!])) {
-            store.update(row.id as string | number, {
-              [operation.oldColumn!]: undefined,
-              [operation.newColumn!]: r[operation.oldColumn!]
-            })
-          }
-        }
-        break
+  /**
+   * Apply a renameColumn operation.
+   *
+   * Same capability probe as {@link MigrationRunner.applyAddColumn} (#127): on
+   * a positional store the value move below cannot rename anything — the cell
+   * is already read under the new name, so the copy condition is never true and
+   * the sheet header keeps the old name (#180). Such a store renames its own
+   * header.
+   *
+   * On name-keyed stores the value move IS the rename: it fires when the source
+   * has a value and the target is empty (missing, or cleared by a prior op) —
+   * an emptiness test rather than `in`, consistent with the addColumn guard
+   * (#99). Using `in` here would wrongly skip the rename when the target key
+   * lingers from an earlier removeColumn/rename.
+   */
+  private applyRenameColumn(store: DataStore<RowWithId>, operation: SchemaOperation): void {
+    const oldColumn = operation.oldColumn!
+    const newColumn = operation.newColumn!
+
+    if (store.renameColumn) {
+      store.renameColumn(oldColumn, newColumn)
+      return
+    }
+
+    for (const row of store.findAll()) {
+      const r = row as Record<string, unknown>
+      if (!isEmptyCell(r[oldColumn]) && isEmptyCell(r[newColumn])) {
+        store.update(row.id as string | number, {
+          [oldColumn]: undefined,
+          [newColumn]: r[oldColumn]
+        })
       }
     }
   }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -115,6 +115,44 @@ export interface DataStore<T extends RowWithId = RowWithId> {
    * representable there, so MigrationRunner falls back to a value backfill.
    */
   addColumn?(column: string, options?: AddColumnOptions): void
+
+  /**
+   * Physically rename a column in the underlying storage (optional).
+   *
+   * Counterpart of {@link DataStore.addColumn} for positional stores: moving
+   * values between fields cannot rename anything there, because the field a
+   * cell belongs to is decided by its position — the migration left the sheet
+   * header on the old name while the schema declared the new one (#180). The
+   * declared column set is the POST-rename schema, so implementations receive
+   * a `newName` they know and an `oldName` they do not.
+   *
+   * Implementations must be idempotent (a second run writes nothing) and must
+   * not cost more I/O as the row count grows.
+   *
+   * Name-keyed stores (MockAdapter, LocalAdapter) omit this — a rename there is
+   * exactly the value move MigrationRunner falls back to.
+   */
+  renameColumn?(oldName: string, newName: string): void
+
+  /**
+   * Physically remove a column from the underlying storage (optional).
+   *
+   * **Destructive**: the column's values are deleted with it and no rollback
+   * can restore them.
+   *
+   * Counterpart of {@link DataStore.addColumn} for positional stores: clearing
+   * the values leaves the column in place, and the next deploy — whose schema
+   * no longer declares it — reads and writes every column to its right one
+   * position off (#180). The declared column set is the POST-removal schema, so
+   * implementations receive a column they no longer know.
+   *
+   * Implementations must be idempotent (removing an absent column is a no-op)
+   * and must not cost more I/O as the row count grows.
+   *
+   * Name-keyed stores (MockAdapter, LocalAdapter) omit this — there is no
+   * physical column to drop, so MigrationRunner falls back to clearing values.
+   */
+  removeColumn?(column: string): void
 }
 
 // ============================================================================

--- a/packages/core/src/testing/fake-sheet.ts
+++ b/packages/core/src/testing/fake-sheet.ts
@@ -119,6 +119,24 @@ export class FakeSheet {
     }
   }
 
+  /**
+   * Deletes the column at `columnIndex` (1-indexed), shifting cells after that
+   * position one column left — values included, which is what makes it the
+   * physical counterpart of {@link insertColumnBefore} (#180). Rows whose
+   * content ends before the position are left as-is (they read as blank there
+   * either way).
+   */
+  deleteColumn(columnIndex: number): void {
+    if (columnIndex < 1) {
+      throw new Error(`deleteColumn: column index must be >= 1 (got ${columnIndex})`)
+    }
+    for (const row of this.grid) {
+      if (row.length >= columnIndex) {
+        row.splice(columnIndex - 1, 1)
+      }
+    }
+  }
+
   /** Empties the grid and resets frozen-row state. */
   clear(): void {
     this.grid = []

--- a/packages/core/tests/unit/concurrent-write-locking.test.ts
+++ b/packages/core/tests/unit/concurrent-write-locking.test.ts
@@ -687,6 +687,41 @@ describe('MigrationRunner locking (#128)', () => {
     expect(dataRows(sheet)[0]).toEqual([1, 'Alice', 99])
   })
 
+  it('does not deadlock when a migration renames or removes a column physically (#180)', async () => {
+    // Both physical schema ops take the script lock themselves, so they must
+    // re-enter the one migrate() already holds instead of asking for a second.
+    const sheet = setupSharedSheet([
+      ['id', 'name', 'age'],
+      [1, 'Alice', 30]
+    ])
+    installExclusiveLock()
+
+    // Post-migration schema: `name` renamed to `label`, `age` dropped.
+    const users = new SheetsAdapter<TestRow>({ ...BASE_OPTIONS, columns: ['id', 'label'] })
+    const resolver: StoreResolver = <T extends Row>() => users as unknown as DataStore<T>
+    const runner = runnerWith(
+      migrationsStore(),
+      [
+        {
+          version: 1,
+          name: 'rename-and-drop',
+          up: schema => {
+            schema.renameColumn(SHEET_NAME, 'name', 'label')
+            schema.removeColumn(SHEET_NAME, 'age')
+          },
+          down: schema => schema.renameColumn(SHEET_NAME, 'label', 'name')
+        }
+      ],
+      resolver
+    )
+
+    await expect(runner.migrate()).resolves.toMatchObject({ currentVersion: 1 })
+    expect(sheet.getRange(1, 1, 2, 2).getValues()).toEqual([
+      ['id', 'label'],
+      [1, 'Alice']
+    ])
+  })
+
   it('migrate() still runs when LockService is unavailable (Node)', async () => {
     delete (globalThis as Record<string, unknown>).LockService
     const store = migrationsStore()

--- a/packages/core/tests/unit/fake-sheet.test.ts
+++ b/packages/core/tests/unit/fake-sheet.test.ts
@@ -192,6 +192,46 @@ describe('FakeSheet', () => {
     })
   })
 
+  describe('deleteColumn', () => {
+    it('removes the column and shifts the ones after it left, values included', () => {
+      const sheet = new FakeSheet('Sheet1')
+      sheet.appendRow(['id', 'legacy', 'name'])
+      sheet.appendRow([1, 'L1', 'John'])
+
+      sheet.deleteColumn(2)
+
+      expect(sheet.getLastColumn()).toBe(2)
+      expect(sheet.getRange(1, 1, 2, 2).getValues()).toEqual([
+        ['id', 'name'],
+        [1, 'John'],
+      ])
+    })
+
+    it('reads as blank past the shortened row instead of throwing', () => {
+      const sheet = new FakeSheet('Sheet1')
+      sheet.appendRow(['id', 'name'])
+
+      sheet.deleteColumn(2)
+
+      expect(sheet.getRange(1, 1, 1, 2).getValues()).toEqual([['id', '']])
+    })
+
+    it('is a no-op for rows that end before the position', () => {
+      const sheet = new FakeSheet('Sheet1')
+      sheet.appendRow(['id', 'name'])
+
+      sheet.deleteColumn(5)
+
+      expect(sheet.getLastColumn()).toBe(2)
+      expect(sheet.getRange(1, 1, 1, 2).getValues()).toEqual([['id', 'name']])
+    })
+
+    it('throws for column indexes below 1', () => {
+      const sheet = new FakeSheet('Sheet1')
+      expect(() => sheet.deleteColumn(0)).toThrow(/must be >= 1/)
+    })
+  })
+
   describe('clear / clearContents', () => {
     it('clear empties the grid and resets frozen rows', () => {
       const sheet = new FakeSheet('Sheet1')

--- a/packages/core/tests/unit/migration-adapter-parity.test.ts
+++ b/packages/core/tests/unit/migration-adapter-parity.test.ts
@@ -39,6 +39,15 @@ const RENAME: Migration[] = [
   },
 ]
 
+const DROP_NAME: Migration[] = [
+  {
+    version: 1,
+    name: 'drop-name',
+    up: schema => schema.removeColumn('users', 'name'),
+    down: schema => schema.addColumn('users', 'name'),
+  },
+]
+
 function mockSetup() {
   const users = new MockAdapter<any>({ initialData: [{ id: 1, name: 'John' }] })
   const resolver: StoreResolver = <T extends Row>() => users as unknown as DataStore<T>
@@ -150,7 +159,63 @@ describe('migration parity between MockAdapter and SheetsAdapter [#112]', () => 
     ])
   })
 
-  it('applies renameColumn on both stores', async () => {
+  it('renames physically on SheetsAdapter when the schema is the post-rename one [#180]', async () => {
+    // Deliberate asymmetry, the addColumn one turned inside out (#127): a
+    // name-keyed store renames by moving the value to the new key, while the
+    // positional store renames by rewriting the header cell and leaving every
+    // value exactly where it is — there is nothing to move, the cell is already
+    // read under the new name. Same end state, different mechanics.
+    const mock = mockSetup()
+    await runner(mock.resolver, RENAME).migrate()
+
+    const sheets = sheetsSetup(
+      ['id', 'label'],
+      [
+        ['id', 'name'],
+        [1, 'John'],
+      ]
+    )
+    const result = await runner(sheets.resolver, RENAME).migrate()
+
+    expect(mock.read().label).toBe('John')
+    expect(mock.read().name).toBeUndefined()
+    expect(sheets.read().label).toBe('John')
+    expect(result.currentVersion).toBe(1)
+    expect(sheets.users.getRawData()).toEqual([
+      ['id', 'label'],
+      [1, 'John'],
+    ])
+  })
+
+  it('removes physically on SheetsAdapter when the schema is the post-removal one [#180]', async () => {
+    // The name-keyed store clears the key; the positional store deletes the
+    // column itself, because leaving it would shift every column to its right
+    // for the very schema being deployed here.
+    const mock = mockSetup()
+    await runner(mock.resolver, DROP_NAME).migrate()
+
+    const sheets = sheetsSetup(
+      ['id', 'status'],
+      [
+        ['id', 'name', 'status'],
+        [1, 'John', 'active'],
+      ]
+    )
+    await runner(sheets.resolver, DROP_NAME).migrate()
+
+    expect(mock.read().name).toBeUndefined()
+    expect(sheets.read().status).toBe('active')
+    expect(sheets.users.getRawData()).toEqual([
+      ['id', 'status'],
+      [1, 'active'],
+    ])
+  })
+
+  it('applies renameColumn on both stores when both names are declared', async () => {
+    // Here the Sheets schema declares `name` AND `label`: two real columns, so
+    // the header must not change and the rename degrades to the value move the
+    // name-keyed store performs (#180 keeps this case value-level on purpose —
+    // dropping the old header cell would misalign this very adapter).
     const mock = mockSetup()
     await runner(mock.resolver, RENAME).migrate()
 

--- a/packages/core/tests/unit/migration-remove-column.test.ts
+++ b/packages/core/tests/unit/migration-remove-column.test.ts
@@ -1,0 +1,315 @@
+/**
+ * removeColumn must physically delete the column (#180).
+ *
+ * Before this suite, removeColumn was a pure value operation: it cleared each
+ * row's cell through `update()` and left the physical column — header and all —
+ * in place. On a positional store that leaves a ghost column behind, and the
+ * NEXT deploy, whose schema no longer declares it, maps every column to its
+ * right one position off: reads return the neighbour's value and writes land in
+ * the abandoned column. Confirmed on the live platform (gas-e2e run
+ * 31298563680).
+ *
+ * Mirrors the #127 addColumn suite: the store owns the physical operation, the
+ * runner delegates to it, the cost never grows with the row count, and a re-run
+ * converges instead of rewriting.
+ *
+ * `removeColumn` is destructive by contract — the deleted cells are gone, and
+ * no rollback can bring them back.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { createMigrationRunner } from '../../src/core/migration'
+import type { Migration, MigrationRecord, StoreResolver } from '../../src/core/migration'
+import { MigrationExecutionError } from '../../src/core/migration'
+import { SchemaMismatchError } from '../../src/core/errors'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { FakeRange, FakeSheet } from '../../src/testing/fake-sheet'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+import type { GasFakesHandle } from '../../src/testing/install'
+import type { DataStore, Row, RowWithId } from '../../src/core/types'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+
+let handle: GasFakesHandle | undefined
+
+afterEach(() => {
+  handle?.restore()
+  handle = undefined
+  vi.restoreAllMocks()
+})
+
+/** Install a fake spreadsheet with one Users sheet and return a positional adapter over it. */
+function sheetsStore(columns: string[], grid: unknown[][]): SheetsAdapter<RowWithId> {
+  const spreadsheet = fromArrays({ Users: grid })
+  handle = installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+  return new SheetsAdapter<RowWithId>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Users',
+    columns,
+  })
+}
+
+function resolverFor(store: DataStore<RowWithId>): StoreResolver {
+  return <T extends Row>() => store as unknown as DataStore<T>
+}
+
+function dropLegacy(column = 'legacy'): Migration[] {
+  return [
+    {
+      version: 1,
+      name: 'drop-legacy',
+      up: schema => schema.removeColumn('users', column),
+      down: schema => schema.addColumn('users', column),
+    },
+  ]
+}
+
+function addStatus(options?: { default?: unknown }): Migration[] {
+  return [
+    {
+      version: 1,
+      name: 'add-status',
+      up: schema => schema.addColumn('users', 'status', options),
+      down: schema => schema.removeColumn('users', 'status'),
+    },
+  ]
+}
+
+function runnerFor(store: DataStore<RowWithId>, migrations: Migration[]) {
+  return createMigrationRunner({
+    migrationsStore: new MockAdapter<MigrationRecord>(),
+    storeResolver: resolverFor(store),
+    migrations,
+  })
+}
+
+/** Count the Sheets calls that map to a real API round trip, including the structural delete. */
+function countSheetsCalls() {
+  const getValues = vi.spyOn(FakeRange.prototype, 'getValues')
+  const setValues = vi.spyOn(FakeRange.prototype, 'setValues')
+  const deleteColumn = vi.spyOn(FakeSheet.prototype, 'deleteColumn')
+  return {
+    get reads() {
+      return getValues.mock.calls.length
+    },
+    get writes() {
+      return setValues.mock.calls.length
+    },
+    get deletes() {
+      return deleteColumn.mock.calls.length
+    },
+  }
+}
+
+function dataGrid(rowCount: number): unknown[][] {
+  const rows: unknown[][] = [['id', 'legacy', 'name']]
+  for (let i = 1; i <= rowCount; i++) rows.push([i, `L${i}`, `user-${i}`])
+  return rows
+}
+
+describe('removeColumn deletes the column for real [#180]', () => {
+  it('deletes the physical column and keeps the remaining data under its own headers', async () => {
+    const users = sheetsStore(['id', 'name'], [
+      ['id', 'legacy', 'name'],
+      [1, 'L1', 'John'],
+      [2, 'L2', 'Jane'],
+    ])
+
+    const result = await runnerFor(users, dropLegacy()).migrate()
+
+    expect(result.currentVersion).toBe(1)
+    expect(users.getRawData()).toEqual([
+      ['id', 'name'],
+      [1, 'John'],
+      [2, 'Jane'],
+    ])
+  })
+
+  it('keeps reads and writes correct under the post-removal schema', async () => {
+    const users = sheetsStore(['id', 'name', 'status'], [
+      ['id', 'legacy', 'name', 'status'],
+      [1, 'L1', 'John', 'active'],
+      [2, 'L2', 'Jane', 'archived'],
+    ])
+
+    await runnerFor(users, dropLegacy()).migrate()
+
+    users.clearCache()
+    expect(users.findById(1)).toEqual({ id: 1, name: 'John', status: 'active' })
+    users.update(2, { status: 'live' })
+    expect(users.getRawData()).toEqual([
+      ['id', 'name', 'status'],
+      [1, 'John', 'active'],
+      [2, 'Jane', 'live'],
+    ])
+  })
+
+  it('deletes a trailing column too', async () => {
+    const users = sheetsStore(['id', 'name'], [
+      ['id', 'name', 'legacy'],
+      [1, 'John', 'L1'],
+    ])
+
+    await runnerFor(users, dropLegacy()).migrate()
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'name'],
+      [1, 'John'],
+    ])
+  })
+})
+
+describe('removeColumn fails loudly when the layout contradicts the schema [#180]', () => {
+  it('throws SchemaMismatchError when the remaining header would not be the declared schema', async () => {
+    const users = sheetsStore(['id', 'name'], [
+      ['id', 'legacy', 'email'],
+      [1, 'L1', 'john@test.com'],
+    ])
+    const before = users.getRawData()
+    const migrationsStore = new MockAdapter<MigrationRecord>()
+    const runner = createMigrationRunner({
+      migrationsStore,
+      storeResolver: resolverFor(users),
+      migrations: dropLegacy(),
+    })
+
+    const error = await runner.migrate().catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(MigrationExecutionError)
+    expect((error as MigrationExecutionError).cause).toBeInstanceOf(SchemaMismatchError)
+
+    expect(users.getRawData()).toEqual(before)
+    expect(migrationsStore.findAll()).toEqual([])
+    expect(runner.getCurrentVersion()).toBe(0)
+  })
+})
+
+describe('removeColumn is a single structural call [#180]', () => {
+  it('costs the same bounded number of Sheets calls for 10 and for 1000 rows', async () => {
+    const small = sheetsStore(['id', 'name'], dataGrid(10))
+    let calls = countSheetsCalls()
+    await runnerFor(small, dropLegacy()).migrate()
+    const smallCost = { reads: calls.reads, writes: calls.writes, deletes: calls.deletes }
+    handle?.restore()
+    handle = undefined
+    vi.restoreAllMocks()
+
+    const large = sheetsStore(['id', 'name'], dataGrid(1000))
+    calls = countSheetsCalls()
+    await runnerFor(large, dropLegacy()).migrate()
+    const largeCost = { reads: calls.reads, writes: calls.writes, deletes: calls.deletes }
+
+    expect(largeCost).toEqual(smallCost)
+    // One structural delete removes the values with it — no per-row clearing.
+    expect(largeCost.deletes).toBe(1)
+    expect(largeCost.writes).toBe(0)
+    expect(largeCost.reads).toBeLessThanOrEqual(2)
+
+    const rows = large.findAll()
+    expect(rows).toHaveLength(1000)
+    expect(rows.every(row => !('legacy' in (row as Record<string, unknown>)))).toBe(true)
+  })
+})
+
+describe('removeColumn converges on re-run [#180]', () => {
+  it('is a no-op once the column is gone from the sheet', async () => {
+    const users = sheetsStore(['id', 'name'], dataGrid(50))
+    await runnerFor(users, dropLegacy()).migrate()
+    const afterFirst = users.getRawData()
+
+    users.clearCache()
+    const calls = countSheetsCalls()
+    await runnerFor(users, dropLegacy()).migrate()
+
+    expect(calls.writes).toBe(0)
+    expect(calls.deletes).toBe(0)
+    expect(users.getRawData()).toEqual(afterFirst)
+  })
+})
+
+describe('removeColumn on a column the schema still declares [#180]', () => {
+  it('clears the values with one ranged write instead of dropping the column', async () => {
+    // The declared columns are this store's positional map. Dropping a column
+    // it still declares would shift every column to the right of it under the
+    // wrong header, so the values are cleared and the layout is kept — the
+    // physical delete happens under the schema that no longer declares it.
+    const users = sheetsStore(['id', 'name', 'status'], [
+      ['id', 'name', 'status'],
+      [1, 'John', 'active'],
+      [2, 'Jane', ''],
+    ])
+
+    const calls = countSheetsCalls()
+    await runnerFor(users, dropLegacy('status')).migrate()
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'name', 'status'],
+      [1, 'John', ''],
+      [2, 'Jane', ''],
+    ])
+    expect(calls.deletes).toBe(0)
+    expect(calls.writes).toBe(1)
+  })
+
+  it('converges: a second run clears nothing', async () => {
+    const users = sheetsStore(['id', 'name', 'status'], [
+      ['id', 'name', 'status'],
+      [1, 'John', 'active'],
+    ])
+    await runnerFor(users, dropLegacy('status')).migrate()
+    const afterFirst = users.getRawData()
+
+    users.clearCache()
+    const calls = countSheetsCalls()
+    await runnerFor(users, dropLegacy('status')).migrate()
+
+    expect(calls.writes).toBe(0)
+    expect(users.getRawData()).toEqual(afterFirst)
+  })
+
+  it('still supports rolling back an addColumn against the schema that declares it', async () => {
+    const users = sheetsStore(['id', 'name', 'status'], [
+      ['id', 'name', 'status'],
+      [1, 'John', ''],
+    ])
+    const runner = runnerFor(users, addStatus({ default: 'unknown' }))
+
+    await runner.migrate()
+    await runner.rollback()
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'name', 'status'],
+      [1, 'John', ''],
+    ])
+    expect(runner.getCurrentVersion()).toBe(0)
+  })
+
+  it('is a no-op when the declared column is not on the sheet yet', async () => {
+    const users = sheetsStore(['id', 'name', 'status'], [
+      ['id', 'name'],
+      [1, 'John'],
+    ])
+
+    const calls = countSheetsCalls()
+    await runnerFor(users, dropLegacy('status')).migrate()
+
+    expect(calls.writes).toBe(0)
+    expect(calls.deletes).toBe(0)
+    expect(users.getRawData()).toEqual([
+      ['id', 'name'],
+      [1, 'John'],
+    ])
+  })
+})
+
+describe('removeColumn keeps the value-level behavior on name-keyed stores [#180]', () => {
+  it('clears the value through the runner fallback on MockAdapter', async () => {
+    const users = new MockAdapter<RowWithId>({
+      initialData: [{ id: 1, legacy: 'L1' } as RowWithId],
+    })
+
+    await runnerFor(users, dropLegacy()).migrate()
+
+    expect((users.findById(1) as Record<string, unknown>).legacy).toBeUndefined()
+  })
+})

--- a/packages/core/tests/unit/migration-rename-column.test.ts
+++ b/packages/core/tests/unit/migration-rename-column.test.ts
@@ -1,0 +1,304 @@
+/**
+ * renameColumn must physically rewrite the header cell (#180).
+ *
+ * Before this suite, renameColumn was a pure value operation: for every row it
+ * moved the value from the old field to the new one through `update()`. On a
+ * positional store that is a no-op — the adapter already reads the cell at the
+ * new name's position, so the "old" field is never present and the copy
+ * condition is never true — and the sheet header keeps the OLD name while the
+ * schema declares the new one. Confirmed on the live platform (gas-e2e run
+ * 31298563680): v2 renamed nothing and left header `name` vs schema
+ * `displayName`.
+ *
+ * Mirrors the #127 addColumn suite: the store owns the physical operation, the
+ * runner delegates to it, the cost never grows with the row count, and a re-run
+ * converges instead of rewriting.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { createMigrationRunner } from '../../src/core/migration'
+import type { Migration, MigrationRecord, StoreResolver } from '../../src/core/migration'
+import { MigrationExecutionError } from '../../src/core/migration'
+import { SchemaMismatchError, UnknownColumnError } from '../../src/core/errors'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { FakeRange } from '../../src/testing/fake-sheet'
+import { fromArrays } from '../../src/testing/loaders'
+import { installGasFakes } from '../../src/testing/install'
+import type { GasFakesHandle } from '../../src/testing/install'
+import type { DataStore, Row, RowWithId } from '../../src/core/types'
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+
+let handle: GasFakesHandle | undefined
+
+afterEach(() => {
+  handle?.restore()
+  handle = undefined
+  vi.restoreAllMocks()
+})
+
+/** Install a fake spreadsheet with one Users sheet and return a positional adapter over it. */
+function sheetsStore(columns: string[], grid: unknown[][]): SheetsAdapter<RowWithId> {
+  const spreadsheet = fromArrays({ Users: grid })
+  handle = installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+  return new SheetsAdapter<RowWithId>({
+    spreadsheetId: SPREADSHEET_ID,
+    sheetName: 'Users',
+    columns,
+  })
+}
+
+function resolverFor(store: DataStore<RowWithId>): StoreResolver {
+  return <T extends Row>() => store as unknown as DataStore<T>
+}
+
+/** rename `name` -> `displayName`, the shape of the live v2 migration. */
+function renameName(from = 'name', to = 'displayName'): Migration[] {
+  return [
+    {
+      version: 1,
+      name: 'rename-name',
+      up: schema => schema.renameColumn('users', from, to),
+      down: schema => schema.renameColumn('users', to, from),
+    },
+  ]
+}
+
+function runnerFor(store: DataStore<RowWithId>, migrations: Migration[]) {
+  return createMigrationRunner({
+    migrationsStore: new MockAdapter<MigrationRecord>(),
+    storeResolver: resolverFor(store),
+    migrations,
+  })
+}
+
+/** Count Range-level Sheets calls, the unit that maps to a real API round trip. */
+function countRangeCalls() {
+  const getValues = vi.spyOn(FakeRange.prototype, 'getValues')
+  const setValues = vi.spyOn(FakeRange.prototype, 'setValues')
+  return {
+    get reads() {
+      return getValues.mock.calls.length
+    },
+    get writes() {
+      return setValues.mock.calls.length
+    },
+    reset() {
+      getValues.mockClear()
+      setValues.mockClear()
+    },
+  }
+}
+
+function dataGrid(rowCount: number): unknown[][] {
+  const rows: unknown[][] = [['id', 'name']]
+  for (let i = 1; i <= rowCount; i++) rows.push([i, `user-${i}`])
+  return rows
+}
+
+describe('renameColumn renames the column for real [#180]', () => {
+  it('rewrites the header cell and leaves every data cell where it is', async () => {
+    const users = sheetsStore(['id', 'displayName'], [
+      ['id', 'name'],
+      [1, 'John'],
+      [2, 'Jane'],
+    ])
+
+    const result = await runnerFor(users, renameName()).migrate()
+
+    expect(result.currentVersion).toBe(1)
+    expect(users.getRawData()).toEqual([
+      ['id', 'displayName'],
+      [1, 'John'],
+      [2, 'Jane'],
+    ])
+  })
+
+  it('renames a mid-schema column without disturbing its neighbours', async () => {
+    const users = sheetsStore(['id', 'displayName', 'status'], [
+      ['id', 'name', 'status'],
+      [1, 'John', 'active'],
+    ])
+
+    await runnerFor(users, renameName()).migrate()
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'displayName', 'status'],
+      [1, 'John', 'active'],
+    ])
+    users.clearCache()
+    expect(users.findById(1)).toEqual({ id: 1, displayName: 'John', status: 'active' })
+  })
+
+  it('keeps reads and writes correct under the post-rename schema', async () => {
+    const users = sheetsStore(['id', 'displayName', 'status'], [
+      ['id', 'name', 'status'],
+      [1, 'John', 'active'],
+    ])
+
+    await runnerFor(users, renameName()).migrate()
+    users.clearCache()
+    users.update(1, { displayName: 'John II' })
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'displayName', 'status'],
+      [1, 'John II', 'active'],
+    ])
+  })
+})
+
+describe('renameColumn fails loudly when the rename cannot be represented [#180]', () => {
+  it('throws UnknownColumnError when the new name is not in the declared schema', async () => {
+    // This is also the shape of a rename rolled back against the wrong schema
+    // (`down: renameColumn(newName, oldName)` while the store still declares
+    // newName). The value-level version of that did not fail — it cleared the
+    // source cell and dropped the target, because `objectToRow` only writes
+    // declared columns. Silent data loss, replaced by a loud error.
+    const users = sheetsStore(['id', 'name'], [
+      ['id', 'name'],
+      [1, 'John'],
+    ])
+    const before = users.getRawData()
+    const migrationsStore = new MockAdapter<MigrationRecord>()
+    const runner = createMigrationRunner({
+      migrationsStore,
+      storeResolver: resolverFor(users),
+      migrations: renameName(),
+    })
+
+    const error = await runner.migrate().catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(MigrationExecutionError)
+    expect((error as MigrationExecutionError).cause).toBeInstanceOf(UnknownColumnError)
+    expect((error as MigrationExecutionError).cause.message).toContain('displayName')
+
+    expect(users.getRawData()).toEqual(before)
+    expect(migrationsStore.findAll()).toEqual([])
+    expect(runner.getCurrentVersion()).toBe(0)
+  })
+
+  it('throws SchemaMismatchError when the header holds neither the old nor the new name', async () => {
+    const users = sheetsStore(['id', 'displayName'], [
+      ['id', 'email'],
+      [1, 'john@test.com'],
+    ])
+    const before = users.getRawData()
+    const runner = runnerFor(users, renameName())
+
+    const error = await runner.migrate().catch((e: unknown) => e)
+    expect((error as MigrationExecutionError).cause).toBeInstanceOf(SchemaMismatchError)
+    expect(users.getRawData()).toEqual(before)
+    expect(runner.getCurrentVersion()).toBe(0)
+  })
+
+  it('throws SchemaMismatchError when the old name sits at a different physical position', async () => {
+    const users = sheetsStore(['id', 'displayName', 'status'], [
+      ['id', 'status', 'name'],
+      [1, 'active', 'John'],
+    ])
+    const runner = runnerFor(users, renameName())
+
+    const error = await runner.migrate().catch((e: unknown) => e)
+    expect((error as MigrationExecutionError).cause).toBeInstanceOf(SchemaMismatchError)
+    expect(runner.getCurrentVersion()).toBe(0)
+  })
+})
+
+describe('renameColumn is a single header write [#180]', () => {
+  it('costs the same bounded number of Sheets calls for 10 and for 1000 rows', async () => {
+    const small = sheetsStore(['id', 'displayName'], dataGrid(10))
+    let calls = countRangeCalls()
+    await runnerFor(small, renameName()).migrate()
+    const smallCost = { reads: calls.reads, writes: calls.writes }
+    handle?.restore()
+    handle = undefined
+    vi.restoreAllMocks()
+
+    const large = sheetsStore(['id', 'displayName'], dataGrid(1000))
+    calls = countRangeCalls()
+    await runnerFor(large, renameName()).migrate()
+    const largeCost = { reads: calls.reads, writes: calls.writes }
+
+    expect(largeCost).toEqual(smallCost)
+    // One header cell write. Never one write per row.
+    expect(largeCost.writes).toBe(1)
+    expect(largeCost.reads + largeCost.writes).toBeLessThanOrEqual(4)
+
+    const rows = large.findAll()
+    expect(rows).toHaveLength(1000)
+    expect(rows.every(row => typeof (row as Record<string, unknown>).displayName === 'string')).toBe(true)
+  })
+})
+
+describe('renameColumn converges on re-run [#180]', () => {
+  it('writes nothing on a second run — the header already reads the new name', async () => {
+    const users = sheetsStore(['id', 'displayName'], dataGrid(50))
+    await runnerFor(users, renameName()).migrate()
+    const afterFirst = users.getRawData()
+
+    users.clearCache()
+    const calls = countRangeCalls()
+    await runnerFor(users, renameName()).migrate()
+
+    expect(calls.writes).toBe(0)
+    expect(users.getRawData()).toEqual(afterFirst)
+  })
+
+  it('is a no-op on a sheet the adapter just created with the post-rename header', async () => {
+    const users = sheetsStore(['id', 'displayName'], [['id', 'displayName']])
+
+    await runnerFor(users, renameName()).migrate()
+
+    expect(users.getRawData()).toEqual([['id', 'displayName']])
+  })
+})
+
+describe('renameColumn when both names are declared [#180]', () => {
+  it('moves the values instead of rewriting the header — both columns are real', async () => {
+    // Deliberate asymmetry with the physical case: the declared schema still
+    // owns a `name` column, so its header cell must stay. The operation then
+    // means what it means on a name-keyed store — move the value across.
+    const users = sheetsStore(['id', 'name', 'label'], [
+      ['id', 'name', 'label'],
+      [1, 'John', ''],
+      [2, 'Jane', 'kept'],
+    ])
+
+    await runnerFor(users, renameName('name', 'label')).migrate()
+
+    expect(users.getRawData()).toEqual([
+      ['id', 'name', 'label'],
+      [1, '', 'John'],
+      [2, 'Jane', 'kept'],
+    ])
+  })
+
+  it('converges: a second run moves nothing', async () => {
+    const users = sheetsStore(['id', 'name', 'label'], [
+      ['id', 'name', 'label'],
+      [1, 'John', ''],
+    ])
+    await runnerFor(users, renameName('name', 'label')).migrate()
+    const afterFirst = users.getRawData()
+
+    users.clearCache()
+    const calls = countRangeCalls()
+    await runnerFor(users, renameName('name', 'label')).migrate()
+
+    expect(calls.writes).toBe(0)
+    expect(users.getRawData()).toEqual(afterFirst)
+  })
+})
+
+describe('renameColumn keeps the value-level behavior on name-keyed stores [#180]', () => {
+  it('moves the value through the runner fallback on MockAdapter', async () => {
+    const users = new MockAdapter<RowWithId>({
+      initialData: [{ id: 1, name: 'John' } as RowWithId],
+    })
+
+    await runnerFor(users, renameName()).migrate()
+
+    const row = users.findById(1) as Record<string, unknown>
+    expect(row.displayName).toBe('John')
+    expect(row.name).toBeUndefined()
+  })
+})

--- a/website/docs/error-handling.md
+++ b/website/docs/error-handling.md
@@ -218,8 +218,8 @@ try {
 | `MISSING_STORE` | `MissingStoreError` | Table config without matching store |
 | `VALIDATION_ERROR` | `ValidationError` | Input validation failure |
 | `INVALID_OPERATOR` | `InvalidOperatorError` | Invalid operator in where clause |
-| `UNKNOWN_COLUMN` | `UnknownColumnError` | `addColumn` for a column outside the store schema |
-| `SCHEMA_MISMATCH` | `SchemaMismatchError` | Sheet header contradicts the declared columns |
+| `UNKNOWN_COLUMN` | `UnknownColumnError` | `addColumn`, or `renameColumn`'s new name, for a column outside the store schema |
+| `SCHEMA_MISMATCH` | `SchemaMismatchError` | Sheet header contradicts the declared columns (also raised by `renameColumn`/`removeColumn` when the physical layout does not match) |
 | `MIGRATION_VERSION_ERROR` | `MigrationVersionError` | Invalid migration version |
 | `MIGRATION_EXECUTION_ERROR` | `MigrationExecutionError` | Migration up/down failure |
 | `NO_MIGRATIONS_TO_ROLLBACK` | `NoMigrationsToRollbackError` | Rollback with no applied migrations |

--- a/website/docs/migration-system.md
+++ b/website/docs/migration-system.md
@@ -76,6 +76,58 @@ is a no-op rather than a full rewrite of the table. In-memory stores
 position: they accept any column, and the backfill goes through a single
 `batchUpdate`.
 
+### How `renameColumn` is applied
+
+On `SheetsAdapter` a rename is a **header rewrite**, not a data move: the value
+already sits in the right column, only its name is wrong.
+
+- **New name declared, old name gone** (the schema a deploy ships once its types
+  are regenerated) — the migration rewrites that one header cell. No row is
+  touched, so the cost is a single write no matter how large the table is, and a
+  re-run writes nothing.
+- **New name not declared** — `UnknownColumnError`. Regenerate your types (or
+  add the column to the schema) and re-run.
+- **The header cell holds neither name** — `SchemaMismatchError`, because the
+  sheet is not laid out the way the schema says and rewriting would mislabel a
+  live column.
+- **Both names declared** — the two columns are real and distinct, so the header
+  stays and the values move across (only where the source has a value and the
+  target is empty), as a ranged read plus two ranged writes.
+
+In-memory stores have no header: there, the rename *is* the value move.
+
+Because the declared columns decide the layout, roll a rename back **under the
+schema that rollback targets** — deploy the previous schema, then run
+`rollback()`. A `down: (db) => db.renameColumn(newName, oldName)` executed while
+the store still declares `newName` raises `UnknownColumnError` instead of
+writing anything.
+
+### How `removeColumn` is applied
+
+:::danger Destructive — no undo
+Removing a column deletes its values along with it. A `down` migration can
+re-create the column, but **nothing can restore the data that was in it**. Take a
+copy of the sheet before running a removal against production.
+:::
+
+- **Not declared in `columns`** (the post-removal schema) — the migration
+  deletes the physical column, and the columns to its right shift left with
+  their data. This is what keeps the deploy that no longer knows the column
+  reading its own values: a column left behind would make every field to its
+  right read the neighbour's cell and write into the abandoned one.
+- **Still declared in `columns`** — the column is part of the store's positional
+  map, so dropping it would misalign this very deploy. Its values are cleared
+  with one ranged write and the column stays; the physical delete happens under
+  the deploy whose schema no longer declares it. This is also what makes
+  `down: (db) => db.removeColumn(...)` usable as the rollback of an `addColumn`.
+- **Already gone from the sheet** — a no-op, so re-runs converge.
+- **The rest of the header would not match the schema after the delete** —
+  `SchemaMismatchError`, for the same reason as `addColumn`: shifting a
+  misaligned sheet would move live data under the wrong headers.
+
+In-memory stores have no physical column to drop: there, the removal clears the
+key on every row.
+
 ## MigrationRunner
 
 ### Creating a Runner


### PR DESCRIPTION
## Summary

Fixes #180 (real-GAS confirmed: rename left header≠schema; remove left a ghost column that misaligned the next deploy). Completes the #127 pattern for the remaining schema ops:

- **`renameColumn(old, new)`** — physical header-cell rewrite when the header at `new`'s schema position reads `old`; no-op when already renamed (converges); `UnknownColumnError` when `new` isn't declared (the old value path silently destroyed data in exactly this case); `SchemaMismatchError` on any other header. Deliberate degradation: when **both** names are declared, the columns are genuinely distinct in this layout, so it stays a value move (target-first write order) — preserving the existing `[#112]` parity pin.
- **`removeColumn(col)`** — physical `deleteColumn` when the column is absent from the declared (post-removal) schema but present in the header, after validating the surrounding alignment; idempotent no-op when already gone. Deliberately **not** physical while still declared (that would misalign this very adapter — it clears values instead, keeping the `up: addColumn / down: removeColumn` rollback pattern working); the remaining hand-edit hole is exactly what #179's header guard catches. Destructive contract documented with a `:::danger` block in the wiki.
- `MigrationRunner` probes the new optional `DataStore.renameColumn?`/`removeColumn?` capabilities (additive), value-level fallback intact for name-keyed stores; `FakeSheet` gains GAS-parity `deleteColumn`.

**Pin flip**: e2e S4 now asserts the physical chain (header `['id','displayName','legacy','status']` after rename, `['id','displayName','status']` after remove, aligned data, correct post-op reads/writes, byte-identical reruns). Parity suite keeps its four value-level pins and gains two `[#180]` asymmetry cases.

Red-then-green: 12 new-unit failures pre-change → 55 green; e2e local check fails with `v2.renameColumn is not a function` when the fix is stashed. Suite: core 709, all packages green; `migration-add-column.test.ts` untouched.

## Related Issues

Closes #180

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated (23 new)
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_