### PR TITLE
chore: use workspace:^ for @gsquery/core internal dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "@gsquery/core": "workspace:*"
+    "@gsquery/core": "workspace:^"
   },
   "engines": {
     "node": ">=18"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -40,7 +40,7 @@
     "directory": "packages/client"
   },
   "dependencies": {
-    "@gsquery/core": "workspace:*"
+    "@gsquery/core": "workspace:^"
   },
   "devDependencies": {
     "@types/google-apps-script": "^2.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
   packages/cli:
     dependencies:
       '@gsquery/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       chokidar:
         specifier: ^4.0.3
@@ -68,7 +68,7 @@ importers:
   packages/client:
     dependencies:
       '@gsquery/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/google-apps-script':


### PR DESCRIPTION
## Summary

Release-prep for v1.0.0. `pnpm publish` replaces the `workspace:` protocol at pack time: `workspace:*` becomes the **exact** version (`1.0.0`), while `workspace:^` becomes `^1.0.0`. With exact pinning, any future patch release where `@gsquery/cli` or `@gsquery/client` lags `@gsquery/core` by one publish would force consumers into version conflicts. Caret ranges let published packages accept compatible core versions.

## Changes

- `packages/cli/package.json`: peerDependency `@gsquery/core` → `workspace:^`
- `packages/client/package.json`: dependency `@gsquery/core` → `workspace:^`
- `pnpm-lock.yaml`: regenerated for the specifier change (resolution unchanged — still links the workspace package)
- `e2e/gas` keeps `workspace:*` — it's a private harness, never published

## Verification

- `pnpm -r typecheck` clean
- Full test suite green (core 46 files, client 15 files / 192 tests)
- `pnpm install --frozen-lockfile` satisfied after lockfile regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_