### PR TITLE
fix(release): drop package-name so the merged release PR matches

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "separate-pull-requests": false,
   "packages": {
     ".": {
-      "package-name": "gas-sheets-query",
       "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
## Summary

One-line config fix unblocking the v1.0.0 tag. The Release run after merging #205 built **zero** releases and aborted with "untagged, merged release PRs outstanding" — root cause in the logs:

```
⚠ PR component: undefined does not match configured component: gas-sheets-query
```

The merged Release PR's title (`chore: release main`) carries no component, while `package-name` makes release-please expect one. With a single-package manifest and `include-component-in-tag: false`, `package-name` feeds only this mismatched comparison — removing it lets the next run match PR #205, create tag `v1.0.0` + the GitHub Release, and set `release_created=true` so the publish job finally runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_