### PR TITLE
ci: add manual npm-token pre-flight check (npm whoami)

### DIFF
--- a/.github/workflows/npm-token-check.yml
+++ b/.github/workflows/npm-token-check.yml
@@ -1,0 +1,25 @@
+name: NPM token check
+
+# Pre-flight for releases: verifies the NPM_TOKEN secret exists and is
+# still accepted by the registry (classic tokens were mass-revoked by npm
+# in late 2025, so age alone can kill it). Never publishes anything.
+on:
+  workflow_dispatch:
+
+jobs:
+  whoami:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is empty or not set"
+            exit 1
+          fi
+          npm whoami


### PR DESCRIPTION
## Summary

10-line `workflow_dispatch`-only job: fails if `NPM_TOKEN` is unset, otherwise runs `npm whoami` against the registry with it. Verifies the secret exists **and is still accepted** (npm mass-revoked classic tokens in late 2025, so an old token can be dead regardless of being set) — without publishing anything. Pre-flight before merging the v1.0.0 Release PR (#205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_