### PR TITLE
feat(core): add upsert + document operational limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Google Sheets is not a database engine — know what you're trading:
 - **Columns are mapped by position** — if somebody inserts or reorders a column in the sheet, the layout no longer matches the schema. Every read and write checks the header row once per execution and throws `SchemaMismatchError` instead of silently reading and writing the wrong columns; opt out per adapter with `skipHeaderCheck: true`.
 - **A hidden `_gsquery_meta` sheet holds id counters** — auto `idMode` persists a per-table monotonic counter there so a deleted row's id is not reused (expect gaps after deletions, like any SQL auto-increment). If someone deletes the sheet, the next insert recreates it and re-bootstraps from the current max id — but rows deleted while the counter was missing can have their ids re-issued in that window, so treat the sheet as part of your data.
 
+Quotas, retry policy, script locking, and the cell/cache limits behind these
+trade-offs are documented in [Operations](https://juhyeonni.github.io/gas-sheets-query/operations).
+
 ## 🤖 AI Coding Assistants
 
 Install [`@gsquery/skills`](./packages/skills) so AI tools (Claude Code, Cursor, Copilot, etc.) write correct gsquery code:

--- a/packages/client/src/local/local-adapter.ts
+++ b/packages/client/src/local/local-adapter.ts
@@ -117,7 +117,7 @@ export class LocalAdapter<T extends RowWithId> implements DataStore<T> {
   private nextId = 1
   private idIndex: Map<string | number, number> = new Map()
   private indexStore: IndexStore<T>
-  private idMode: IdMode
+  readonly idMode: IdMode
   private readonly columnTypes: Record<string, ColumnType> | undefined
 
   readonly tableName: string

--- a/packages/core/src/adapters/mock-adapter.ts
+++ b/packages/core/src/adapters/mock-adapter.ts
@@ -40,7 +40,7 @@ export class MockAdapter<T extends RowWithId> implements DataStore<T> {
   /** Column indexes for query optimization */
   private indexStore: IndexStore<T>
   /** ID generation mode */
-  private idMode: IdMode
+  readonly idMode: IdMode
 
   constructor(initialData?: T[] | MockAdapterOptions<T>) {
     // Support both array and options object for backward compatibility

--- a/packages/core/src/adapters/sheets-adapter.ts
+++ b/packages/core/src/adapters/sheets-adapter.ts
@@ -178,7 +178,7 @@ export class SheetsAdapter<T extends RowWithId> implements DataStore<T> {
   private columns: string[]
   private idColumn: string
   private createIfNotExists: boolean
-  private idMode: IdMode
+  readonly idMode: IdMode
   private columnTypes: Record<string, ColumnType>
   private allowFormulas: boolean
   private skipHeaderCheck: boolean

--- a/packages/core/src/core/repository.ts
+++ b/packages/core/src/core/repository.ts
@@ -1,8 +1,9 @@
 /**
  * Repository - high-level CRUD operations over a DataStore
  */
-import type { RowWithId, DataStore, QueryOptions, BatchUpdateItem, UpdateData } from './types.js'
-import { RowNotFoundError } from './errors.js'
+import type { RowWithId, DataStore, QueryOptions, BatchUpdateItem, UpdateData, UpsertData } from './types.js'
+import { RowNotFoundError, ValidationError } from './errors.js'
+import { withScriptLock } from './script-lock.js'
 
 /**
  * Repository provides a clean CRUD interface over any DataStore implementation
@@ -70,6 +71,48 @@ export class Repository<T extends RowWithId> {
    */
   updateOrNull(id: string | number, data: UpdateData<T>): T | undefined {
     return this.store.update(id, data)
+  }
+
+  /**
+   * Insert a row, or patch the row that already carries the same id (#217).
+   *
+   * The branch is decided by the *result of the update*, not by a preceding
+   * read: attempting the update first is one Sheets round trip cheaper on the
+   * common (row exists) path, and leaves no window between deciding and
+   * writing.
+   *
+   * The whole sequence is held under one script lock so two concurrent
+   * executions cannot both miss and both insert. `withScriptLock` is
+   * re-entrant, so the store's own locking nests inside this one, and it is a
+   * plain call outside GAS. The flip side is a longer critical section than a
+   * single write: two store round trips on the create path.
+   *
+   * @throws ValidationError when an id is supplied, no row carries it, and the
+   * store allocates its own ids (`auto` idMode) — inserting there would write
+   * the row under a different id than the caller asked for, leaving every
+   * reference to the requested id dangling with no error. Omit the id to
+   * create a row in an `auto` store.
+   */
+  upsert(data: UpsertData<T>): T {
+    return withScriptLock(() => {
+      const id = (data as Partial<T>).id
+      if (id !== undefined) {
+        const patch = { ...(data as T) } as Record<string, unknown>
+        delete patch.id
+        const updated = this.store.update(id, patch as UpdateData<T>)
+        if (updated) return updated
+
+        if (this.store.idMode === 'auto') {
+          throw new ValidationError(
+            `upsert: no row with id ${String(id)}${this.tableName ? ` in "${this.tableName}"` : ''}, ` +
+            'and this store allocates ids ("auto" idMode), so it cannot create one under that id. ' +
+            'Omit the id to create a row, or use idMode "client".',
+            'id'
+          )
+        }
+      }
+      return this.store.insert(data as T | Omit<T, 'id'>)
+    })
   }
 
   /**

--- a/packages/core/src/core/sheets-db.ts
+++ b/packages/core/src/core/sheets-db.ts
@@ -9,6 +9,7 @@ import type {
   InferRowFromSchema,
   InferTablesFromConfig,
   UpdateData,
+  UpsertData,
   BatchUpdateItem
 } from './types.js'
 import { Repository } from './repository.js'
@@ -42,6 +43,9 @@ export interface TableHandle<T extends RowWithId> {
 
   /** Shorthand: update by id */
   update(id: string | number, data: UpdateData<T>): T
+
+  /** Shorthand: insert, or patch the row that already carries this id */
+  upsert(data: UpsertData<T>): T
 
   /** Shorthand: delete by id */
   delete(id: string | number): void
@@ -85,6 +89,7 @@ function createTableHandle<T extends RowWithId>(
     findById: (id) => repo.findById(id),
     findAll: () => repo.findAll(),
     update: (id, data) => repo.update(id, data),
+    upsert: (data) => repo.upsert(data),
     delete: (id) => repo.delete(id),
     batchInsert: (data) => repo.batchInsert(data),
     batchUpdate: (items) => repo.batchUpdate(items)

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -56,6 +56,13 @@ export interface QueryOptions<T = Row> {
  */
 export type UpdateData<T extends RowWithId> = Partial<Omit<T, 'id'>>
 
+/**
+ * Payload accepted by {@link DataStore} upsert callers (#217): a row without an
+ * id (create), or a patch that carries the id of the row to write. A complete
+ * row satisfies the second arm, so both `create` and `update` shapes fit.
+ */
+export type UpsertData<T extends RowWithId> = Omit<T, 'id'> | (UpdateData<T> & Pick<T, 'id'>)
+
 /** Options for the optional {@link DataStore.addColumn} schema operation */
 export interface AddColumnOptions {
   /**
@@ -77,6 +84,16 @@ export interface BatchUpdateItem<T extends RowWithId = RowWithId> {
  * Implemented by GasAdapter (real Sheets) and MockAdapter (testing)
  */
 export interface DataStore<T extends RowWithId = RowWithId> {
+  /**
+   * How ids are produced by this store, when it knows (optional).
+   *
+   * Declared so callers above the store can tell "I may supply an id" from
+   * "the store allocates ids and will overwrite mine" — an `auto` store
+   * silently rewrites the id on insert, which would let `Repository.upsert`
+   * write a row under an id nobody asked for (#217).
+   */
+  readonly idMode?: IdMode
+
   /** Get all rows from the table */
   findAll(): T[]
   

--- a/packages/core/tests/unit/upsert.test.ts
+++ b/packages/core/tests/unit/upsert.test.ts
@@ -1,0 +1,228 @@
+/**
+ * #217 — public `upsert`: insert-or-update by id in one call.
+ *
+ * The sync contract already assumed upsert semantics (`insert` on the wire is
+ * "create or replace", see sync-transport), but no public API expressed it.
+ *
+ * Three properties are pinned here beyond the happy path:
+ *
+ * - The existence check is the *write result*, not a prior read, so there is no
+ *   window between deciding the branch and writing.
+ * - The whole find-then-write sequence is held under ONE script lock, so two
+ *   concurrent executions cannot both miss and both insert.
+ * - A store that allocates its own ids refuses an unknown explicit id rather
+ *   than writing the row under a different one.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { MockAdapter } from '../../src/adapters/mock-adapter'
+import { SheetsAdapter } from '../../src/adapters/sheets-adapter'
+import { Repository } from '../../src/core/repository'
+import { defineSheetsDB } from '../../src/core/sheets-db'
+import { installGasFakes } from '../../src/testing/install'
+import { fromArrays } from '../../src/testing/loaders'
+import { ValidationError } from '../../src/core/errors'
+import type { DataStore, RowWithId } from '../../src/core/types'
+
+interface User extends RowWithId {
+  id: string | number
+  name: string
+  age: number
+}
+
+const SPREADSHEET_ID = 'test-spreadsheet-id'
+const SHEET_NAME = 'Users'
+const COLUMNS = ['id', 'name', 'age']
+
+describe('Repository.upsert (#217)', () => {
+  it('updates the existing row when the id is present', () => {
+    const store = new MockAdapter<User>({
+      idMode: 'client',
+      initialData: [{ id: 'u1', name: 'Alice', age: 30 }]
+    })
+    const repo = new Repository(store, 'users')
+
+    const result = repo.upsert({ id: 'u1', name: 'Alice B', age: 31 })
+
+    expect(result).toEqual({ id: 'u1', name: 'Alice B', age: 31 })
+    expect(store.findAll()).toHaveLength(1)
+  })
+
+  it('inserts when the id is not present, keeping the client id', () => {
+    const store = new MockAdapter<User>({ idMode: 'client' })
+    const repo = new Repository(store, 'users')
+
+    const result = repo.upsert({ id: 'u9', name: 'New', age: 20 })
+
+    expect(result).toEqual({ id: 'u9', name: 'New', age: 20 })
+    expect(store.findById('u9')).toEqual(result)
+  })
+
+  it('inserts with a server-allocated id when no id is given (auto mode)', () => {
+    const store = new MockAdapter<User>()
+    const repo = new Repository(store, 'users')
+
+    const result = repo.upsert({ name: 'New', age: 20 })
+
+    expect(result.id).toBe(1)
+    expect(store.findAll()).toHaveLength(1)
+  })
+
+  it('applies a partial patch to the existing row instead of replacing it', () => {
+    const store = new MockAdapter<User>({
+      idMode: 'client',
+      initialData: [{ id: 'u1', name: 'Alice', age: 30 }]
+    })
+    const repo = new Repository(store, 'users')
+
+    const result = repo.upsert({ id: 'u1', age: 31 })
+
+    expect(result).toEqual({ id: 'u1', name: 'Alice', age: 31 })
+  })
+
+  it('refuses to invent a row when an auto-mode store is given an unknown id', () => {
+    // Auto idMode owns id allocation, so the insert branch cannot honor the
+    // requested id. Writing the row under a different one would leave every
+    // reference to id 99 dangling with no error, so it fails instead.
+    const store = new MockAdapter<User>({ initialData: [{ id: 1, name: 'Alice', age: 30 }] })
+    const repo = new Repository(store, 'users')
+
+    expect(() => repo.upsert({ id: 99, name: 'Ghost', age: 1 })).toThrow(ValidationError)
+    expect(store.findAll()).toHaveLength(1)
+  })
+
+  it('creates in an auto-mode store when no id is supplied', () => {
+    const store = new MockAdapter<User>({ initialData: [{ id: 1, name: 'Alice', age: 30 }] })
+
+    const result = new Repository(store, 'users').upsert({ name: 'Bob', age: 25 })
+
+    expect(result.id).toBe(2)
+    expect(store.findAll()).toHaveLength(2)
+  })
+
+  it('still inserts under an unknown id when the store cannot report its idMode', () => {
+    // A custom DataStore that does not declare idMode keeps the plain
+    // "update, else insert" behavior — the guard only fires on a known 'auto'.
+    const inner = new MockAdapter<User>({ idMode: 'client' })
+    const store: DataStore<User> = {
+      findAll: () => inner.findAll(),
+      find: (o) => inner.find(o),
+      findById: (id) => inner.findById(id),
+      insert: (row) => inner.insert(row),
+      update: (id, patch) => inner.update(id, patch),
+      delete: (id) => inner.delete(id)
+    }
+
+    const result = new Repository(store, 'users').upsert({ id: 'u1', name: 'New', age: 20 })
+
+    expect(result).toEqual({ id: 'u1', name: 'New', age: 20 })
+  })
+
+  it('does not read through the store cache to decide the branch', () => {
+    const store = new MockAdapter<User>({
+      idMode: 'client',
+      initialData: [{ id: 'u1', name: 'Alice', age: 30 }]
+    })
+    const findById = vi.spyOn(store, 'findById')
+    const repo = new Repository(store, 'users')
+
+    repo.upsert({ id: 'u1', age: 31 })
+
+    expect(findById).not.toHaveBeenCalled()
+  })
+})
+
+describe('TableHandle.upsert (#217)', () => {
+  it('is exposed as a shorthand on the table handle', () => {
+    const db = defineSheetsDB({
+      tables: {
+        users: {
+          columns: ['id', 'name', 'age'] as const,
+          types: { id: '', name: '', age: 0 }
+        }
+      },
+      stores: { users: new MockAdapter({ idMode: 'client' }) }
+    })
+
+    const created = db.from('users').upsert({ id: 'u1', name: 'Alice', age: 30 })
+    const updated = db.from('users').upsert({ id: 'u1', name: 'Alice B', age: 31 })
+
+    expect(created.id).toBe('u1')
+    expect(updated).toEqual({ id: 'u1', name: 'Alice B', age: 31 })
+    expect(db.from('users').findAll()).toHaveLength(1)
+  })
+})
+
+describe('SheetsAdapter upsert atomicity (#217)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as Record<string, unknown>).LockService
+    delete (globalThis as Record<string, unknown>).SpreadsheetApp
+  })
+
+  /** LockService whose script lock is exclusive, counting acquisitions. */
+  function installExclusiveLock(): { acquisitions: number; held: boolean } {
+    const state = { held: false, acquisitions: 0 }
+    const lock = {
+      waitLock(): void {
+        if (state.held) throw new Error('waitLock: script lock is already held')
+        state.held = true
+        state.acquisitions++
+      },
+      tryLock(): boolean {
+        if (state.held) return false
+        state.held = true
+        state.acquisitions++
+        return true
+      },
+      releaseLock(): void {
+        state.held = false
+      },
+      hasLock(): boolean {
+        return state.held
+      }
+    }
+    ;(globalThis as Record<string, unknown>).LockService = { getScriptLock: () => lock }
+    return state
+  }
+
+  it('holds one lock across the find-then-write sequence', () => {
+    const spreadsheet = fromArrays({ [SHEET_NAME]: [COLUMNS, ['u1', 'Alice', 30]] })
+    installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+    const lockState = installExclusiveLock()
+
+    const adapter = new SheetsAdapter<User>({
+      spreadsheetId: SPREADSHEET_ID,
+      sheetName: SHEET_NAME,
+      columns: COLUMNS,
+      idMode: 'client'
+    })
+    const repo = new Repository(adapter, 'users')
+
+    repo.upsert({ id: 'u1', age: 31 })
+
+    // One acquisition, not one per inner store call: withScriptLock is
+    // re-entrant, so the adapter's own lock nests inside the repository's.
+    expect(lockState.acquisitions).toBe(1)
+    expect(lockState.held).toBe(false)
+    expect(adapter.findById('u1')).toEqual({ id: 'u1', name: 'Alice', age: 31 })
+  })
+
+  it('creates the row on the sheet when the id is absent', () => {
+    const spreadsheet = fromArrays({ [SHEET_NAME]: [COLUMNS, ['u1', 'Alice', 30]] })
+    installGasFakes({ spreadsheets: { [SPREADSHEET_ID]: spreadsheet }, activeId: SPREADSHEET_ID })
+    installExclusiveLock()
+
+    const adapter = new SheetsAdapter<User>({
+      spreadsheetId: SPREADSHEET_ID,
+      sheetName: SHEET_NAME,
+      columns: COLUMNS,
+      idMode: 'client'
+    })
+
+    const result = new Repository(adapter, 'users').upsert({ id: 'u2', name: 'Bob', age: 25 })
+
+    expect(result).toEqual({ id: 'u2', name: 'Bob', age: 25 })
+    adapter.clearCache()
+    expect(adapter.findAll()).toHaveLength(2)
+  })
+})

--- a/packages/skills/skills/generic/gsquery-cheatsheet.md
+++ b/packages/skills/skills/generic/gsquery-cheatsheet.md
@@ -36,6 +36,7 @@ users.create({ name: 'Alice', email: 'a@test.com', age: 30, active: true }) // o
 users.findAll()                    // T[]
 users.findById(1)                  // T — throws RowNotFoundError
 users.update(1, { age: 31 })      // T — throws RowNotFoundError
+users.upsert({ id: 1, age: 31 })   // T — update by id, else insert
 users.delete(1)                    // void — throws RowNotFoundError
 users.batchInsert([{...}, {...}])  // T[]
 users.batchUpdate([{ id: 1, data: { active: false } }])

--- a/packages/skills/skills/generic/gsquery-crud.md
+++ b/packages/skills/skills/generic/gsquery-crud.md
@@ -35,6 +35,11 @@ users.findById(1)      // T — throws RowNotFoundError if missing
 // Update
 users.update(1, { age: 31 })  // throws RowNotFoundError if missing
 
+// Upsert — patch the row with this id, or insert it.
+// idMode 'client' honors the id; idMode 'auto' throws ValidationError when no
+// row carries it (omit the id to create there).
+users.upsert({ id: 1, age: 31 })
+
 // Delete
 users.delete(1)                // throws RowNotFoundError if missing
 

--- a/packages/skills/skills/generic/gsquery-errors.md
+++ b/packages/skills/skills/generic/gsquery-errors.md
@@ -16,8 +16,17 @@ import {
   MigrationVersionError, // MIGRATION_VERSION_ERROR — { version }
   MigrationExecutionError, // MIGRATION_EXECUTION_ERROR — { version, migrationName, cause }
   NoMigrationsToRollbackError, // NO_MIGRATIONS_TO_ROLLBACK
+  // GAS platform failures (raised only when running on Apps Script)
+  LockTimeoutError,      // LOCK_TIMEOUT — { timeoutMs?, cause? } — nothing was written
+  QuotaExceededError,    // QUOTA_EXCEEDED — { originalMessage, transient, cause? }
+  SheetsApiError,        // SHEETS_API_ERROR — { originalMessage, transient, cause? }
+  CellSizeLimitError,    // CELL_SIZE_LIMIT — { column, length, limit, tableName, id? }
 } from '@gsquery/core'
 ```
+
+Transient backend failures are already retried (3 attempts, 500ms doubling).
+What reaches you is what retrying cannot fix — check `transient` on a
+`QuotaExceededError` before rescheduling versus failing.
 
 ### Error Handling
 

--- a/packages/skills/skills/gsquery/references/crud-and-queries.md
+++ b/packages/skills/skills/gsquery/references/crud-and-queries.md
@@ -68,6 +68,11 @@ users.findById(1)        // T — throws RowNotFoundError if missing
 // Update — returns updated row
 users.update(1, { age: 31 })  // throws RowNotFoundError if missing
 
+// Upsert — update by id, insert when absent. Partial patch allowed.
+// In auto idMode an id no row carries throws ValidationError (the store
+// allocates ids and cannot honor yours) — omit the id to create there.
+users.upsert({ id: 1, age: 31 })
+
 // Delete
 users.delete(1)          // throws RowNotFoundError if missing
 
@@ -99,6 +104,7 @@ repo.findByIdOrNull(1)          // T | undefined — null-safe
 repo.create({ ... })            // T
 repo.update(1, { ... })         // T — throws RowNotFoundError
 repo.updateOrNull(1, { ... })   // T | undefined — null-safe
+repo.upsert({ id: 1, ... })     // T — update by id, else insert
 repo.delete(1)                  // void — throws RowNotFoundError
 repo.deleteIfExists(1)          // boolean — returns false if missing
 repo.count()                    // number

--- a/packages/skills/skills/gsquery/references/errors.md
+++ b/packages/skills/skills/gsquery/references/errors.md
@@ -16,6 +16,10 @@ import {
   MigrationVersionError,
   MigrationExecutionError,
   NoMigrationsToRollbackError,
+  LockTimeoutError,
+  QuotaExceededError,
+  SheetsApiError,
+  CellSizeLimitError,
 } from '@gsquery/core'
 ```
 
@@ -33,6 +37,14 @@ import {
 | `MigrationVersionError` | `MIGRATION_VERSION_ERROR` | Duplicate/invalid version | `version` |
 | `MigrationExecutionError` | `MIGRATION_EXECUTION_ERROR` | Migration up/down fails | `version`, `migrationName`, `cause` |
 | `NoMigrationsToRollbackError` | `NO_MIGRATIONS_TO_ROLLBACK` | `rollback()` when empty | — |
+| `LockTimeoutError` | `LOCK_TIMEOUT` | Script lock held by another execution (10s budget) | `timeoutMs?`, `cause?` |
+| `QuotaExceededError` | `QUOTA_EXCEEDED` | GAS rate limit / daily quota / 6-min ceiling | `originalMessage`, `transient`, `cause?` |
+| `SheetsApiError` | `SHEETS_API_ERROR` | Sheets backend timeout or internal error | `originalMessage`, `transient`, `cause?` |
+| `CellSizeLimitError` | `CELL_SIZE_LIMIT` | Value over the 50,000-char cell limit | `column`, `length`, `limit`, `tableName`, `id?` |
+
+Transient failures (`SheetsApiError`, transient `QuotaExceededError`) are
+retried automatically — 3 attempts, 500ms doubling. `LockTimeoutError` is not:
+nothing was written, so retry it later rather than immediately.
 
 ### Error Handling Patterns
 

--- a/packages/skills/tests/unit/sync.test.ts
+++ b/packages/skills/tests/unit/sync.test.ts
@@ -9,6 +9,15 @@ const PKG_VERSION = JSON.parse(
 
 const CORE_BARREL = join(SKILLS_DIR, '..', '..', 'core', 'src', 'index.ts')
 
+/**
+ * Both parsers below split an import/export block on commas, so a `//` comment
+ * inside a block would glue itself onto the next symbol (and a `}` inside one
+ * would end the block early). Strip line comments first.
+ */
+function stripLineComments(src: string): string {
+  return src.replace(/\/\/.*$/gm, '')
+}
+
 function markdownFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
     const path = join(dir, entry)
@@ -21,7 +30,7 @@ function markdownFiles(dir: string): string[] {
 function claimedSymbols(): Map<string, string[]> {
   const claimed = new Map<string, string[]>()
   for (const file of markdownFiles(SKILLS_DIR)) {
-    const src = readFileSync(file, 'utf-8')
+    const src = stripLineComments(readFileSync(file, 'utf-8'))
     for (const block of src.matchAll(/import\s*\{([^}]+)\}\s*from\s*'@gsquery\/core'/g)) {
       for (const raw of block[1].split(',')) {
         const symbol = raw.trim().replace(/^type\s+/, '')
@@ -35,7 +44,7 @@ function claimedSymbols(): Map<string, string[]> {
 
 /** Symbols @gsquery/core actually re-exports from its barrel. */
 function exportedSymbols(): Set<string> {
-  const src = readFileSync(CORE_BARREL, 'utf-8')
+  const src = stripLineComments(readFileSync(CORE_BARREL, 'utf-8'))
   const exported = new Set<string>()
   for (const block of src.matchAll(/export\s*(?:type\s*)?\{([^}]+)\}/g)) {
     for (const raw of block[1].split(',')) {

--- a/website/docs/api-reference.md
+++ b/website/docs/api-reference.md
@@ -62,6 +62,7 @@ interface TableHandle<T extends RowWithId> {
   findById(id: string | number): T                    // throws RowNotFoundError
   findAll(): T[]
   update(id: string | number, data: Partial<T>): T    // throws RowNotFoundError
+  upsert(data: UpsertData<T>): T                       // update by id, else insert
   delete(id: string | number): void                    // throws RowNotFoundError
   batchInsert(data: (T | Omit<T, 'id'>)[]): T[]
   batchUpdate(items: { id: string | number; data: Partial<T> }[]): T[]
@@ -81,6 +82,7 @@ class Repository<T extends RowWithId> {
   create(data: T | Omit<T, 'id'>): T
   update(id: string | number, data: Partial<T>): T      // throws RowNotFoundError
   updateOrNull(id: string | number, data: Partial<T>): T | undefined
+  upsert(data: UpsertData<T>): T                         // update by id, else insert
   delete(id: string | number): void                      // throws RowNotFoundError
   deleteIfExists(id: string | number): boolean
   count(): number
@@ -338,6 +340,8 @@ interface WhereCondition<T> { field: keyof T & string; operator: Operator; value
 interface OrderByCondition<T> { field: keyof T & string; direction: SortDirection }
 interface QueryOptions<T> { where: WhereCondition<T>[]; orderBy: OrderByCondition<T>[]; limitValue?: number; offsetValue?: number }
 interface BatchUpdateItem<T> { id: string | number; data: Partial<T> }
+type UpdateData<T> = Partial<Omit<T, 'id'>>
+type UpsertData<T> = Omit<T, 'id'> | (UpdateData<T> & Pick<T, 'id'>)
 ```
 
 ---

--- a/website/docs/crud-operations.md
+++ b/website/docs/crud-operations.md
@@ -93,6 +93,29 @@ const updated = users.repo.updateOrNull(1, { age: 31 })
 // { id: 1, name: 'Alice', age: 31, ... } or undefined
 ```
 
+## Upsert
+
+Insert a row, or patch the row that already carries the same `id` — one call,
+no existence check of your own.
+
+```ts
+users.upsert({ id: 1, age: 31 })   // row 1 exists -> patched
+users.upsert({ id: 7, name: 'Grace', age: 28 })  // no row 7 -> inserted
+```
+
+Only the keys you pass are written on the update branch, so `upsert` patches
+rather than replaces. The `id` itself is never modified.
+
+The whole find-then-write sequence runs under one script lock on GAS, so two
+concurrent executions cannot both miss and both insert.
+
+:::note auto idMode
+With `idMode: 'auto'` the store allocates ids, so the insert branch cannot
+honor an id you supply. Upserting an id that no row carries throws
+`ValidationError` rather than writing the row under a different id — omit the
+`id` to create a row there, and pass explicit ids only with `idMode: 'client'`.
+:::
+
 ## Delete
 
 ### delete (throwing)

--- a/website/docs/error-handling.md
+++ b/website/docs/error-handling.md
@@ -16,8 +16,16 @@ Error
       ├── InvalidOperatorError
       ├── MigrationVersionError
       ├── MigrationExecutionError
-      └── NoMigrationsToRollbackError
+      ├── NoMigrationsToRollbackError
+      ├── LockTimeoutError        (GAS platform)
+      ├── QuotaExceededError      (GAS platform)
+      ├── SheetsApiError          (GAS platform)
+      └── CellSizeLimitError      (GAS platform)
 ```
+
+The four platform errors are raised only when running on Apps Script. See
+[Operations](./operations.md) for the quota, retry, and locking behavior behind
+them.
 
 ## Error Types
 
@@ -213,6 +221,88 @@ try {
 }
 ```
 
+### LockTimeoutError
+
+The script lock could not be acquired within its 10-second wait budget: another
+execution is mid-write. **Nothing was written**, so the operation is safe to
+retry later — but not immediately, which is why the built-in retry deliberately
+skips this error.
+
+```ts
+class LockTimeoutError extends SheetsQueryError {
+  readonly timeoutMs?: number   // the wait budget that elapsed
+  readonly cause?: unknown      // the original platform exception
+}
+```
+
+### QuotaExceededError
+
+A GAS quota or rate limit was hit. `transient` separates a short-term rate limit
+(clears in seconds, retried automatically) from a daily quota or the 6-minute
+execution ceiling (cannot clear inside this execution, never retried).
+
+```ts
+class QuotaExceededError extends SheetsQueryError {
+  readonly originalMessage: string
+  readonly transient: boolean
+  readonly cause?: unknown
+}
+
+try {
+  db.from('users').batchInsert(rows)
+} catch (e) {
+  if (e instanceof QuotaExceededError) {
+    if (e.transient) scheduleRetry()   // rate limit
+    else parkUntilTomorrow()           // daily quota / execution ceiling
+  }
+}
+```
+
+### SheetsApiError
+
+A Sheets/Apps Script backend failure that is neither a quota nor a lock —
+service timeouts, internal errors, `Service unavailable`. These are
+overwhelmingly transient and are retried automatically before they reach you.
+
+```ts
+class SheetsApiError extends SheetsQueryError {
+  readonly originalMessage: string
+  readonly transient: boolean   // default true
+  readonly cause?: unknown
+}
+```
+
+### CellSizeLimitError
+
+A serialized value would not fit in one Sheets cell (50,000 characters). The
+guard runs over the whole batch **before** the first write, so the operation is
+all-or-nothing rather than aborting halfway.
+
+```ts
+class CellSizeLimitError extends SheetsQueryError {
+  readonly column: string
+  readonly length: number
+  readonly limit: number        // 50_000
+  readonly tableName: string
+  readonly id?: string | number
+}
+```
+
+## Classifying Platform Errors
+
+Raw Apps Script failures are strings. Two helpers turn them into the typed
+errors above, and are exported for use around your own Sheets calls:
+
+```ts
+import { classifyGasError, isTransientGasError } from '@gsquery/core'
+
+// undefined when the value is NOT a recognized platform failure —
+// an unrecognized error is a logical error and must not be relabelled.
+const typed = classifyGasError(error)
+
+if (isTransientGasError(error)) scheduleRetry()
+```
+
 ## Error Codes Reference
 
 | Code | Error Class | When |
@@ -221,13 +311,17 @@ try {
 | `ROW_NOT_FOUND` | `RowNotFoundError` | `findById(999)`, `update(999, ...)`, `delete(999)` |
 | `NO_RESULTS` | `NoResultsError` | `query.firstOrFail()` with no matches |
 | `MISSING_STORE` | `MissingStoreError` | Table config without matching store |
-| `VALIDATION_ERROR` | `ValidationError` | Input validation failure |
+| `VALIDATION_ERROR` | `ValidationError` | Input validation failure; also `upsert` with an id no row carries on an `auto` idMode store |
 | `INVALID_OPERATOR` | `InvalidOperatorError` | Invalid operator in where clause |
 | `UNKNOWN_COLUMN` | `UnknownColumnError` | `addColumn`, or `renameColumn`'s new name, for a column outside the store schema |
 | `SCHEMA_MISMATCH` | `SchemaMismatchError` | Sheet header contradicts the declared columns (also raised by `renameColumn`/`removeColumn` when the physical layout does not match) |
 | `MIGRATION_VERSION_ERROR` | `MigrationVersionError` | Invalid migration version |
 | `MIGRATION_EXECUTION_ERROR` | `MigrationExecutionError` | Migration up/down failure |
 | `NO_MIGRATIONS_TO_ROLLBACK` | `NoMigrationsToRollbackError` | Rollback with no applied migrations |
+| `LOCK_TIMEOUT` | `LockTimeoutError` | Script lock held by another execution for the full wait budget |
+| `QUOTA_EXCEEDED` | `QuotaExceededError` | GAS rate limit, daily quota, or the 6-minute execution ceiling |
+| `SHEETS_API_ERROR` | `SheetsApiError` | Sheets backend timeout / internal error / service unavailable |
+| `CELL_SIZE_LIMIT` | `CellSizeLimitError` | Value over the 50,000-character cell limit |
 
 ## Handling Patterns
 

--- a/website/docs/operations.md
+++ b/website/docs/operations.md
@@ -1,0 +1,156 @@
+---
+description: Operational limits of Sheets-as-a-database — quotas, retry policy, script locking, cell and cache limits — and the patterns that keep them from becoming incidents.
+---
+
+# Operations
+
+Google Sheets is a document, not a database engine, and Apps Script bills you
+for every call into it. This page states the limits the library runs into, what
+it already does about them, and what is left to your code — so you learn them
+here rather than from an incident.
+
+## Quotas and Rate Limits
+
+Apps Script enforces two very different kinds of quota, worded almost
+identically by the platform:
+
+| Kind | Example platform message | Clears | Library behavior |
+|------|--------------------------|--------|------------------|
+| Short-term rate limit | `Service invoked too many times in a short time` | seconds | Retried with backoff |
+| Daily quota | `Service invoked too many times for one day` | midnight PT | Not retried |
+| Daily runtime quota | `Service using too much computer time for one day` | midnight PT | Not retried |
+| Execution ceiling | `Exceeded maximum execution time` (6 min) | next execution | Not retried |
+
+All four surface as [`QuotaExceededError`](./error-handling.md#quotaexceedederror);
+its `transient` flag tells the two apart. Retrying a terminal quota inside the
+same execution only burns what is left of the run, so the library does not.
+
+**Patterns**
+
+- Prefer `batchInsert` / `batchUpdate` / a single `query()` over per-row calls.
+  Quota is consumed per Sheets API call, and a batch is one ranged write.
+- Long jobs belong in a time-driven trigger that processes a slice per run and
+  records its progress, not in one execution that races the 6-minute ceiling.
+- Catch `QuotaExceededError` and check `transient` before deciding to reschedule
+  versus fail loudly.
+
+## Retry Behavior
+
+Transient backend failures — `Service Spreadsheets timed out`, `Internal error`,
+`Service unavailable`, short-term rate limits — are retried automatically by the
+adapter with truncated exponential backoff:
+
+| Setting | Default | Export |
+|---------|---------|--------|
+| Total attempts (including the first) | `3` | `DEFAULT_RETRY_ATTEMPTS` |
+| Delay before the first retry (doubles after) | `500ms` | `DEFAULT_RETRY_BASE_DELAY_MS` |
+| Worst-case added latency per guarded call | `1.5s` | — |
+
+What is deliberately **not** retried:
+
+- **Unrecognized errors.** A logical bug retried three times is a bug with three
+  times the side effects. Only messages the classifier recognizes as platform
+  failures are eligible.
+- **`LockTimeoutError`.** The caller already spent the full lock wait budget;
+  asking again immediately just spends it twice.
+- **Daily quotas and the execution ceiling.** They cannot clear inside this
+  execution.
+- **Shape-changing calls** — `appendRow`, `deleteRow`, `insertSheet`,
+  `insertColumnBefore`, `deleteColumn`. A timeout from one of them does not say
+  whether the mutation landed, so a retry risks a duplicated row or a second
+  deleted column. These are classified but never repeated; losing the operation
+  is recoverable, silently doubling it is not.
+
+You can reuse the same policy around your own Sheets calls:
+
+```ts
+import { withRetries, isTransientGasError } from '@gsquery/core'
+
+const values = withRetries(() => sheet.getRange('A1:D100').getValues())
+
+// Or decide for yourself:
+try {
+  doSomething()
+} catch (e) {
+  if (isTransientGasError(e)) scheduleRetry()
+  else throw e
+}
+```
+
+Only wrap calls that are safe to repeat: `withRetries` re-runs `fn` verbatim.
+
+## Concurrency
+
+Apps Script runs your script concurrently for different users, so every
+read-then-write sequence (find a row index, then write to that row number) must
+be held inside one script lock or a concurrent execution can shift the rows out
+from under it.
+
+- Every `SheetsAdapter` write path — `insert`, `update`, `delete`,
+  `batchInsert`, `batchUpdate`, migrations — already holds
+  `LockService.getScriptLock()` for the whole sequence. `Repository.upsert`
+  takes the lock itself, since it composes two store calls.
+- The lock is **re-entrant** within an execution, so nesting (a migration
+  holding the lock while the adapter writes rows) does not deadlock.
+- Wait budget is **10 seconds**, and is not configurable. On expiry you get
+  [`LockTimeoutError`](./error-handling.md#locktimeouterror) — and **nothing was
+  written**, so the operation is safe to retry later.
+- Buffered `SpreadsheetApp` writes are flushed before the lock is released, so
+  the next execution never observes a half-applied write.
+- Outside GAS (Node tests, browsers) `LockService` is absent and the helpers
+  degrade to a plain call.
+
+**What the lock does not give you**: transactions. Two separate calls are two
+separate critical sections; there is no rollback of writes that already landed.
+If several rows must change together, put them in one `batchUpdate`.
+
+Retries sleep while holding the lock, so a guarded call can extend a lock hold
+by up to 1.5s. Keep locked sections short — a scattered `batchUpdate` retries
+once per contiguous run.
+
+## Cell and Sheet Limits
+
+| Limit | Value | Behavior |
+|-------|-------|----------|
+| Characters per cell | 50,000 (`MAX_CELL_LENGTH`) | Checked over the whole batch *before* the first write, so an oversized value fails the operation instead of aborting it halfway |
+| Cells per spreadsheet | 10,000,000 | Enforced by Sheets; plan a rollover sheet before you approach it |
+
+An overflow raises
+[`CellSizeLimitError`](./error-handling.md#cellsizelimiterror) naming the
+column, the length, and the row id. Store long text in Drive and keep the file
+id in the cell.
+
+## Read Caching and Staleness
+
+`SheetsAdapter` snapshots the data block on first read and serves later reads of
+the same execution from that snapshot — one API call instead of one per query.
+The consequence is that writes made by *other* executions are invisible until:
+
+- the adapter's own write path invalidates the cache, or
+- you call `adapter.clearCache()`, or
+- a new execution starts.
+
+`findById` is not affected — it reads the row live. `find` and `findAll` are
+the cached paths, and so is anything built on them (`query()`, JOINs,
+aggregation).
+
+Long-running triggers that poll for external edits must call `clearCache()`
+between passes.
+
+## Checklist Before Going to Production
+
+- Writes go through batch APIs, not per-row loops.
+- Long jobs are sliced across time-driven trigger runs.
+- `QuotaExceededError` (check `transient`) and `LockTimeoutError` are caught and
+  rescheduled rather than surfaced as generic failures.
+- Values that can grow unbounded are kept out of cells.
+- Anything polling for external edits calls `clearCache()`.
+- The sheet's column layout is treated as schema: a manual column insert breaks
+  the positional mapping and raises `SchemaMismatchError`.
+
+## See Also
+
+- [Error Handling](./error-handling.md) — every typed error and its code
+- [Batch Operations](./batch-operations.md)
+- [Indexing and Performance](./indexing-and-performance.md)
+- [Migration System](./migration-system.md)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -35,6 +35,7 @@ const sidebars: SidebarsConfig = {
         'typed-client',
         'local-first-client',
         'indexing-and-performance',
+        'operations',
         'ai-assistant-skills',
       ],
     },


### PR DESCRIPTION
## Summary

Two of the four newly filed issues, reviewed against the codebase first:

**#217 — public `upsert`.** `Repository.upsert` / `TableHandle.upsert` insert a row or patch the row already carrying the same id. The sync protocol already assumed upsert semantics (`insert` on the wire is create-or-replace); no public API expressed it.

- The branch is decided by the *result of the update*, not a preceding read — one Sheets round trip cheaper when the row exists, and no window between deciding and writing.
- The whole sequence runs under one re-entrant script lock, so two concurrent executions cannot both miss and both insert.
- A store that allocates its own ids cannot honor an id on the insert branch, so an unknown id there throws `ValidationError` instead of writing the row under a *different* id and leaving every reference dangling. `DataStore` gains an optional `readonly idMode` so callers above the store can tell the two apart.
- Payload type is `UpsertData<T> = Omit<T, 'id'> | (UpdateData<T> & Pick<T, 'id'>)` — full row, id-less row, or a patch carrying the id.

**#219 — operational limits.** Quotas, retry policy, script locking and the cell/cache limits were implemented (#136) but documented nowhere. Adds an Operations page, links it from the README limitations, and fills the four GAS platform errors (`LockTimeoutError`, `QuotaExceededError`, `SheetsApiError`, `CellSizeLimitError`) plus `classifyGasError` / `isTransientGasError` into the error reference and the skill files.

Drive-by: the skills sync test split import/export blocks on commas without stripping `//` comments, so a comment glued itself onto the next symbol — which reported the barrel's own `LockTimeoutError` as a removed API.

## Related Issues

Closes #217
Closes #219

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Checklist

- [x] Targets the `dev` branch
- [x] Tests added or updated
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Follows Conventional Commits
- [x] Docs/comments are in English

## Notes

- Docs site builds clean with `onBrokenLinks: 'throw'`.
- `e2e/gas` typecheck fails with 3 pre-existing `TS7006` errors on `dev` as well; untouched here.
- Not addressed, from the review: `MockAdapter` keys `update` off a strict `Map` while `SheetsAdapter` compares `String(id)`, so `'5'` vs `5` diverges between them. That is adapter-level (#195); after the guard above both sides now fail loudly rather than writing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTtQND4iPgKoGh6Q9MUHsU