### PR TITLE
fix(core): allocate auto ids from a persistent monotonic counter (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Google Sheets is not a database engine — know what you're trading:
 - **Local-first client is single-tab** — two tabs sharing the same namespace can clobber each other's queued mutations.
 - **Formula escaping is on by default** — user-supplied strings are stored as literal text (never executed as formulas); opt out per adapter with `allowFormulas: true` if you intentionally store formulas.
 - **Columns are mapped by position** — if somebody inserts or reorders a column in the sheet, the layout no longer matches the schema. Every read and write checks the header row once per execution and throws `SchemaMismatchError` instead of silently reading and writing the wrong columns; opt out per adapter with `skipHeaderCheck: true`.
+- **A hidden `_gsquery_meta` sheet holds id counters** — auto `idMode` persists a per-table monotonic counter there so a deleted row's id is never reused (expect gaps after deletions, like any SQL auto-increment). Deleting the sheet is safe: it is recreated and the counter re-bootstraps from the current max.
 
 ## 🤖 AI Coding Assistants
 

--- a/e2e/gas/README.md
+++ b/e2e/gas/README.md
@@ -99,6 +99,7 @@ pnpm --filter @gsquery/gas-e2e-harness build       # produces dist/Code.js
 |---|---|
 | `formula escape` test fails only in GAS | The `USER_ENTERED` apostrophe assumption in `escapeCellValue`/`unescapeCellValue` doesn't match real Sheets — a real finding, fix the adapter |
 | `burstCheck` reports duplicate ids | Real `LockService` isn't protecting the insert path — regression of #128 |
+| `auto ids are never reused` fails | The persistent id counter (#177) regressed — allocation fell back to `max+1`, or the `_gsquery_meta` read/write inside the lock is broken |
 | `date columnType` fails only in GAS | Timezone/serial-number coercion differs from the fakes — extend `deserializeByType` |
 | `mixedCheck` reports `contaminated` rows | A write landed on a row number resolved before a concurrent delete shifted it — the stale-index race of #128/#155 |
 | `mixedCheck` reports `wrongStates`/`missingSlots` | An update, delete or batchUpdate was silently lost under contention |

--- a/e2e/gas/src/main.ts
+++ b/e2e/gas/src/main.ts
@@ -66,6 +66,7 @@ function cleanupRunSheets(spreadsheetId: string, runId: string): void {
         ss.deleteSheet(sheet)
       }
     }
+    purgeMetaRows(ss, `e2e_${runId}_`)
   } catch {
     // Cleanup is best-effort; leftover sheets are removed by ?action=cleanup.
   }
@@ -94,7 +95,38 @@ function deleteAllE2ESheets(spreadsheetId: string): number {
       deleted++
     }
   }
+  purgeMetaRows(ss, 'e2e_')
   return deleted
+}
+
+/**
+ * Drops `_gsquery_meta` id-counter rows (#177) belonging to deleted e2e
+ * tables, so the shared test spreadsheet's meta sheet doesn't accumulate a
+ * row per run forever. Best-effort and bottom-up (deleteRow shifts rows up).
+ */
+function purgeMetaRows(ss: unknown, prefix: string): void {
+  try {
+    const container = ss as {
+      getSheetByName?: (name: string) => {
+        getLastRow: () => number
+        getRange: (r: number, c: number, nr: number, nc: number) => { getValues: () => unknown[][] }
+        deleteRow: (r: number) => void
+      } | null
+    }
+    if (typeof container.getSheetByName !== 'function') return
+    const meta = container.getSheetByName('_gsquery_meta')
+    if (!meta) return
+    const lastRow = meta.getLastRow()
+    if (lastRow < 2) return
+    const tables = meta.getRange(2, 1, lastRow - 1, 1).getValues()
+    for (let i = tables.length - 1; i >= 0; i--) {
+      if (String(tables[i][0]).indexOf(prefix) === 0) {
+        meta.deleteRow(i + 2)
+      }
+    }
+  } catch {
+    // Leftover counter rows are harmless; never fail a run over cleanup.
+  }
 }
 
 /**

--- a/e2e/gas/src/tests.ts
+++ b/e2e/gas/src/tests.ts
@@ -139,6 +139,23 @@ export function registerTests(ctx: HarnessContext): void {
     assertEq(adapter.findAll().length, 1, 'one row remains')
   })
 
+  // ── 3b. Monotonic auto ids (#177) ─────────────────────────────────────────
+  test('auto ids are never reused after deleting the max row (#177)', () => {
+    const adapter = makeAdapter('noreuse', ['id', 'name'])
+    adapter.insert({ name: 'a' })
+    adapter.insert({ name: 'b' })
+    const c = adapter.insert({ name: 'c' })
+
+    adapter.delete(c.id)
+    const d = adapter.insert({ name: 'd' })
+    assertOk(Number(d.id) > Number(c.id), `id ${d.id} allocated after deleted max ${c.id} — no reuse`)
+
+    // Delete everything: the persisted counter must outlive the data.
+    for (const row of adapter.findAll()) adapter.delete(row.id)
+    const e = adapter.insert({ name: 'e' })
+    assertOk(Number(e.id) > Number(d.id), `id ${e.id} still moves forward on an emptied table`)
+  })
+
   // ── 4. Client-mode duplicate ID rejection (#128) ─────────────────────────
   test('client idMode: duplicate ID insert throws DuplicateIdError', () => {
     const adapter = makeAdapter('dup', ['id', 'name'], { idMode: 'client' })

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -54,6 +54,25 @@ const TEXT_PREFIX = "'"
  */
 export const MAX_CELL_LENGTH = 50000
 
+/**
+ * Hidden sheet that persists per-table monotonic id counters (#177).
+ *
+ * Auto-mode ids used to be `max(current ids) + 1`, so deleting the
+ * highest-numbered row freed its id for the very next insert — and any
+ * foreign key still holding that id silently re-pointed at the new record
+ * (deterministic repro in the S7 referential-integrity scenario). The
+ * counter lives in the spreadsheet itself, not PropertiesService, because
+ * the sheet is the database: a second script project opening the same
+ * spreadsheet must see the same counter, and a copied spreadsheet must
+ * carry it along.
+ *
+ * Layout: header `[table, nextId]`, one row per table. Missing sheet or
+ * row just means "no counter yet" — allocation bootstraps from the current
+ * max and only ever moves forward, so a user deleting this sheet degrades
+ * to pre-counter behavior until the next insert recreates it.
+ */
+export const META_SHEET_NAME = '_gsquery_meta'
+
 /** SheetsAdapter configuration options */
 export interface SheetsAdapterOptions {
   /** Spreadsheet ID (optional - uses active spreadsheet if not provided) */
@@ -166,6 +185,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
 
   // Sheet reference cache
   private _sheet: GoogleAppsScript.Spreadsheet.Sheet | null = null
+  private _metaSheet: GoogleAppsScript.Spreadsheet.Sheet | null = null
   private _spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet | null = null
   // Data cache - invalidated on write operations
   private _dataCache: T[] | null = null
@@ -284,6 +304,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   /** Clear all caches (sheet references and data) */
   clearCache(): void {
     this._sheet = null
+    this._metaSheet = null
     this._spreadsheet = null
     this._dataCache = null
     // The sheet may have been edited since the last check — re-arm the guard.
@@ -672,12 +693,95 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   }
 
   /**
-   * Get the next available ID by scanning the current max.
-   * Must be called inside withLock() together with the row write so that
-   * ID allocation and the write are atomic.
+   * Resolve the {@link META_SHEET_NAME} sheet, creating it on first use.
+   *
+   * Creation follows the #178 pattern exactly (locked re-check through a
+   * fresh handle, adopt-on-failure, no matching of localized error text) —
+   * two executions inserting into a spreadsheet that has no meta sheet yet
+   * race on insertSheet the same way they race on a not-yet-created table.
    */
-  private getNextId(): number {
-    return this.readMaxId() + 1
+  private getMetaSheet(): GoogleAppsScript.Spreadsheet.Sheet {
+    if (this._metaSheet) return this._metaSheet
+
+    const ss = this.getSpreadsheet()
+    let sheet = this.sheetsCall(() => ss.getSheetByName(META_SHEET_NAME))
+
+    if (!sheet) {
+      sheet = this.withLock(() => {
+        const fresh = this.reopenSpreadsheet()
+        const existing = this.sheetsCall(() => fresh.getSheetByName(META_SHEET_NAME))
+        if (existing) return existing
+        try {
+          const created = this.sheetsCallOnce(() => fresh.insertSheet(META_SHEET_NAME))
+          this.sheetsCall(() => created.getRange(1, 1, 1, 2).setValues([['table', 'nextId']]))
+          // Cosmetic only, and not implemented by the testing fakes.
+          if (typeof created.hideSheet === 'function') {
+            try {
+              created.hideSheet()
+            } catch {
+              // A hidden-sheet restriction must not fail the insert.
+            }
+          }
+          return created
+        } catch (err) {
+          const adopted = this.sheetsCall(() => this.reopenSpreadsheet().getSheetByName(META_SHEET_NAME))
+          if (adopted) return adopted
+          throw err
+        }
+      })
+    }
+
+    this._metaSheet = sheet
+    return sheet
+  }
+
+  /**
+   * Allocate `count` consecutive auto ids and persist the advanced counter,
+   * returning the first id of the run (#177).
+   *
+   * `max(stored, current max + 1)` is what makes the counter self-healing:
+   * a missing sheet/row (first use on an existing table, or a user deleted
+   * the meta sheet) bootstraps from the data, and a manually entered high id
+   * is absorbed instead of colliding. The one accepted limit: deletions that
+   * happened BEFORE the counter first existed cannot be compensated
+   * retroactively.
+   *
+   * Must be called inside withLock() together with the row write — the
+   * read-allocate-persist sequence is exactly the kind of critical section
+   * the lock exists for, and flush-on-acquire (#186) keeps the meta read
+   * fresh across executions.
+   */
+  private allocateAutoIds(count: number): number {
+    const meta = this.getMetaSheet()
+    const lastRow = meta.getLastRow()
+
+    let rowIndex = -1
+    let stored = 0
+    if (lastRow >= 2) {
+      const rows = this.sheetsCall(() => meta.getRange(2, 1, lastRow - 1, 2).getValues())
+      for (let i = 0; i < rows.length; i++) {
+        if (String(rows[i][0]) === this.sheetName) {
+          rowIndex = i + 2
+          const value = Number(rows[i][1])
+          if (!isNaN(value)) stored = value
+          break
+        }
+      }
+    }
+
+    const first = Math.max(stored, this.readMaxId() + 1)
+    const next = first + count
+
+    if (rowIndex === -1) {
+      // A spurious-failure retry could append a duplicate table row; the
+      // lookup above takes the first match, and max() with the live data
+      // keeps a stale duplicate harmless — but don't create one knowingly.
+      this.sheetsCallOnce(() => meta.appendRow([this.sheetName, next]))
+    } else {
+      this.sheetsCall(() => meta.getRange(rowIndex, 2).setValues([[next]]))
+    }
+
+    return first
   }
 
   /** Read the current max ID from the sheet */
@@ -806,7 +910,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
       // Auto mode: allocate the ID and write the row atomically under the lock,
       // otherwise concurrent executions can allocate the same ID.
       return this.withLock(() => {
-        const id = this.getNextId()
+        const id = this.allocateAutoIds(1)
         const newRow = { ...data, [this.idColumn]: id } as T
         const rowValues = this.objectToRow(newRow)
         this.sheetsCallOnce(() => sheet.appendRow(rowValues))
@@ -917,7 +1021,8 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
     return this.withLock(() => {
       const results: T[] = []
       const rowsToInsert: unknown[][] = []
-      let nextId = this.getNextId()
+      // One counter read/write covers the whole batch (#177).
+      let nextId = this.allocateAutoIds(items.length)
       for (const data of items) {
         const newRow = { ...data, [this.idColumn]: nextId } as T
         results.push(newRow)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ export type { SheetsDB, TableHandle, CreateSheetsDBOptions, DefineSheetsDBOption
 // Adapters
 export { MockAdapter } from './adapters/mock-adapter'
 export type { MockAdapterOptions } from './adapters/mock-adapter'
-export { SheetsAdapter, MAX_CELL_LENGTH } from './adapters/sheets-adapter'
+export { SheetsAdapter, MAX_CELL_LENGTH, META_SHEET_NAME } from './adapters/sheets-adapter'
 export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter'
 
 // Query utilities

--- a/packages/core/src/testing/fake-spreadsheet.ts
+++ b/packages/core/src/testing/fake-spreadsheet.ts
@@ -1,6 +1,7 @@
 /**
  * FakeSpreadsheet — named-sheet container mirroring GAS `Spreadsheet`'s
- * allowlisted surface (`getSheetByName`, `insertSheet`, `getSheets`, `getName`).
+ * allowlisted surface (`getSheetByName`, `insertSheet`, `deleteSheet`,
+ * `getSheets`, `getName`).
  */
 import { FakeSheet } from './fake-sheet'
 
@@ -30,6 +31,22 @@ export class FakeSpreadsheet {
     const sheet = new FakeSheet(name)
     this.sheets.set(name, sheet)
     return sheet
+  }
+
+  /**
+   * Removes a sheet. Throws when the sheet is not part of this spreadsheet or
+   * when it is the last remaining sheet (GAS parity — a spreadsheet always
+   * keeps at least one sheet).
+   */
+  deleteSheet(sheet: FakeSheet): void {
+    const name = sheet.getName()
+    if (this.sheets.get(name) !== sheet) {
+      throw new Error(`deleteSheet: sheet "${name}" does not belong to this spreadsheet`)
+    }
+    if (this.sheets.size === 1) {
+      throw new Error('deleteSheet: a spreadsheet must contain at least one sheet')
+    }
+    this.sheets.delete(name)
   }
 
   /** Sheets in insertion order. */

--- a/packages/core/tests/scenario/referential-integrity.scenario.test.ts
+++ b/packages/core/tests/scenario/referential-integrity.scenario.test.ts
@@ -7,14 +7,13 @@
  * into a SheetsDB and queried with `joinQuery()`.
  *
  * The scenario exercises the interaction nobody tests in isolation: `auto` ids
- * are allocated as `max(id) + 1` (SheetsAdapter.getNextId), so deleting the
- * highest-numbered row hands its id straight to the next insert. Any row in
- * another table still pointing at the deleted id silently re-points at the new
- * occupant. Nothing in the library detects this — there are no foreign keys,
- * no cascade, and no tombstones.
- *
- * These tests pin the behavior as it is today; they do not assert what a
- * relational database would do.
+ * used to be allocated as `max(id) + 1`, so deleting the highest-numbered row
+ * handed its id straight to the next insert, and any row in another table
+ * still pointing at the deleted id silently re-pointed at the new occupant
+ * (#177). Since the fix, allocation goes through a persistent monotonic
+ * counter (the `_gsquery_meta` sheet), so a deleted id is never re-issued: the
+ * orphaned FK stays a visible orphan (left join → null, inner join → dropped)
+ * instead of silently rebinding.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { SheetsAdapter, createSheetsDB } from '../../src/index'
@@ -145,16 +144,16 @@ describe('S7 referential integrity under id reuse', () => {
   })
 
   it(
-    'silently re-points an orphaned order at the new owner of a reused id ' +
-      '[documents: id-reuse-dangling-join]',
+    'never hands a deleted max id to a new insert — the orphan stays visible ' +
+      '[regression: #177]',
     () => {
       harness = setupHarness()
       const { db } = harness
 
       seedUsersAndOrders(db)
 
-      // Eve is the highest-numbered user. Deleting her frees id 5 — auto mode
-      // allocates max(id) + 1, and after the delete max(id) is 4.
+      // Eve is the highest-numbered user. Deleting her used to free id 5 for
+      // the very next insert (allocation was max(id) + 1).
       db.from('users').delete(5)
       expect(db.from('users').findAll().map(u => u.id)).toEqual([1, 2, 3, 4])
 
@@ -163,43 +162,39 @@ describe('S7 referential integrity under id reuse', () => {
       expect(db.from('users').repo.exists(5)).toBe(false)
       expect(joinedUser(ordersWithUser(db)[4])).toBeNull()
 
-      // A brand-new, unrelated signup. No error, no warning: it receives the
-      // id the deleted user used to own.
+      // A brand-new, unrelated signup. The persistent counter remembers id 5
+      // was issued, so Frank gets 6 — Eve's order cannot rebind to him.
       const frank = db.from('users').create({ name: 'Frank', email: 'frank@corp.test' })
-      expect(frank.id).toBe(5)
+      expect(frank.id).toBe(6)
 
       const joined = ordersWithUser(db)
 
-      // THE DEFECT: order 5 was Eve's. It now reports Frank as its user, with
-      // no error, no null, and no way for the caller to tell.
+      // Order 5 remains a loud, honest orphan instead of silently becoming
+      // Frank's — this exact rebinding happened before the fix.
       expect(joined[4]).toEqual({
         id: 5,
         userId: 5,
         item: 'item-5',
         amount: 50,
-        user: { id: 5, name: 'Frank', email: 'frank@corp.test' },
+        user: null,
       })
-      expect(joinedUser(joined[4])?.name).toBe('Frank')
 
-      // Every other order is unaffected, so nothing about the result set looks
-      // suspicious — the corruption is a single silently-rebound row.
-      expect(joined.map(o => [o.id, joinedUser(o)?.name])).toEqual([
+      expect(joined.map(o => [o.id, joinedUser(o)?.name ?? null])).toEqual([
         [1, 'Alice'],
         [2, 'Bob'],
         [3, 'Carol'],
         [4, 'Dave'],
-        [5, 'Frank'],
+        [5, null],
       ])
 
-      // An inner join keeps it too: the FK resolves, so it is not filtered out.
+      // The inner join drops the orphan rather than resolving it to Frank.
       const inner = db
         .from('orders')
         .joinQuery()
         .innerJoin('users', 'userId', 'id', { as: 'user' })
         .orderBy('id')
         .exec()
-      expect(inner).toHaveLength(5)
-      expect(joinedUser(inner[4])?.name).toBe('Frank')
+      expect(inner.map(o => o.id)).toEqual([1, 2, 3, 4])
     }
   )
 
@@ -263,25 +258,24 @@ describe('S7 referential integrity under id reuse', () => {
     ).toBe(4)
   })
 
-  it('reuses the id again after the reused row is itself deleted', () => {
+  it('keeps ids unique under repeated delete-max churn [regression: #177]', () => {
     harness = setupHarness()
     const { db } = harness
 
     seedUsersAndOrders(db)
 
-    // Repeated churn at the tail keeps handing out the same id, so a table
-    // that only ever appends at the end can bind one FK value to a whole
-    // sequence of unrelated records over its lifetime.
+    // Repeated churn at the tail used to hand out id 5 over and over, binding
+    // one FK value to a whole sequence of unrelated records. The counter only
+    // moves forward: every re-signup gets a fresh id.
+    let expected = 5
     for (const name of ['Frank', 'Grace', 'Heidi']) {
-      db.from('users').delete(5)
+      db.from('users').delete(expected)
       const created = db.from('users').create({ name, email: `${name.toLowerCase()}@corp.test` })
-      expect(created.id).toBe(5)
+      expected += 1
+      expect(created.id).toBe(expected)
     }
 
-    expect(joinedUser(ordersWithUser(db)[4])).toEqual({
-      id: 5,
-      name: 'Heidi',
-      email: 'heidi@corp.test',
-    })
+    // Eve's order still points at id 5, which no user ever holds again.
+    expect(joinedUser(ordersWithUser(db)[4])).toBeNull()
   })
 })

--- a/packages/core/tests/unit/monotonic-auto-id.test.ts
+++ b/packages/core/tests/unit/monotonic-auto-id.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #177 — auto ids must never be reused, whatever was deleted.
+ *
+ * Allocation used to be `max(current ids) + 1`, so deleting the
+ * highest-numbered row freed its id for the very next insert and any foreign
+ * key still holding that id silently re-pointed at the new record. Ids are
+ * now allocated from a persistent monotonic counter stored in the
+ * spreadsheet's hidden `_gsquery_meta` sheet, as `max(stored, max + 1)` —
+ * forward-only, and self-healing when the meta sheet or row is missing.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { META_SHEET_NAME, SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { FakeSpreadsheet, installGasFakes, fromArrays } from '../../src/testing'
+
+interface Row {
+  id: number
+  name: string
+  [key: string]: unknown
+}
+
+interface ClientRow {
+  id: string
+  name: string
+  [key: string]: unknown
+}
+
+let restore: (() => void) | undefined
+
+function setup(spreadsheet?: FakeSpreadsheet): FakeSpreadsheet {
+  const ss = spreadsheet ?? new FakeSpreadsheet('S')
+  const handle = installGasFakes({ spreadsheets: { S: ss }, activeId: 'S' })
+  restore = () => handle.restore()
+  return ss
+}
+
+function makeAdapter(): SheetsAdapter<Row> {
+  return new SheetsAdapter<Row>({ spreadsheetId: 'S', sheetName: 'users', columns: ['id', 'name'] })
+}
+
+afterEach(() => {
+  restore?.()
+  restore = undefined
+})
+
+describe('monotonic auto ids (#177)', () => {
+  it('does not reuse the id of a deleted max row', () => {
+    setup()
+    const adapter = makeAdapter()
+
+    adapter.insert({ name: 'a' })
+    adapter.insert({ name: 'b' })
+    const c = adapter.insert({ name: 'c' })
+    expect(c.id).toBe(3)
+
+    adapter.delete(3)
+    const d = adapter.insert({ name: 'd' })
+
+    // Pre-fix this was 3 again — the exact FK-rebinding hazard of #177.
+    expect(d.id).toBe(4)
+    expect(adapter.findAll().map(r => r.id)).toEqual([1, 2, 4])
+  })
+
+  it('survives delete-all: the counter outlives the data', () => {
+    setup()
+    const adapter = makeAdapter()
+
+    adapter.batchInsert([{ name: 'a' }, { name: 'b' }, { name: 'c' }])
+    for (const id of [1, 2, 3]) adapter.delete(id)
+    expect(adapter.findAll()).toEqual([])
+
+    // An empty sheet used to reset allocation to 1.
+    expect(adapter.insert({ name: 'fresh' }).id).toBe(4)
+  })
+
+  it('batchInsert reserves one contiguous run and advances the counter past it', () => {
+    setup()
+    const adapter = makeAdapter()
+
+    const batch = adapter.batchInsert([{ name: 'a' }, { name: 'b' }, { name: 'c' }])
+    expect(batch.map(r => r.id)).toEqual([1, 2, 3])
+
+    adapter.delete(3)
+    expect(adapter.insert({ name: 'd' }).id).toBe(4)
+  })
+
+  it('bootstraps from existing data when no counter exists yet', () => {
+    const spreadsheet = fromArrays(
+      {
+        users: [
+          ['id', 'name'],
+          [7, 'legacy']
+        ]
+      },
+      'S'
+    )
+    setup(spreadsheet)
+    const adapter = makeAdapter()
+
+    // First allocation on a pre-counter sheet continues after the current max.
+    expect(adapter.insert({ name: 'new' }).id).toBe(8)
+    // ...and from here on the counter protects deletions.
+    adapter.delete(8)
+    expect(adapter.insert({ name: 'newer' }).id).toBe(9)
+  })
+
+  it('self-heals when a user deletes the meta sheet: moves forward, never back', () => {
+    const spreadsheet = setup()
+    const adapter = makeAdapter()
+
+    adapter.batchInsert([{ name: 'a' }, { name: 'b' }])
+    expect(spreadsheet.getSheetByName(META_SHEET_NAME)).not.toBeNull()
+
+    spreadsheet.deleteSheet(spreadsheet.getSheetByName(META_SHEET_NAME)!)
+    adapter.clearCache()
+
+    // Degrades to max+1 (the pre-counter behavior) and recreates the sheet.
+    expect(adapter.insert({ name: 'c' }).id).toBe(3)
+    expect(spreadsheet.getSheetByName(META_SHEET_NAME)).not.toBeNull()
+  })
+
+  it('absorbs a manually entered id above the counter instead of colliding', () => {
+    const spreadsheet = setup()
+    const adapter = makeAdapter()
+
+    adapter.insert({ name: 'a' })
+    // A human types a row with id 100 straight into the sheet.
+    spreadsheet.getSheetByName('users')!.appendRow([100, 'manual'])
+    adapter.clearCache()
+
+    expect(adapter.insert({ name: 'b' }).id).toBe(101)
+  })
+
+  it('keeps per-table counters independent on one spreadsheet', () => {
+    setup()
+    const users = makeAdapter()
+    const orders = new SheetsAdapter<Row>({
+      spreadsheetId: 'S',
+      sheetName: 'orders',
+      columns: ['id', 'name']
+    })
+
+    users.batchInsert([{ name: 'u1' }, { name: 'u2' }, { name: 'u3' }])
+    expect(orders.insert({ name: 'o1' }).id).toBe(1)
+    users.delete(3)
+    expect(users.insert({ name: 'u4' }).id).toBe(4)
+    expect(orders.insert({ name: 'o2' }).id).toBe(2)
+  })
+
+  it('a second adapter instance on the same table sees the same counter', () => {
+    setup()
+    const first = makeAdapter()
+
+    first.insert({ name: 'a' })
+    first.insert({ name: 'b' })
+    first.delete(2)
+
+    // A different execution (new adapter instance) must not re-issue id 2 —
+    // this is why the counter lives in the spreadsheet, not in memory.
+    const second = makeAdapter()
+    expect(second.insert({ name: 'c' }).id).toBe(3)
+  })
+
+  it('client idMode never touches the counter or the meta sheet', () => {
+    const spreadsheet = setup()
+    const adapter = new SheetsAdapter<ClientRow>({
+      spreadsheetId: 'S',
+      sheetName: 'docs',
+      columns: ['id', 'name'],
+      idMode: 'client'
+    })
+
+    adapter.insert({ id: 'uuid-1', name: 'a' })
+    adapter.batchInsert([{ id: 'uuid-2', name: 'b' }])
+
+    expect(spreadsheet.getSheetByName(META_SHEET_NAME)).toBeNull()
+  })
+})

--- a/packages/core/tests/unit/sheet-creation-race.test.ts
+++ b/packages/core/tests/unit/sheet-creation-race.test.ts
@@ -13,8 +13,16 @@
  * a second creation.
  */
 import { afterEach, describe, expect, it } from 'vitest'
-import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { META_SHEET_NAME, SheetsAdapter } from '../../src/adapters/sheets-adapter'
 import { FakeSpreadsheet, installGasFakes } from '../../src/testing'
+
+/** Sheet names present, sorted — auto inserts also create the #177 meta sheet. */
+function sheetNames(spreadsheet: FakeSpreadsheet): string[] {
+  return spreadsheet
+    .getSheets()
+    .map(s => s.getName())
+    .sort()
+}
 
 interface Row {
   id: number
@@ -68,8 +76,9 @@ describe('sheet auto-creation race (#178)', () => {
     expect(rows.map(r => r.name).sort()).toEqual(['loser-row', 'winner-row'])
     expect(rows.find(r => r.id === inserted.id)?.name).toBe('loser-row')
 
-    // Exactly one physical sheet was created.
-    expect(spreadsheet.getSheets().length).toBe(1)
+    // Exactly one physical 'users' sheet was created (plus the id-counter
+    // meta sheet that auto-mode inserts maintain, #177).
+    expect(sheetNames(spreadsheet)).toEqual([META_SHEET_NAME, 'users'])
     // The winner's header row survived intact (no clobber by a second creation).
     expect(spreadsheet.getSheetByName('users')?.getRange(1, 1, 1, 2).getValues()[0]).toEqual(['id', 'name'])
   })
@@ -108,7 +117,7 @@ describe('sheet auto-creation race (#178)', () => {
     expect(rows.length).toBe(2)
     expect(rows.map(r => r.name).sort()).toEqual(['loser-row', 'winner-row'])
     expect(rows.find(r => r.id === inserted.id)?.name).toBe('loser-row')
-    expect(spreadsheet.getSheets().length).toBe(1)
+    expect(sheetNames(spreadsheet)).toEqual([META_SHEET_NAME, 'users'])
   })
 
   it('creates the sheet exactly once when it truly does not exist', () => {
@@ -119,7 +128,7 @@ describe('sheet auto-creation race (#178)', () => {
     const adapter = makeAdapter()
     adapter.insert({ name: 'first' })
 
-    expect(spreadsheet.getSheets().length).toBe(1)
+    expect(sheetNames(spreadsheet)).toEqual([META_SHEET_NAME, 'users'])
     expect(adapter.findAll().length).toBe(1)
   })
 })

--- a/website/docs/id-modes.md
+++ b/website/docs/id-modes.md
@@ -33,7 +33,11 @@ console.log(user2.id) // 2
 ### How It Works
 
 - **MockAdapter**: Maintains an internal counter, auto-increments on each insert
-- **SheetsAdapter**: Reads the max ID from the sheet and increments; uses GAS `LockService` for concurrency safety
+- **SheetsAdapter**: Allocates from a persistent per-table counter stored in a hidden `_gsquery_meta` sheet inside the spreadsheet, under the GAS `LockService` script lock
+
+Like a SQL `AUTO_INCREMENT`, the counter only moves forward: **deleting a row never frees its id for reuse**, so a foreign key pointing at a deleted record stays a visible orphan instead of silently re-binding to whatever row is inserted next. Expect gaps in the id sequence after deletions — that is by design.
+
+The `_gsquery_meta` sheet is safe to leave alone and safe to lose: if someone deletes it, the next insert recreates it and re-bootstraps the counter from the current max id (ids still only move forward from there). The counter lives in the spreadsheet — not in script properties — so every script project that opens the spreadsheet shares one counter, and a copied spreadsheet carries its counter along.
 
 ## Client Mode
 


### PR DESCRIPTION
## Summary

Auto-mode ids were `max(current ids) + 1`, so deleting the highest-numbered row freed its id for the very next insert — and any foreign key still holding that id **silently re-pointed at the new record** (S7 deterministic repro: Eve's order became Frank's with zero errors). This was the last remaining silent-data-corruption class before v1.0.

Ids are now allocated from a per-table monotonic counter persisted in a hidden `_gsquery_meta` sheet **inside the spreadsheet itself**. Not PropertiesService, deliberately: the sheet is the database — a second script project opening the same spreadsheet must see the same counter, and a copied spreadsheet must carry it along.

## Design

- **Allocation**: `next = max(storedCounter, currentMax + 1)`, then persist `next + count`. Self-healing: a missing meta sheet/row bootstraps from the data, a manually typed high id is absorbed, the value only moves forward. Accepted limit: deletions that happened *before* the counter first existed can't be compensated retroactively.
- **Atomicity**: allocation lives inside the existing `insert`/`batchInsert` lock; `batchInsert` reserves the whole run with one counter read/write. Flush-on-acquire (#186) keeps the counter read fresh across executions.
- **Meta sheet creation** reuses the #178 pattern verbatim (locked re-check through a fresh handle, adopt-on-failure, no localized-error-text matching). `hideSheet` is feature-detected (cosmetic; fakes don't implement it).
- MockAdapter already used an in-memory monotonic counter — this aligns SheetsAdapter with the semantics the mock always had.

## Changes

- `packages/core/src/adapters/sheets-adapter.ts`: `getNextId` → `getMetaSheet` + `allocateAutoIds(count)`; `META_SHEET_NAME` exported
- `packages/core/tests/unit/monotonic-auto-id.test.ts` (new): delete-max, delete-all, batch run reservation, bootstrap-from-data, meta-deletion self-heal, manual high id, per-table independence, cross-instance counter, client-mode untouched
- `packages/core/tests/scenario/referential-integrity.scenario.test.ts`: S7 pins flipped `[documents: id-reuse-dangling-join]` → `[regression: #177]` — the orphaned FK now stays a visible orphan (left join → `null`, inner join → dropped)
- `packages/core/tests/unit/sheet-creation-race.test.ts`: sheet-count assertions now name-based (meta sheet exists alongside the data sheet)
- `packages/core/src/testing/fake-spreadsheet.ts`: `deleteSheet` added (GAS parity, needed by the self-heal test)
- `e2e/gas`: golden test "auto ids are never reused after deleting the max row (#177)" (live-platform validation); cleanup purges `e2e_*` counter rows from the meta sheet
- README Limitations + `website/docs/id-modes.md`: gaps after deletion are by design (SQL auto-increment semantics), meta sheet safe to lose

## Verification

- Full workspace green: core 47 files / 739 tests, cli 255, client 192, harness local check 3
- `pnpm -r typecheck` clean
- Red→green: the two S7 pins asserted the reuse behavior and passed pre-fix; post-fix they fail exactly at the flipped assertions (id 6 vs 5), then pass with the regression expectations
- Live validation lands with the dev-push gas-e2e run after merge (new golden test + existing burst)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_