### PR TITLE
fix(ci): let configure-pages enable the Pages site on first deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,6 +39,8 @@ jobs:
       - run: pnpm build
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

The docs site (https://juhyeonni.github.io/gas-sheets-query/) 404s because GitHub Pages was never enabled for the repo — Deploy Docs only reached main with the v1.0 merge, and its first run failed at `configure-pages` (`Get Pages site failed ... Not Found`). Adding `enablement: true` lets the action create the Pages site itself (source: GitHub Actions). The push of this PR re-triggers Deploy Docs (workflow file path is in its triggers), so the site should come up right after merge; if the default token lacks the required permission, the fallback is one manual toggle: Settings → Pages → Source: GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9hSihptvSe5pSDyihvTYp)_