### PR TITLE
fix(release): empty package-name so the standalone release PR component matches

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "separate-pull-requests": false,
   "packages": {
     ".": {
+      "package-name": "",
       "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [


### PR DESCRIPTION
## Summary

Second (and per release-please source, correct) fix for the v1.0.0 tagging abort. `buildRelease`'s standalone-PR check compares the release branch's parsed component (`''` — branch is `release-please--branches--main`) against `getBranchComponent()`:

- with `package-name` set → compares against that name → mismatch (run 1)
- with `package-name` removed → falls back to root package.json name (`gas-sheets-query-monorepo`) → mismatch (run 2)

`getBranchComponent()` can never be empty through the fallbacks — **unless `package-name` is an explicit empty string**, which survives the `??` (not nullish) and fails the `||` (falsy), normalizing both sides to `''` → match → PR #205 gets tagged `v1.0.0`, the GitHub Release is created, and `release_created=true` finally un-skips the publish job.

Evidence: `release-please/src/strategies/base.ts` — constructor line ~137 (`options.component || normalizeComponent(this.packageName)`), `getBranchComponent()`/`getDefaultComponent()` (~lines 179-193), and the standalone check at ~656-670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_