### PR TITLE
chore: pin release-as 1.0.0 in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "package-name": "gas-sheets-query",
+      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },


### PR DESCRIPTION
## Summary

One-line config change: `"release-as": "1.0.0"` in `release-please-config.json`.

The `Release-As:` commit footer (#204) was not honored — prose followed the footer paragraph in that commit message, so it parsed as body text rather than a git trailer — and release-please opened PR #205 at **2.0.0-rc3** (a breaking-change commit in the merged dev history triggered a major bump on the rc line). The config field is the deterministic way to pin the version.

⚠️ **Remove this field right after 1.0.0 ships**, or every subsequent release stays pinned to 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_