### PR TITLE
fix(core): flush on lock acquisition to synchronize reads inside the critical section (#186)

### DIFF
--- a/packages/core/src/core/script-lock.ts
+++ b/packages/core/src/core/script-lock.ts
@@ -87,6 +87,14 @@ export function withScriptLock<R>(fn: () => R, timeoutMs: number = DEFAULT_LOCK_
 
   const lock = acquireLock(timeoutMs)
   lockDepth++
+  // Synchronize this execution's view before the critical section reads:
+  // another execution's flush-on-release guarantees its writes committed,
+  // but not that OUR first read inside the lock observes them — a stale
+  // read here minted a duplicate auto id once in 50 contended inserts on
+  // the live platform (#186). flush() also refreshes the read state, so
+  // the canonical GAS pattern is lock -> flush -> read -> write -> flush
+  // -> release.
+  flushPendingWrites()
   try {
     return fn()
   } finally {
@@ -118,6 +126,8 @@ export async function withScriptLockAsync<R>(
 
   const lock = acquireLock(timeoutMs)
   lockDepth++
+  // See withScriptLock: synchronize the view on acquisition (#186).
+  flushPendingWrites()
   try {
     return await fn()
   } finally {

--- a/packages/core/tests/unit/flush-before-unlock.test.ts
+++ b/packages/core/tests/unit/flush-before-unlock.test.ts
@@ -5,8 +5,9 @@
  * the live platform by the E2E burst test: 2×25 locked inserts → 49 rows,
  * both callers reporting success).
  *
- * These tests pin the ordering contract: flush() is invoked inside the
- * critical section boundary, strictly before releaseLock().
+ * These tests pin the ordering contract: flush() runs right after the
+ * outermost acquisition (synchronizing this execution's view, #186) and
+ * again strictly before releaseLock() (committing our writes, #164).
  */
 import { afterEach, describe, expect, it } from 'vitest'
 import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
@@ -68,7 +69,7 @@ describe('flush before unlock (#164)', () => {
       recorder.events.push('work')
     })
 
-    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+    expect(recorder.events).toEqual(['acquire', 'flush', 'work', 'flush', 'release'])
   })
 
   it('withScriptLock flushes even when the callback throws', () => {
@@ -82,7 +83,7 @@ describe('flush before unlock (#164)', () => {
       })
     ).toThrow('boom')
 
-    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+    expect(recorder.events).toEqual(['acquire', 'flush', 'work', 'flush', 'release'])
   })
 
   it('withScriptLockAsync flushes before releasing', async () => {
@@ -93,7 +94,7 @@ describe('flush before unlock (#164)', () => {
       recorder.events.push('work')
     })
 
-    expect(recorder.events).toEqual(['acquire', 'work', 'flush', 'release'])
+    expect(recorder.events).toEqual(['acquire', 'flush', 'work', 'flush', 'release'])
   })
 
   it('nested locks flush once, at the outermost release', () => {
@@ -107,7 +108,7 @@ describe('flush before unlock (#164)', () => {
       recorder.events.push('outer')
     })
 
-    expect(recorder.events).toEqual(['acquire', 'inner', 'outer', 'flush', 'release'])
+    expect(recorder.events).toEqual(['acquire', 'flush', 'inner', 'outer', 'flush', 'release'])
   })
 
   it('SheetsAdapter.insert commits its append before the lock is released', () => {


### PR DESCRIPTION
## Summary

Live gas-e2e run 31329462753 caught a duplicate auto id under contention: the burst step produced **50 rows but only 49 unique ids**. The #164 fix (flush-before-release) guarantees the previous lock holder's writes are committed, but not that the **next** holder's first read inside the lock observes them — SpreadsheetApp can serve that read from the new execution's stale view, so two executions computed the same `max(id)` and minted the same auto id.

This completes the canonical GAS locking pattern by also flushing **immediately after the outermost lock acquisition**:

```
lock → flush → read → write → flush → release
```

## Changes

- `packages/core/src/core/script-lock.ts`: `withScriptLock` and `withScriptLockAsync` call `flushPendingWrites()` right after the outermost `acquireLock()`, synchronizing this execution's read view before the critical section reads. Nested (re-entrant) calls are unaffected — they flush neither on entry nor exit, same as before.
- `packages/core/tests/unit/flush-before-unlock.test.ts`: ordering contract pinned as `['acquire', 'flush', 'work', 'flush', 'release']` (nested: `['acquire', 'flush', 'inner', 'outer', 'flush', 'release']`), with the header doc now citing both #164 and #186.

## Verification

- 31 tests green across `flush-before-unlock`, `concurrent-write-locking`, `sheet-creation-race`
- Full `@gsquery/core` suite green (46 files); `pnpm -r typecheck` clean
- Statistical live validation: the gas-e2e `burst` step (2×25 contended locked inserts, asserts 50 rows / 50 unique ids) runs on every dev push touching `packages/**` — this being a rare race (1 duplicate in 50 on the reproducing run), each future run adds confidence rather than a single run proving it

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_