### PR TITLE
chore: unpin release-as now that 1.0.0 has shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "packages": {
     ".": {
       "package-name": "",
-      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "packages/core/package.json", "jsonpath": "$.version" },


### PR DESCRIPTION
## Summary

One-line removal of the `release-as: 1.0.0` pin — it was a one-shot override for the first stable release; leaving it would freeze every future release at 1.0.0. `package-name: ""` stays: that's the fix (#209) that lets release-please tag standalone release PRs at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_