### PR TITLE
fix: explicit .js extensions in relative imports; disclose declarative-only schema attributes (#198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Google Sheets is not a database engine — know what you're trading:
 - **No transactions** — mutations are script-locked but not atomic across multiple operations; there is no rollback of applied writes.
 - **Full-table reads** — queries read the data block once per execution and filter in memory; fine for thousands of rows, not for hundreds of thousands. Sheets caps at 10M cells.
 - **Per-execution cache** — an adapter instance snapshots the sheet on first read; writes from other executions are invisible until `clearCache()` or a new execution.
-- **Schema `@unique` / `@@index` are declarative only** — parsed and emitted, but not enforced at runtime; indexes accelerate the mock/local adapters, not `SheetsAdapter`.
+- **Schema `@unique` / `@@index` / `@default` / `@updatedAt` are declarative only** — parsed and emitted, but not enforced or applied at runtime: indexes accelerate the mock/local adapters (not `SheetsAdapter`), and default/timestamp values must be supplied by your code on insert/update.
 - **Local-first client is single-tab** — two tabs sharing the same namespace can clobber each other's queued mutations.
 - **Formula escaping is on by default** — user-supplied strings are stored as literal text (never executed as formulas); opt out per adapter with `allowFormulas: true` if you intentionally store formulas.
 - **Columns are mapped by position** — if somebody inserts or reorders a column in the sheet, the layout no longer matches the schema. Every read and write checks the header row once per execution and throws `SchemaMismatchError` instead of silently reading and writing the wrong columns; opt out per adapter with `skipHeaderCheck: true`.
-- **A hidden `_gsquery_meta` sheet holds id counters** — auto `idMode` persists a per-table monotonic counter there so a deleted row's id is never reused (expect gaps after deletions, like any SQL auto-increment). Deleting the sheet is safe: it is recreated and the counter re-bootstraps from the current max.
+- **A hidden `_gsquery_meta` sheet holds id counters** — auto `idMode` persists a per-table monotonic counter there so a deleted row's id is not reused (expect gaps after deletions, like any SQL auto-increment). If someone deletes the sheet, the next insert recreates it and re-bootstraps from the current max id — but rows deleted while the counter was missing can have their ids re-issued in that window, so treat the sheet as part of your data.
 
 ## 🤖 AI Coding Assistants
 

--- a/docs/schema-syntax.md
+++ b/docs/schema-syntax.md
@@ -97,7 +97,9 @@ id: number @id
 
 ### @default(value)
 
-Sets the default value.
+Declares the field's default value.
+
+> ⚠️ **Not applied at runtime.** `@default` is parsed and carried through codegen as documentation of intent, but no adapter fills the value in: generated `create()` types still require the field, and your application code must supply it (the one exception is the primary key in auto `idMode`, which the adapter allocates regardless of this attribute). Runtime application is planned for a later release.
 
 | Value | Description |
 |-------|-------------|
@@ -126,7 +128,9 @@ email: string @unique
 
 ### @updatedAt
 
-Automatically updates to current time when record is modified.
+Declares that the field holds the record's last-modified time.
+
+> ⚠️ **Not applied at runtime.** Nothing auto-fills this on update today — set it from your application code (`update(id, { ..., updatedAt: new Date() })`). Runtime application is planned for a later release.
 
 ```yaml
 updatedAt: datetime @updatedAt

--- a/packages/client/src/runtime.ts
+++ b/packages/client/src/runtime.ts
@@ -140,7 +140,7 @@ export function createStore<T extends RowWithId>(
  * ```ts
  * // In generated client.ts:
  * import { createClientFactory } from '@gsquery/client'
- * import { schema, Tables } from './types'
+ * import { schema, Tables } from './types.js'
  * 
  * export const createClient = createClientFactory<Tables>(schema)
  * 

--- a/packages/core/src/adapters/mock-adapter.ts
+++ b/packages/core/src/adapters/mock-adapter.ts
@@ -1,11 +1,11 @@
 /**
  * Mock adapter for testing - in-memory data storage
  */
-import type { RowWithId, DataStore, QueryOptions, WhereCondition, BatchUpdateItem, IdMode, UpdateData } from '../core/types'
-import { IndexStore } from '../core/index-store'
-import type { IndexDefinition } from '../core/index-store'
-import { evaluateCondition, compareRows } from '../core/query-utils'
-import { DuplicateIdError } from '../core/errors'
+import type { RowWithId, DataStore, QueryOptions, WhereCondition, BatchUpdateItem, IdMode, UpdateData } from '../core/types.js'
+import { IndexStore } from '../core/index-store.js'
+import type { IndexDefinition } from '../core/index-store.js'
+import { evaluateCondition, compareRows } from '../core/query-utils.js'
+import { DuplicateIdError } from '../core/errors.js'
 
 /** MockAdapter configuration options */
 export interface MockAdapterOptions<T extends RowWithId = RowWithId> {

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -10,16 +10,16 @@ import type {
   IdMode,
   UpdateData,
   AddColumnOptions
-} from '../core/types'
-import { evaluateCondition, compareRows } from '../core/query-utils'
+} from '../core/types.js'
+import { evaluateCondition, compareRows } from '../core/query-utils.js'
 import {
   CellSizeLimitError,
   DuplicateIdError,
   SchemaMismatchError,
   UnknownColumnError
-} from '../core/errors'
-import { withScriptLock } from '../core/script-lock'
-import { withRetries } from '../core/gas-retry'
+} from '../core/errors.js'
+import { withScriptLock } from '../core/script-lock.js'
+import { withRetries } from '../core/gas-retry.js'
 
 /** Column type definition for schema-based serialization */
 export type ColumnType = 

--- a/packages/core/src/core/column-conversion.ts
+++ b/packages/core/src/core/column-conversion.ts
@@ -13,7 +13,7 @@
  * serialization work on that file lands, so there is exactly one
  * implementation.
  */
-import type { ColumnType } from '../adapters/sheets-adapter'
+import type { ColumnType } from '../adapters/sheets-adapter.js'
 
 /**
  * Convert a single raw value to its runtime representation for `colType`.

--- a/packages/core/src/core/gas-retry.ts
+++ b/packages/core/src/core/gas-retry.ts
@@ -20,7 +20,7 @@
  * sleeps, so the thundering-herd problem jitter solves does not apply at this
  * scale, and determinism keeps the policy testable.
  */
-import { classifyGasError, isTransientGasError } from './errors'
+import { classifyGasError, isTransientGasError } from './errors.js'
 
 /** Total number of calls (not extra retries) a guarded operation may make. */
 export const DEFAULT_RETRY_ATTEMPTS = 3

--- a/packages/core/src/core/index-store.ts
+++ b/packages/core/src/core/index-store.ts
@@ -8,7 +8,7 @@
  *   - Composite column: "field1|field2" → Map<JSON([val1, val2]), Set<rowIndex>>
  */
 
-import type { Row } from './types'
+import type { Row } from './types.js'
 
 /** Index definition */
 export interface IndexDefinition {

--- a/packages/core/src/core/join-query-builder.ts
+++ b/packages/core/src/core/join-query-builder.ts
@@ -2,8 +2,8 @@
  * JoinQueryBuilder - Query builder with JOIN support
  * Simulates relational joins using batch fetching to prevent N+1 queries
  */
-import type { DataStore, QueryOptions, Operator, SingleValueOperator, SortDirection, WhereCondition, OrderByCondition, RowWithId } from './types'
-import { NoResultsError } from './errors'
+import type { DataStore, QueryOptions, Operator, SingleValueOperator, SortDirection, WhereCondition, OrderByCondition, RowWithId } from './types.js'
+import { NoResultsError } from './errors.js'
 
 /**
  * Join configuration

--- a/packages/core/src/core/migration.ts
+++ b/packages/core/src/core/migration.ts
@@ -3,9 +3,9 @@
  * 
  * Provides version-controlled schema changes with up/down migrations.
  */
-import type { Row, RowWithId, DataStore, BatchUpdateItem } from './types'
-import { SheetsQueryError } from './errors'
-import { withScriptLockAsync } from './script-lock'
+import type { Row, RowWithId, DataStore, BatchUpdateItem } from './types.js'
+import { SheetsQueryError } from './errors.js'
+import { withScriptLockAsync } from './script-lock.js'
 
 // ============================================================================
 // Migration Types
@@ -193,7 +193,7 @@ class RecordingSchemaBuilder implements SchemaBuilder {
  * Defined once in join-query-builder; imported and re-exported here to keep
  * this module's public surface (and the MigrationStoreResolver alias in index.ts).
  */
-import type { StoreResolver } from './join-query-builder'
+import type { StoreResolver } from './join-query-builder.js'
 export type { StoreResolver }
 
 /**

--- a/packages/core/src/core/query-builder.ts
+++ b/packages/core/src/core/query-builder.ts
@@ -1,8 +1,8 @@
 /**
  * Query Builder - fluent API for building queries
  */
-import type { RowWithId, DataStore, QueryOptions, Operator, SingleValueOperator, SortDirection, WhereCondition, OrderByCondition } from './types'
-import { NoResultsError } from './errors'
+import type { RowWithId, DataStore, QueryOptions, Operator, SingleValueOperator, SortDirection, WhereCondition, OrderByCondition } from './types.js'
+import { NoResultsError } from './errors.js'
 
 /**
  * Aggregation specification

--- a/packages/core/src/core/query-utils.ts
+++ b/packages/core/src/core/query-utils.ts
@@ -2,7 +2,7 @@
  * Shared query utilities for evaluating conditions and sorting rows.
  * Used by both MockAdapter and SheetsAdapter (local strategy).
  */
-import type { Row, WhereCondition, OrderByCondition } from './types'
+import type { Row, WhereCondition, OrderByCondition } from './types.js'
 
 /**
  * Escape regex special characters in a string

--- a/packages/core/src/core/repository.ts
+++ b/packages/core/src/core/repository.ts
@@ -1,8 +1,8 @@
 /**
  * Repository - high-level CRUD operations over a DataStore
  */
-import type { RowWithId, DataStore, QueryOptions, BatchUpdateItem, UpdateData } from './types'
-import { RowNotFoundError } from './errors'
+import type { RowWithId, DataStore, QueryOptions, BatchUpdateItem, UpdateData } from './types.js'
+import { RowNotFoundError } from './errors.js'
 
 /**
  * Repository provides a clean CRUD interface over any DataStore implementation

--- a/packages/core/src/core/script-lock.ts
+++ b/packages/core/src/core/script-lock.ts
@@ -8,7 +8,7 @@
  * sequence. LockService is absent outside GAS (Node tests, bundlers), in which
  * case these helpers degrade to running the callback unlocked.
  */
-import { classifyGasError, LockTimeoutError } from './errors'
+import { classifyGasError, LockTimeoutError } from './errors.js'
 
 /** Default time (ms) to wait for the script lock before giving up. */
 export const DEFAULT_LOCK_TIMEOUT_MS = 10000

--- a/packages/core/src/core/sheets-db.ts
+++ b/packages/core/src/core/sheets-db.ts
@@ -10,13 +10,13 @@ import type {
   InferTablesFromConfig,
   UpdateData,
   BatchUpdateItem
-} from './types'
-import { Repository } from './repository'
-import { QueryBuilder, createQueryBuilder } from './query-builder'
-import { JoinQueryBuilder, createJoinQueryBuilder } from './join-query-builder'
-import type { StoreResolver } from './join-query-builder'
-import { TableNotFoundError, MissingStoreError } from './errors'
-import { MockAdapter } from '../adapters/mock-adapter'
+} from './types.js'
+import { Repository } from './repository.js'
+import { QueryBuilder, createQueryBuilder } from './query-builder.js'
+import { JoinQueryBuilder, createJoinQueryBuilder } from './join-query-builder.js'
+import type { StoreResolver } from './join-query-builder.js'
+import { TableNotFoundError, MissingStoreError } from './errors.js'
+import { MockAdapter } from '../adapters/mock-adapter.js'
 
 /**
  * Table handle providing Repository and QueryBuilder access

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -1,8 +1,8 @@
 /**
  * Core types for gas-sheets-query
  */
-import type { ColumnType } from '../adapters/sheets-adapter'
-import type { IndexDefinition } from './index-store'
+import type { ColumnType } from '../adapters/sheets-adapter.js'
+import type { IndexDefinition } from './index-store.js'
 
 /**
  * ID generation mode for insert operations

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,34 +29,34 @@ export type {
   InferType,
   InferRowFromSchema,
   InferTablesFromConfig
-} from './core/types'
+} from './core/types.js'
 
 // Core classes
-export { Repository } from './core/repository'
-export { QueryBuilder, createQueryBuilder } from './core/query-builder'
-export type { AggSpec, AggResult, GroupedAggResult, HavingCondition } from './core/query-builder'
-export { JoinQueryBuilder, createJoinQueryBuilder } from './core/join-query-builder'
-export type { JoinConfig, StoreResolver } from './core/join-query-builder'
+export { Repository } from './core/repository.js'
+export { QueryBuilder, createQueryBuilder } from './core/query-builder.js'
+export type { AggSpec, AggResult, GroupedAggResult, HavingCondition } from './core/query-builder.js'
+export { JoinQueryBuilder, createJoinQueryBuilder } from './core/join-query-builder.js'
+export type { JoinConfig, StoreResolver } from './core/join-query-builder.js'
 
 // SheetsDB factory functions
-export { createSheetsDB, defineSheetsDB } from './core/sheets-db'
-export type { SheetsDB, TableHandle, CreateSheetsDBOptions, DefineSheetsDBOptions } from './core/sheets-db'
+export { createSheetsDB, defineSheetsDB } from './core/sheets-db.js'
+export type { SheetsDB, TableHandle, CreateSheetsDBOptions, DefineSheetsDBOptions } from './core/sheets-db.js'
 
 // Adapters
-export { MockAdapter } from './adapters/mock-adapter'
-export type { MockAdapterOptions } from './adapters/mock-adapter'
-export { SheetsAdapter, MAX_CELL_LENGTH, META_SHEET_NAME } from './adapters/sheets-adapter'
-export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter'
+export { MockAdapter } from './adapters/mock-adapter.js'
+export type { MockAdapterOptions } from './adapters/mock-adapter.js'
+export { SheetsAdapter, MAX_CELL_LENGTH, META_SHEET_NAME } from './adapters/sheets-adapter.js'
+export type { ColumnType, SheetsAdapterOptions } from './adapters/sheets-adapter.js'
 
 // Query utilities
-export { evaluateCondition, compareRows } from './core/query-utils'
+export { evaluateCondition, compareRows } from './core/query-utils.js'
 
 // Column type conversion
-export { deserializeColumnValue, deserializeRow } from './core/column-conversion'
+export { deserializeColumnValue, deserializeRow } from './core/column-conversion.js'
 
 // Index Store
-export { IndexStore, createIndexKey, serializeValues } from './core/index-store'
-export type { IndexDefinition } from './core/index-store'
+export { IndexStore, createIndexKey, serializeValues } from './core/index-store.js'
+export type { IndexDefinition } from './core/index-store.js'
 
 // Errors
 export {
@@ -77,11 +77,11 @@ export {
   CellSizeLimitError,
   classifyGasError,
   isTransientGasError
-} from './core/errors'
+} from './core/errors.js'
 
 // Bounded retry with backoff for transient GAS failures (#136)
-export { withRetries, DEFAULT_RETRY_ATTEMPTS, DEFAULT_RETRY_BASE_DELAY_MS } from './core/gas-retry'
-export type { RetryOptions } from './core/gas-retry'
+export { withRetries, DEFAULT_RETRY_ATTEMPTS, DEFAULT_RETRY_BASE_DELAY_MS } from './core/gas-retry.js'
+export type { RetryOptions } from './core/gas-retry.js'
 
 // Migration System
 export {
@@ -90,7 +90,7 @@ export {
   MigrationVersionError,
   MigrationExecutionError,
   NoMigrationsToRollbackError
-} from './core/migration'
+} from './core/migration.js'
 export type {
   Migration,
   MigrationRecord,
@@ -102,4 +102,4 @@ export type {
   SchemaOperationType,
   ColumnOptions,
   StoreResolver as MigrationStoreResolver
-} from './core/migration'
+} from './core/migration.js'

--- a/packages/core/src/testing/export.ts
+++ b/packages/core/src/testing/export.ts
@@ -3,11 +3,11 @@
  * grids, CSV, or a versioned JSON envelope. Free functions (not class
  * methods), mirroring {@link loaders}.
  */
-import { FakeSheet } from './fake-sheet'
-import { FakeSpreadsheet } from './fake-spreadsheet'
-import { serializeCsvCell } from './csv'
-import { tagDates } from './json'
-import type { SnapshotEnvelope } from './json'
+import { FakeSheet } from './fake-sheet.js'
+import { FakeSpreadsheet } from './fake-spreadsheet.js'
+import { serializeCsvCell } from './csv.js'
+import { tagDates } from './json.js'
+import type { SnapshotEnvelope } from './json.js'
 
 /**
  * A defensively-copied, rectangular grid of the sheet's content.

--- a/packages/core/src/testing/fake-spreadsheet.ts
+++ b/packages/core/src/testing/fake-spreadsheet.ts
@@ -3,7 +3,7 @@
  * allowlisted surface (`getSheetByName`, `insertSheet`, `deleteSheet`,
  * `getSheets`, `getName`).
  */
-import { FakeSheet } from './fake-sheet'
+import { FakeSheet } from './fake-sheet.js'
 
 export class FakeSpreadsheet {
   private readonly sheets = new Map<string, FakeSheet>()

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -3,11 +3,11 @@
  * Offline, deterministic fakes for Google Sheets/GAS globals. Not re-exported
  * from the main entrypoint — excluded from the main and GAS bundles.
  */
-export { FakeSheet, FakeRange } from './fake-sheet'
-export { FakeSpreadsheet } from './fake-spreadsheet'
-export { installGasFakes } from './install'
-export type { InstallGasFakesOptions, GasFakesHandle } from './install'
-export { fromArrays, fromCsv, fromJson } from './loaders'
-export type { FromCsvOptions } from './loaders'
-export { toGrid, toCsv, toJson } from './export'
-export type { SnapshotEnvelope, SnapshotSheetEntry } from './json'
+export { FakeSheet, FakeRange } from './fake-sheet.js'
+export { FakeSpreadsheet } from './fake-spreadsheet.js'
+export { installGasFakes } from './install.js'
+export type { InstallGasFakesOptions, GasFakesHandle } from './install.js'
+export { fromArrays, fromCsv, fromJson } from './loaders.js'
+export type { FromCsvOptions } from './loaders.js'
+export { toGrid, toCsv, toJson } from './export.js'
+export type { SnapshotEnvelope, SnapshotSheetEntry } from './json.js'

--- a/packages/core/src/testing/install.ts
+++ b/packages/core/src/testing/install.ts
@@ -2,7 +2,7 @@
  * Global shim: installs `SpreadsheetApp`/`LockService` on `globalThis` so
  * `SheetsAdapter` and consumer code run unmodified against fakes in Node.
  */
-import { FakeSpreadsheet } from './fake-spreadsheet'
+import { FakeSpreadsheet } from './fake-spreadsheet.js'
 
 /** Options for {@link installGasFakes}. */
 export interface InstallGasFakesOptions {

--- a/packages/core/src/testing/loaders.ts
+++ b/packages/core/src/testing/loaders.ts
@@ -4,11 +4,11 @@
  * so `FakeSheet`/`FakeSpreadsheet` keep exposing only their GAS-parity
  * allowlist.
  */
-import { FakeSheet } from './fake-sheet'
-import { FakeSpreadsheet } from './fake-spreadsheet'
-import { parseCsv, coerceCell } from './csv'
-import { untagDates } from './json'
-import type { SnapshotEnvelope } from './json'
+import { FakeSheet } from './fake-sheet.js'
+import { FakeSpreadsheet } from './fake-spreadsheet.js'
+import { parseCsv, coerceCell } from './csv.js'
+import { untagDates } from './json.js'
+import type { SnapshotEnvelope } from './json.js'
 
 /** Options for {@link fromCsv}. */
 export interface FromCsvOptions {

--- a/website/docs/id-modes.md
+++ b/website/docs/id-modes.md
@@ -37,7 +37,7 @@ console.log(user2.id) // 2
 
 Like a SQL `AUTO_INCREMENT`, the counter only moves forward: **deleting a row never frees its id for reuse**, so a foreign key pointing at a deleted record stays a visible orphan instead of silently re-binding to whatever row is inserted next. Expect gaps in the id sequence after deletions — that is by design.
 
-The `_gsquery_meta` sheet is safe to leave alone and safe to lose: if someone deletes it, the next insert recreates it and re-bootstraps the counter from the current max id (ids still only move forward from there). The counter lives in the spreadsheet — not in script properties — so every script project that opens the spreadsheet shares one counter, and a copied spreadsheet carries its counter along.
+If someone deletes the `_gsquery_meta` sheet, the next insert recreates it and re-bootstraps the counter from the current max id. One caveat: while the counter is missing, allocation degrades to `max + 1` — so if the highest-id rows are also deleted **before** the next insert, those ids are re-issued in that window. Treat the meta sheet as part of your data, not as a disposable artifact. The counter lives in the spreadsheet — not in script properties — so every script project that opens the spreadsheet shares one counter, and a copied spreadsheet carries its counter along.
 
 ## Client Mode
 

--- a/website/docs/schema-definition.md
+++ b/website/docs/schema-definition.md
@@ -96,9 +96,13 @@ tables:
 | Attribute | Description | Example |
 |-----------|-------------|---------|
 | `@id` | Primary key field | `id: number @id` |
-| `@default(value)` | Default value | `active: boolean @default(true)` |
-| `@unique` | Unique constraint | `email: string @unique` |
-| `@updatedAt` | Auto-update timestamp | `updatedAt: datetime @updatedAt` |
+| `@default(value)` | Declared default value (documentation only — see below) | `active: boolean @default(true)` |
+| `@unique` | Unique constraint (declarative only — not enforced at runtime) | `email: string @unique` |
+| `@updatedAt` | Declared update timestamp (documentation only — see below) | `updatedAt: datetime @updatedAt` |
+
+:::warning `@default` and `@updatedAt` are not applied at runtime
+These attributes are parsed and carried through codegen as documentation of intent, but **no adapter applies them**: generated `create()` types still require the fields, and nothing auto-fills timestamps on update. Supply the values from your application code (e.g. `create({ ..., createdAt: new Date() })`). Runtime application is planned for a later release.
+:::
 
 ### Block Attributes
 


### PR DESCRIPTION
## Summary

Fixes the two HIGH findings from evaluation round 2 plus the W4 docs overclaim.

## #198 — d.ts unusable under nodenext (silent `any` with skipLibCheck)

Emitted declarations mirrored the source's extensionless relative imports — illegal under `moduleResolution: nodenext`/`node16` (TS2834 ×21), and with `skipLibCheck: true` the errors vanish and **every export silently types as `any`**. Fix: explicit `.js` extensions on all relative imports in `packages/core/src` (75) and `packages/client/src` (1) — the exact convention `packages/cli/src` already used (which is why the CLI ran under Node ESM at all). No new tooling, no declaration bundler.

Verified with a real consumer (`file:` dependency on built core): nodenext ± skipLibCheck and bundler ± skipLibCheck all now produce exactly one error — the intentional `const x: "NOT ANY" = defineSheetsDB` trap firing with the full correct signature.

## W2 — `@default` / `@updatedAt` disclosed as declarative-only

Docs described `@updatedAt` as "automatically updates" — no adapter applies either attribute. Now disclosed in README Limitations (extending the existing `@unique`/`@@index` bullet), a warning box in `schema-definition.md`, and per-attribute warnings in `schema-syntax.md`. Runtime implementation tracked in #199.

## W4 — id-counter docs no longer overclaim

"a deleted row's id is **never** reused" / "safe to lose" → both now name the real window (meta sheet deleted + max rows deleted before next insert → reuse possible, runtime-reproduced), matching `allocateAutoIds`' actual bootstrap.

## Also registered (not in this PR)

#199 (@default runtime implementation), #200 (nullable sample types), #201 (apostrophe+trigger e2e verification), and W6/W7 appended to #194.

## Verification

- `pnpm -r typecheck` clean; full test suite green (core 743 / cli 255 / client 192 / harness 3)
- core rebuild + consumer-side nodenext repro above
- esbuild/vitest unaffected (`.js` → `.ts` resolution is native to both)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_